### PR TITLE
Chat Display Settings

### DIFF
--- a/BondageClub/CSS/Styles.css
+++ b/BondageClub/CSS/Styles.css
@@ -51,6 +51,44 @@ canvas {
 	font-style: italic;
 	color: silver;
 }
+#TextAreaChatLog[data-ColorTheme=Dark i] {
+	background-color: #111;
+	color: #eee;
+}
+#TextAreaChatLog[data-ColorTheme=Dark i] .ChatMessageName {
+	text-shadow: 0.05em 0.05em #eee;
+}
+#TextAreaChatLog[data-EnterLeave=Smaller i] .ChatMessageEnterLeave {
+	font-size: 0.5em;
+	text-align: center;
+}
+#TextAreaChatLog[data-EnterLeave=Hidden i] .ChatMessageEnterLeave {
+	display: none;
+}
+#TextAreaChatLog[data-MemberNumbers=Never i] .ChatMessage::after,
+#TextAreaChatLog[data-MemberNumbers=OnMouseover i] .ChatMessage::after {
+	display: none;
+}
+#TextAreaChatLog[data-MemberNumbers=OnMouseover i] .ChatMessage:hover::after {
+	display: block;
+}
+#TextAreaChatLog[data-DisplayTimestamps=false i] .ChatMessage::before {
+	display: none;
+}
+#TextAreaChatLog[data-DisplayTimestamps=false i] .ChatMessage::after {
+	top: 0;
+}
+#TextAreaChatLog[data-ColorNames=false] .ChatMessageName {
+	color: inherit !important;
+	text-shadow: none;
+	font-weight: bold;
+}
+#TextAreaChatLog[data-ColorActions=false i] .ChatMessageAction {
+	background-color: transparent !important;
+}
+#TextAreaChatLog[data-ColorEmotes=false i] .ChatMessageEmote {
+	background-color: transparent !important;
+}
 #FriendList {
 	border: 2px solid white;
 	overflow: auto;

