### PR TITLE
Chat Styles (experimental)

### DIFF
--- a/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
+++ b/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
@@ -11,8 +11,8 @@ function ChatRoomCreateElement() {
 	if (document.getElementById("InputChat") == null) {
 		ElementCreateInput("InputChat", "text", "", "250");
 		document.getElementById("InputChat").setAttribute("autocomplete", "off");
-		ElementCreateTextArea("TextAreaChatLog");
-		ElementValue("TextAreaChatLog", ChatRoomLog);
+		ElementCreateDiv("TextAreaChatLog");
+		ElementContent("TextAreaChatLog", ChatRoomLog);
 		ElementScrollToEnd("TextAreaChatLog");
 		ElementFocus("InputChat");
 	}
@@ -254,9 +254,31 @@ function ChatRoomResponse(data) {
 // When the server sends a chat message
 function ChatRoomMessage(data) {
 	if ((data != null) && (typeof data === "string") && (data != "")) {
-		ChatRoomLog = ChatRoomLog + data + '\r\n';
+
+		// Color the name if this is a regular chat message
+		var RegEx = /^([A-Za-z\s]+):/;
+		var Result = RegEx.exec(data);
+		if (Result != null && Result[1] != null) {
+			var C = ChatRoomGetCharacterByName(Result[1]);
+			if (C != null) {
+				for (var A = 0; A < C.Appearance.length; A++)
+					if (C.Appearance[A].Asset.Group.Name == "HairFront") {
+						var Color = C.Appearance[A].Color;
+						data = data.replace(Result[0], '<span class="ChatName" style="color: ' + Color + '">' + Result[1] + ':</span>');
+					}
+			}
+		}
+
+		// Style actions and emotes
+		RegEx = new RegExp("(\\(.*?\\))", "g");
+		data = data.replace(RegEx, '<span class="ChatAction">$&</span>');
+		RegEx = new RegExp("(\\*.*?\\*)", "g");
+		data = data.replace(RegEx, '<span class="ChatEmote">$&</span>');
+
+		// Add the message
+		ChatRoomLog = ChatRoomLog + "<div>" + data + "</div>";
 		if (document.getElementById("TextAreaChatLog") != null) {
-			ElementValue("TextAreaChatLog", ChatRoomLog);
+			ElementContent("TextAreaChatLog", ChatRoomLog);
 			ElementScrollToEnd("TextAreaChatLog");
 			ElementFocus("InputChat");
 		}
@@ -288,4 +310,11 @@ function ChatRoomViewProfile() {
 		DialogLeave();
 		InformationSheetLoadCharacter(C);
 	}
+}
+
+// Returns the first character in the room that has a certain name
+function ChatRoomGetCharacterByName(Name) {
+	for (var C = 0; C < ChatRoomCharacter.length; C++)
+		if (ChatRoomCharacter[C].Name == Name)
+			return ChatRoomCharacter[C];
 }

--- a/BondageClub/Scripts/Element.js
+++ b/BondageClub/Scripts/Element.js
@@ -9,6 +9,15 @@ function ElementValue(ID, Value) {
 			document.getElementById(ID).value = Value;
 }
 
+// Returns the current HTML content of an element
+function ElementContent(ID, Content) {
+	if (document.getElementById(ID) != null)
+		if (Content == null)
+			return document.getElementById(ID).innerHTML;
+		else 
+			document.getElementById(ID).innerHTML = Content;
+}
+
 // Creates a new text area element in the main document
 function ElementCreateTextArea(ID) {
 	if (document.getElementById(ID) == null) {
@@ -33,6 +42,17 @@ function ElementCreateInput(ID, Type, Value, MaxLength) {
 		Input.setAttribute("onfocus", "this.removeAttribute('readonly');");
 		Input.addEventListener("keydown", KeyDown);
 		document.body.appendChild(Input);
+	}
+}
+
+// Creates a new div element in the main document
+function ElementCreateDiv(ID) {
+	if (document.getElementById(ID) == null) {
+		var Div = document.createElement("div");
+		Div.setAttribute("ID", ID);
+		Div.setAttribute("name", ID);
+		Div.addEventListener("keydown", KeyDown);
+		document.body.appendChild(Div);
 	}
 }
 
@@ -102,7 +122,10 @@ function ElementScrollToEnd(ID) {
 	if (document.getElementById(ID) != null) {
 		var element = document.getElementById(ID);
 		element.focus();
-		element.selectionStart = element.selectionEnd = element.value.length;
+		if (element.value != null)
+			element.selectionStart = element.selectionEnd = element.value.length;
+		else
+			element.scrollTop = element.scrollHeight;
 	}
 }
 

--- a/BondageClub/index.html
+++ b/BondageClub/index.html
@@ -26,6 +26,21 @@
 		position: absolute;
     }
     * { -webkit-tap-highlight-color:rgba(0,0,0,0); }
+	#TextAreaChatLog {
+		background-color: white;
+		border: 1px solid black;
+		overflow: auto;
+	}
+	.ChatName {
+		text-shadow: 1px 1px black;
+	}
+	.ChatAction {
+		color: #555;
+	}
+	.ChatEmote {
+		color: #555;
+		font-style: italic;
+	}
 </style>
 
 <script src="Scripts/Common.js"></script>


### PR DESCRIPTION
I remembered that colors in chat were a somewhat heavily requested feature on Discord, so I just decided to give it a shot. This is mostly intended to be a demo; you might not want to merge this, it might cause some problems I didn't think about. However, it did work rather nicely when I tested it.

Currently, this colors people's names before their chat messages (currently it just uses the character's hair color, could be changed to be customizable), as well as parentheses-actions and asterisk-emotes (the latter also being made italic). To make it a bit easier to read if someone has white hair, I added a text shadow, which is probably not perfect, but it's something.

One potential issue with this approach: since the characters (and therefore their colors) are picked by name, this will not work properly if there are 2 or more people with the same name in the room. Maybe the server could somehow send the account identifier along with the message?

I hope this code can be useful in any way, even if only as inspiration.