### PR TITLE
Minor chat style adjustments

### DIFF
--- a/BondageClub/CSS/Styles.css
+++ b/BondageClub/CSS/Styles.css
@@ -15,9 +15,11 @@ canvas {
 	border: 1px solid black;
 	overflow: auto;
 	word-wrap: break-word;
+	padding: 0 !important;
 }
 .ChatMessage {
 	position: relative;
+	padding-left: 0.4em;
 }
 .ChatMessage::before {
 	content: attr(data-time);
@@ -36,7 +38,7 @@ canvas {
 	right: 0.2em;
 }
 .ChatMessageName {
-	text-shadow: 1px 1px black;
+	text-shadow: 0.05em 0.05em black;
 }
 .ChatMessageAction {
 	color: gray;
@@ -45,7 +47,7 @@ canvas {
 	color: gray;
 	font-style: italic;
 }
-.ChatMessageWhisper{
+.ChatMessageWhisper {
 	font-style: italic;
 	color: silver;
 }


### PR DESCRIPTION
This turned out to be a much smaller change than I thought it would be. It basically does just 2 things:
- Changes how the text shadow of the character names is calculated (the distance between the text and the shadow was way too large on smaller screens before).
- Applies the left padding to chat messages themselves, rather than the entire box. This gets rid of the white gap on the left side of the chat.
I was originally planning to do some more things. For example, hiding the player id numbers unless you hover over a message (as some players requested) turned out to be incredibly easy to do, but I don't have time to test it on mobile, so I wasn't really comfortable to do something like that right before a release. For the next one though, I'll try adding some preferences for such things.