--- a/BondageClub/Screens/Character/Login/Login.js
+++ b/BondageClub/Screens/Character/Login/Login.js
@@ -163,6 +163,7 @@ function LoginResponse(C) {
 			// Gets the online preferences
 			Player.LabelColor = C.LabelColor;
 			Player.ItemPermission = C.ItemPermission;
+			Player.ChatSettings = C.ChatSettings;
 			Player.WhiteList = C.WhiteList;
 			Player.BlackList = C.BlackList;
 			Player.FriendList = C.FriendList;

--- a/BondageClub/Screens/Character/Preference/Preference.js
+++ b/BondageClub/Screens/Character/Preference/Preference.js
@@ -2,15 +2,49 @@
 var PreferenceBackground = "Sheet";
 var PreferenceMessage = "";
 var PreferenceColorPick = "";
+var PreferenceSubscreen = "";
+var PreferenceChatColorThemeSelected = "";
+var PreferenceChatColorThemeList = null;
+var PreferenceChatColorThemeIndex = 0;
+var PreferenceChatEnterLeaveSelected = "";
+var PreferenceChatEnterLeaveList = null;
+var PreferenceChatEnterLeaveIndex = 0;
+var PreferenceChatMemberNumbersSelected = "";
+var PreferenceChatMemberNumbersList = null;
+var PreferenceChatMemberNumbersIndex = 0;
 
 // When the preference screens loads
 function PreferenceLoad() {
 	if (!CommonIsColor(Player.LabelColor)) Player.LabelColor = "#ffffff";
 	ElementCreateInput("InputCharacterLabelColor", "text", Player.LabelColor);
+
+	// If the user never used chat settings before, construct them to replicate the default behavior
+	if (!Player.ChatSettings) Player.ChatSettings = {
+		DisplayTimestamps: true,
+		ColorNames: true,
+		ColorActions: true,
+		ColorEmotes: true
+	};
+
+	PreferenceChatColorThemeList = ["Light", "Dark"];
+	PreferenceChatEnterLeaveList = ["Normal", "Smaller", "Hidden"];
+	PreferenceChatMemberNumbersList = ["Always", "Never", "OnMouseover"];
+	PreferenceChatColorThemeIndex = (!Player.ChatSettings || PreferenceChatColorThemeList.indexOf(Player.ChatSettings.ColorTheme) < 0) ? 0 : PreferenceChatColorThemeList.indexOf(Player.ChatSettings.ColorTheme);
+	PreferenceChatEnterLeaveIndex = (!Player.ChatSettings || PreferenceChatEnterLeaveList.indexOf(Player.ChatSettings.EnterLeave) < 0) ? 0 : PreferenceChatEnterLeaveList.indexOf(Player.ChatSettings.EnterLeave);
+	PreferenceChatMemberNumbersIndex = (!Player.ChatSettings || PreferenceChatMemberNumbersList.indexOf(Player.ChatSettings.MemberNumbers) < 0) ? 0 : PreferenceChatMemberNumbersList.indexOf(Player.ChatSettings.MemberNumbers);
+	PreferenceChatColorThemeSelected = PreferenceChatColorThemeList[PreferenceChatColorThemeIndex];
+	PreferenceChatEnterLeaveSelected = PreferenceChatEnterLeaveList[PreferenceChatEnterLeaveIndex];
+	PreferenceChatMemberNumbersSelected = PreferenceChatMemberNumbersList[PreferenceChatMemberNumbersIndex];
 }
 
 // Run the preference screen
 function PreferenceRun() {
+
+	// If a subscreen is active, draw that instead
+	if (PreferenceSubscreen == "Chat") {
+		PreferenceSubscreenChatRun();
+		return;
+	}
 
 	// Draw the online preferences
 	MainCanvas.textAlign = "left";
@@ -29,14 +63,29 @@ function PreferenceRun() {
 	// Draw the player & controls
 	DrawCharacter(Player, 50, 50, 0.9);
 	if (PreferenceColorPick != "") DrawImage("Backgrounds/ColorPicker.png", 1250, 85);
-	else DrawButton(1815, 75, 90, 90, "", "White", "Icons/Exit.png");
+	else {
+		DrawButton(1815, 75, 90, 90, "", "White", "Icons/Exit.png");
+		DrawButton(1815, 190, 90, 90, "", "White", "Icons/Chat.png");
+	}
 
 }
 
 // When the user clicks in the preference screen
 function PreferenceClick() {
 
+	// If a subscreen is active, process that instead
+	if (PreferenceSubscreen == "Chat") {
+		PreferenceSubscreenChatClick();
+		return;
+	}
+
 	if ((MouseX >= 1815) && (MouseX < 1905) && (MouseY >= 75) && (MouseY < 165) && (PreferenceColorPick == "")) PreferenceExit();
+
+	// If the user clicks on the chat settings button
+	if ((MouseX >= 1815) && (MouseX < 1905) && (MouseY >= 190) && (MouseY < 280) && (PreferenceColorPick == "")) {
+		ElementRemove("InputCharacterLabelColor");
+		PreferenceSubscreen = "Chat";
+	}
 
 	// If we must change the restrain permission level
 	if ((MouseX >= 500) && (MouseX < 590) && (MouseY >= 280) && (MouseY < 370)) {
@@ -57,10 +106,78 @@ function PreferenceExit() {
 		Player.LabelColor = ElementValue("InputCharacterLabelColor");
 		var P = {
 			ItemPermission: Player.ItemPermission,
-			LabelColor: Player.LabelColor
+			LabelColor: Player.LabelColor,
+			ChatSettings: Player.ChatSettings
 		}
 		ServerSend("AccountUpdate", P);
 		ElementRemove("InputCharacterLabelColor");
 		CommonSetScreen("Character", "InformationSheet");
 	} else PreferenceMessage = "ErrorInvalidColor";
+}
+
+// Redirected to from the main Run function if the player is in the chat settings subscreen
+function PreferenceSubscreenChatRun() {
+	MainCanvas.textAlign = "left";
+	DrawText(TextGet("ChatDisplaySettings"), 500, 125, "Black", "Gray");
+	DrawText(TextGet("ColorTheme"), 500, 225, "Black", "Gray");
+	DrawText(TextGet("EnterLeaveStyle"), 500, 325, "Black", "Gray");
+	DrawText(TextGet("DisplayMemberNumbers"), 500, 425, "Black", "Gray");
+	DrawText(TextGet("DisplayTimestamps"), 600, 525, "Black", "Gray");
+	DrawText(TextGet("ColorNames"), 600, 625, "Black", "Gray");
+	DrawText(TextGet("ColorActions"), 600, 725, "Black", "Gray");
+	DrawText(TextGet("ColorEmotes"), 600, 825, "Black", "Gray");
+	MainCanvas.textAlign = "center";
+	DrawBackNextButton(1000, 190, 350, 70, TextGet(PreferenceChatColorThemeSelected), "White", "",
+		() => TextGet((PreferenceChatColorThemeIndex == 0) ? PreferenceChatColorThemeList[PreferenceChatColorThemeList.length - 1] : PreferenceChatColorThemeList[PreferenceChatColorThemeIndex - 1]),
+		() => TextGet((PreferenceChatColorThemeIndex >= PreferenceChatColorThemeList.length - 1) ? PreferenceChatColorThemeList[0] : PreferenceChatColorThemeList[PreferenceChatColorThemeIndex + 1]));
+	DrawBackNextButton(1000, 290, 350, 70, TextGet(PreferenceChatEnterLeaveSelected), "White", "",
+		() => TextGet((PreferenceChatEnterLeaveIndex == 0) ? PreferenceChatEnterLeaveList[PreferenceChatEnterLeaveList.length - 1] : PreferenceChatEnterLeaveList[PreferenceChatEnterLeaveIndex - 1]),
+		() => TextGet((PreferenceChatEnterLeaveIndex >= PreferenceChatEnterLeaveList.length - 1) ? PreferenceChatEnterLeaveList[0] : PreferenceChatEnterLeaveList[PreferenceChatEnterLeaveIndex + 1]));
+	DrawBackNextButton(1000, 390, 350, 70, TextGet(PreferenceChatMemberNumbersSelected), "White", "",
+		() => TextGet((PreferenceChatMemberNumbersIndex == 0) ? PreferenceChatMemberNumbersList[PreferenceChatMemberNumbersList.length - 1] : PreferenceChatMemberNumbersList[PreferenceChatMemberNumbersIndex - 1]),
+		() => TextGet((PreferenceChatMemberNumbersIndex >= PreferenceChatMemberNumbersList.length - 1) ? PreferenceChatMemberNumbersList[0] : PreferenceChatMemberNumbersList[PreferenceChatMemberNumbersIndex + 1]));
+	DrawButton(500, 492, 64, 64, "", "White", (Player.ChatSettings && Player.ChatSettings.DisplayTimestamps) ? "Icons/Checked.png" : "");
+	DrawButton(500, 592, 64, 64, "", "White", (Player.ChatSettings && Player.ChatSettings.ColorNames) ? "Icons/Checked.png" : "");
+	DrawButton(500, 692, 64, 64, "", "White", (Player.ChatSettings && Player.ChatSettings.ColorActions) ? "Icons/Checked.png" : "");
+	DrawButton(500, 792, 64, 64, "", "White", (Player.ChatSettings && Player.ChatSettings.ColorEmotes) ? "Icons/Checked.png" : "");
+
+	DrawButton(1815, 75, 90, 90, "", "White", "Icons/Exit.png");
+	DrawCharacter(Player, 50, 50, 0.9);
+}
+
+// Redirected to from the main Click function if the player is in the chat settings subscreen
+function PreferenceSubscreenChatClick() {
+	// If the user clicked one of the checkboxes
+	if ((MouseX >= 500) && (MouseX < 564)) {
+		if ((MouseY >= 492) && (MouseY < 556)) Player.ChatSettings.DisplayTimestamps = !Player.ChatSettings.DisplayTimestamps;
+		if ((MouseY >= 592) && (MouseY < 656)) Player.ChatSettings.ColorNames = !Player.ChatSettings.ColorNames;
+		if ((MouseY >= 692) && (MouseY < 756)) Player.ChatSettings.ColorActions = !Player.ChatSettings.ColorActions;
+		if ((MouseY >= 792) && (MouseY < 856)) Player.ChatSettings.ColorEmotes = !Player.ChatSettings.ColorEmotes;
+	}
+
+	// If the user used one of the BackNextButtons
+	if ((MouseX >= 1000) && (MouseX < 1350) && (MouseY >= 190) && (MouseY < 270)) {
+		if (MouseX <= 1175) PreferenceChatColorThemeIndex = (PreferenceChatColorThemeIndex <= 0) ? PreferenceChatColorThemeList.length - 1 : PreferenceChatColorThemeIndex - 1;
+		else PreferenceChatColorThemeIndex = (PreferenceChatColorThemeIndex >= PreferenceChatColorThemeList.length - 1) ? 0 : PreferenceChatColorThemeIndex + 1;
+		PreferenceChatColorThemeSelected = PreferenceChatColorThemeList[PreferenceChatColorThemeIndex];
+		Player.ChatSettings.ColorTheme = PreferenceChatColorThemeSelected;
+	}
+	if ((MouseX >= 1000) && (MouseX < 1350) && (MouseY >= 290) && (MouseY < 370)) {
+		if (MouseX <= 1175) PreferenceChatEnterLeaveIndex = (PreferenceChatEnterLeaveIndex <= 0) ? PreferenceChatEnterLeaveList.length - 1 : PreferenceChatEnterLeaveIndex - 1;
+		else PreferenceChatEnterLeaveIndex = (PreferenceChatEnterLeaveIndex >= PreferenceChatEnterLeaveList.length - 1) ? 0 : PreferenceChatEnterLeaveIndex + 1;
+		PreferenceChatEnterLeaveSelected = PreferenceChatEnterLeaveList[PreferenceChatEnterLeaveIndex];
+		Player.ChatSettings.EnterLeave = PreferenceChatEnterLeaveSelected;
+	}
+	if ((MouseX >= 1000) && (MouseX < 1350) && (MouseY >= 390) && (MouseY < 470)) {
+		if (MouseX <= 1175) PreferenceChatMemberNumbersIndex = (PreferenceChatMemberNumbersIndex <= 0) ? PreferenceChatMemberNumbersList.length - 1 : PreferenceChatMemberNumbersIndex - 1;
+		else PreferenceChatMemberNumbersIndex = (PreferenceChatMemberNumbersIndex >= PreferenceChatMemberNumbersList.length - 1) ? 0 : PreferenceChatMemberNumbersIndex + 1;
+		PreferenceChatMemberNumbersSelected = PreferenceChatMemberNumbersList[PreferenceChatMemberNumbersIndex];
+		Player.ChatSettings.MemberNumbers = PreferenceChatMemberNumbersSelected;
+	}
+
+	// If the user clicked the exit icon to return to the main screen
+	if ((MouseX >= 1815) && (MouseX < 1905) && (MouseY >= 75) && (MouseY < 165) && (PreferenceColorPick == "")) {
+		PreferenceSubscreen = "";
+		ElementCreateInput("InputCharacterLabelColor", "text", Player.LabelColor);
+	}
 }

--- a/BondageClub/Screens/Character/Preference/Text_Preference.csv
+++ b/BondageClub/Screens/Character/Preference/Text_Preference.csv
@@ -7,3 +7,19 @@ PermissionLevel2,"Owner, whitelist & Dominants"
 PermissionLevel3,Owner and whitelist only
 PermissionLevel4,Owner only
 ErrorInvalidColor,Put a valid hex #red-green-blue color
+ChatDisplaySettings,- Chat display settings -
+ColorTheme,Color theme:
+Light,Light
+Dark,Dark
+EnterLeaveStyle,Enter/Leave message style:
+Normal,Normal
+Smaller,Smaller
+Hidden,Hidden
+DisplayMemberNumbers,Display member numbers:
+Always,Always
+Never,Never
+OnMouseover,On Mouseover
+DisplayTimestamps,Display timestamps
+ColorNames,Color names
+ColorActions,Color actions
+ColorEmotes,Color emotes

--- a/BondageClub/Screens/Character/Preference/Text_Preference_DE.txt
+++ b/BondageClub/Screens/Character/Preference/Text_Preference_DE.txt
@@ -16,3 +16,35 @@ Owner only
 Nur Besitzer
 Put a valid hex #red-green-blue color
 Bitte gültige #rot-grün-blau Hex-Farbe eingeben
+- Chat display settings -
+- Chatanzeigeoptionen -
+Color theme:
+Farbschema:
+Light
+Hell
+Dark
+Dunkel
+Enter/Leave message style:
+Beitritt/Verlassen-Nachrichten:
+Normal
+Normal
+Smaller
+Kleiner
+Hidden
+Verbergen
+Display member numbers:
+Mitglieder-IDs anzeigen:
+Always
+Immer
+Never
+Nie
+On Mouseover
+Bei Mouseover
+Display timestamps
+Zeitstempel anzeigen
+Color names
+Namen färben
+Color actions
+Handlungen färben
+Color emotes
+Emotes färben

--- a/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
+++ b/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
@@ -37,6 +37,11 @@ function ChatRoomCreateElement() {
 		ElementPositionFix("TextAreaChatLog", 36, 1005, 5, 988, 923);
 		ElementContent("TextAreaChatLog", ChatRoomLog);
 		ElementScrollToEnd("TextAreaChatLog");
+		if (Player.ChatSettings) {
+			for (var property in Player.ChatSettings) {
+				ElementSetDataAttribute("TextAreaChatLog", property, Player.ChatSettings[property]);
+			}
+		}
 		ElementFocus("InputChat");
 	}
 }
@@ -375,6 +380,12 @@ function ChatRoomMessage(data) {
 				if (data.Type == "Hidden") return;
 			}
 
+			// [Temporary?] Checks if the message is a notification about the user entering or leaving the room
+			var enterLeave = "";
+			if ((data.Type == "Action") && (msg.startsWith(SenderCharacter.Name + " entered.") || msg.startsWith(SenderCharacter.Name + " left.") || msg.startsWith(SenderCharacter.Name + " disconnected.") || msg.startsWith(SenderCharacter.Name + " was banned by ") || msg.startsWith(SenderCharacter.Name + " was kicked-out by "))) {
+				enterLeave = " ChatMessageEnterLeave";
+			}
+
 			// Builds the message to add depending on the type
 			if ((data.Type != null) && (data.Type == "Chat") && Player.IsDeaf()) msg = '<span class="ChatMessageName" style="color:' + (SenderCharacter.LabelColor || 'gray') + ';">' + SenderCharacter.Name + ':</span> ' + SpeechGarble(SenderCharacter, msg);
 			if ((data.Type != null) && (data.Type == "Chat") && !Player.IsDeaf()) msg = '<span class="ChatMessageName" style="color:' + (SenderCharacter.LabelColor || 'gray') + ';">' + SenderCharacter.Name + ':</span> ' + msg;
@@ -387,7 +398,7 @@ function ChatRoomMessage(data) {
 			var ShouldScrollDown = ElementIsScrolledToEnd("TextAreaChatLog");
 			var DataAttributes = 'data-time="' + ChatRoomCurrentTime() + '" data-sender="' + data.Sender + '"';
 			var BackgroundColor = ((data.Type == "Emote" || data.Type == "Action") ? 'style="background-color:' + ChatRoomGetLighterColor(SenderCharacter.LabelColor) + ';"' : "");
-			ChatRoomLog = ChatRoomLog + '<div class="ChatMessage ChatMessage' + data.Type + '" ' + DataAttributes + ' ' + BackgroundColor + '>' + msg + '</div>';
+			ChatRoomLog = ChatRoomLog + '<div class="ChatMessage ChatMessage' + data.Type + enterLeave + '" ' + DataAttributes + ' ' + BackgroundColor + '>' + msg + '</div>';
 			if (document.getElementById("TextAreaChatLog") != null) {
 				ElementContent("TextAreaChatLog", ChatRoomLog);
 				if (ShouldScrollDown) ElementScrollToEnd("TextAreaChatLog");
@@ -459,7 +470,7 @@ function ChatRoomCurrentTime() {
 function ChatRoomGetLighterColor(Color) {
 	if (!Color) return "#f0f0f0";
 	var R = Color.substring(1, 3), G = Color.substring(3, 5), B = Color.substring(5, 7);
-	return "#" + (255 - Math.floor((255 - parseInt(R, 16)) * 0.1)).toString(16) + (255 - Math.floor((255 - parseInt(G, 16)) * 0.1)).toString(16) + (255 - Math.floor((255 - parseInt(B, 16)) * 0.1)).toString(16);
+	return "rgba(" + parseInt(R, 16) + "," + parseInt(G, 16) + "," + parseInt(B, 16) + ",0.1)";
 }
 
 // Adds or remove an online member to/from a specific list

--- a/BondageClub/Scripts/Element.js
+++ b/BondageClub/Scripts/Element.js
@@ -117,15 +117,19 @@ function ElementPositionFix(ElementID, Font, X, Y, W, H) {
 
 }
 
+// Sets a custom data-attribute to a specified value on a specified element
+function ElementSetDataAttribute(ID, Name, Value) {
+	var element = document.getElementById(ID);
+	if (element != null) {
+		element.setAttribute("data-" + Name, Value);
+	}
+}
+
 // Scrolls to the end of a specified element
 function ElementScrollToEnd(ID) {
-	if (document.getElementById(ID) != null) {
-		var element = document.getElementById(ID);
-		element.focus();
-		if (element.value != null)
-			element.selectionStart = element.selectionEnd = element.value.length;
-		else
-			element.scrollTop = element.scrollHeight;
+	var element = document.getElementById(ID);
+	if (element != null) {
+		element.scrollTop = element.scrollHeight;
 	}
 }
 


### PR DESCRIPTION
A new menu as a preference subscreen that allows players to adjust the look of their chat. To access it, go to the preference menu and click the chat icon on the right. On first use, the settings default to the style that's currently active in the game for all players. These settings can also be changed without issue while you're inside a chat room.

I added a bit of code to allow styling messages differently that inform about players joining or leaving a room, since a few people said those could get annoying sometimes. If possible, maybe this could be changed in the future? So that the server would send them as their own message type, ideally allowing these strings to be translated as well.

I probably didn't test all possible scenarios you can create by playing around with the settings, but I did test a good number of them and didn't run into any trouble. Hopefully everyone will be able to find a style combination they like. :)

(Also removed some obsolete lines from the ElementScrollToEnd function, which I believe should fix problems with the mobile keyboard, as discovered by a Discord User a while back. If it hasn't been fixed another way already.)