### PR TITLE
Actor Names Fix

### DIFF
--- a/Actor.js
+++ b/Actor.js
@@ -52,7 +52,7 @@ function ActorSpecificGetValue(SpecificActorName, ValueType) {
 
 // Return the current actor's localized name
 function ActorGetDisplayName() {
-	if (ActorNamesText == null) ReadCSV("ActorNamesText", "C999_Common", "ActorNames", "Text", GetWorkingLanguage());
+	if (ActorNamesText == null) ReadCSV("ActorNamesText", "C999_Common", "ActorNames", "Text", GetWorkingLanguageForChapter("C999_Common"));
 	if (ActorGetValue(ActorHideName)) return GetCSVText(ActorNamesText, "Unknown");
 	return GetCSVText(ActorNamesText, CurrentActor);
 }

--- a/C000_Intro/ChapterSelect/Stage_ES.csv
+++ b/C000_Intro/ChapterSelect/Stage_ES.csv
@@ -14,11 +14,11 @@ Stage,LoveReq,SubReq,VarReq,Interaction,Result,NextStage,LoveMod,SubMod,Function
 10,0,0,,Capítulo 8|Clase de teatro,,10,0,0,"LoadChapter(""C008_DramaClass"")"
 10,0,0,,Más capítulos,"Selecciona el capítulo que quieres jugar.|Si juegas por primera vez empieza en el capítulo 1.",20,0,0,
 10,0,0,,Menú principal,"Bienvenida al instituto de bondage,|pásalo bien, sé curiosa y pervertida.",0,0,0,
-20,0,0,,Capítulo 9|Biblioteca,,20,0,0,LoadChapter(C009_Library)
-20,0,0,,Capítulo 10|Venganza,,20,0,0,LoadChapter(C010_Revenge)
-20,0,0,,Capítulo 11|Clase de literatura,,20,0,0,LoadChapter(C011_LiteratureClass)
+20,0,0,,Capítulo 9|Biblioteca,,20,0,0,"LoadChapter(""C009_Library"")"
+20,0,0,,Capítulo 10|Venganza,,20,0,0,"LoadChapter(""C010_Revenge"")"
+20,0,0,,Capítulo 11|Clase de literatura,,20,0,0,"LoadChapter(""C011_LiteratureClass"")"
 20,0,0,,Capítulo 12|Después Class,,20,0,0,"LoadChapter(""C012_AfterClass"")"
-20,0,0,,Capítulo 101|Club de Kinbaku por wildsj,,20,0,0,LoadChapter(C101_Kinbakuclub)
+20,0,0,,Capítulo 101|Club de Kinbaku por wildsj,,20,0,0,"LoadChapter(""C101_KinbakuClub"")"
 20,0,0,,Capítulos anteriores,"Selecciona el capítulo que quieres jugar|Si juegas por primera vez empieza en el capítulo 1",10,0,0,
 20,0,0,,Menú principal,"Bienvenida al instituto de bondage,|pásalo bien, sé curiosa y pervertida.",0,0,0,
 30,0,0,,Inglés,,0,0,0,"SetLanguage(""EN"")"

--- a/C000_Intro/ChapterSelect/Stage_RU.csv
+++ b/C000_Intro/ChapterSelect/Stage_RU.csv
@@ -6,8 +6,8 @@ Stage,LoveReq,SubReq,VarReq,Interaction,Result,NextStage,LoveMod,SubMod,Function
 0,0,0,,Благодарности,Огромное СПАСИБО всем|кто поддерживал игру.,0,0,0,RollCredits()
 10,0,0,,Глава 1|Перед уроком,,10,0,0,"LoadChapter(""C001_BeforeClass"")"
 10,0,0,,Глава 2|Первый урок,,10,0,0,"LoadChapter(""C002_FirstClass"")"
-10,0,0,,Глава 3|Утренний арест,10,0,0,"LoadChapter(""C003_MorningDetention"")"
-10,0,0,,Глава 4|Художественный класс,,10,0,0,"LoadChapter(""""C004_ArtClass"")"
+10,0,0,,Глава 3|Утренний арест,,10,0,0,"LoadChapter(""C003_MorningDetention"")"
+10,0,0,,Глава 4|Художественный класс,,10,0,0,"LoadChapter(""C004_ArtClass"")"
 10,0,0,,Глава 5|Спортивный зал,,10,0,0,"LoadChapter(""C005_GymClass"")"
 10,0,0,,Глава 6|Изоляция,,10,0,0,"LoadChapter(""C006_Isolation"")"
 10,0,0,,Глава 7|Обеденный перерыв,,10,0,0,"LoadChapter(""C007_LunchBreak"")"

--- a/Common.js
+++ b/Common.js
@@ -179,12 +179,17 @@ function ArrayShuffle(a) {
 
 // Returns a working language if translation isn't fully ready
 function GetWorkingLanguage() {
-	if ((CurrentLanguageTag == "FR") && ((CurrentChapter == "C000_Intro") || (CurrentChapter == "C001_BeforeClass") || (CurrentChapter == "C002_FirstClass") || (CurrentChapter == "C003_MorningDetention") || (CurrentChapter == "C004_ArtClass") || (CurrentChapter == "C005_GymClass") || (CurrentChapter == "C006_Isolation") || (CurrentChapter == "C007_LunchBreak") || (CurrentChapter == "C008_DramaClass") || (CurrentChapter == "C009_Library") || (CurrentChapter == "C999_Common"))) return "FR";
-	if ((CurrentLanguageTag == "DE") && ((CurrentChapter == "C000_Intro") || (CurrentChapter == "C001_BeforeClass") || (CurrentChapter == "C002_FirstClass") || (CurrentChapter == "C003_MorningDetention") || (CurrentChapter == "C004_ArtClass") || (CurrentChapter == "C005_GymClass") || (CurrentChapter == "C006_Isolation") || (CurrentChapter == "C007_LunchBreak") || (CurrentChapter == "C008_DramaClass") || (CurrentChapter == "C009_Library") || (CurrentChapter == "C010_Revenge") || (CurrentChapter == "C011_LiteratureClass") || (CurrentChapter == "C012_AfterClass") || (CurrentChapter == "C013_BondageClub") || (CurrentChapter == "C101_KinbakuClub") || (CurrentChapter == "C999_Common"))) return "DE";
-	if ((CurrentLanguageTag == "PL") && ((CurrentChapter == "C000_Intro"))) return "PL";
-	if ((CurrentLanguageTag == "ES") && ((CurrentChapter == "C000_Intro") || (CurrentChapter == "C001_BeforeClass") || (CurrentChapter == "C002_FirstClass") || (CurrentChapter == "C003_MorningDetention"))) return "ES";
-	if ((CurrentLanguageTag == "CN") && ((CurrentChapter == "C000_Intro") || (CurrentChapter == "C001_BeforeClass") || (CurrentChapter == "C002_FirstClass") || (CurrentChapter == "C003_MorningDetention") || (CurrentChapter == "C005_GymClass") || (CurrentChapter == "C999_Common"))) return "CN";
-	if ((CurrentLanguageTag == "RU") && ((CurrentChapter == "C000_Intro") || (CurrentChapter == "C001_BeforeClass"))) return "RU";
+	return GetWorkingLanguageForChapter(CurrentChapter);
+}
+
+// Returns a working language for a specific chapter
+function GetWorkingLanguageForChapter(Chapter) {
+	if ((CurrentLanguageTag == "FR") && ["C000_Intro", "C001_BeforeClass", "C002_FirstClass", "C003_MorningDetention", "C004_ArtClass", "C005_GymClass", "C006_Isolation", "C007_LunchBreak", "C008_DramaClass", "C009_Library", "C999_Common"].indexOf(Chapter) >= 0) return "FR";
+	if ((CurrentLanguageTag == "DE") && ["C000_Intro", "C001_BeforeClass", "C002_FirstClass", "C003_MorningDetention", "C004_ArtClass", "C005_GymClass", "C006_Isolation", "C007_LunchBreak", "C008_DramaClass", "C009_Library", "C010_Revenge", "C011_LiteratureClass", "C012_AfterClass", "C013_BondageClub", "C101_KinbakuClub", "C999_Common"].indexOf(Chapter) >= 0) return "DE";
+	if ((CurrentLanguageTag == "PL") && ["C000_Intro"].indexOf(Chapter) >= 0) return "PL";
+	if ((CurrentLanguageTag == "ES") && ["C000_Intro", "C001_BeforeClass", "C002_FirstClass", "C003_MorningDetention"].indexOf(Chapter) >= 0) return "ES";
+	if ((CurrentLanguageTag == "CN") && ["C000_Intro", "C001_BeforeClass", "C002_FirstClass", "C003_MorningDetention", "C005_GymClass", "C999_Common"].indexOf(Chapter) >= 0) return "CN";
+	if ((CurrentLanguageTag == "RU") && ["C000_Intro", "C001_BeforeClass"].indexOf(Chapter) >= 0) return "RU";
 	return "EN";
     //return CurrentLanguageTag;
 }


### PR DESCRIPTION
Alright, this should make the translated actor names work for all languages in all chapters. Hopefully nothing else is broken, that would be really embarrassing by now. But I tested chapters 1, 2 and 101 in English, German, Spanish and Russian, and everything seemed to be working fine.

While I was at it, I changed the translated chapter list to make it a bit more compact and slightly easier to edit in the future. I was hesitating for a pretty long time if I should do this, because it might cause merge conflicts if someone is currently translating a new chapter and isn't aware of these changes. But I think that would have happened either way because I needed to change the function as a whole. I hope this is okay, if there's anything wrong with it, I can change it back to the previous form before you accept the pull request. Functionality-wise, it works, like I said above.