### PR TITLE
Added a height/size setting

### DIFF
--- a/BondageClub/Assets/Female3DCG/Female3DCG.js
+++ b/BondageClub/Assets/Female3DCG/Female3DCG.js
@@ -456,6 +456,19 @@ var AssetFemale3DCG = [
 	},
 
 	{
+		Group: "Height",
+		AllowNone:false,
+		AllowColorize:false,
+		Asset: [
+			{Name: "0.95", Visible: false},
+			{Name: "0.975", Visible: false},
+			{Name: "1.0", Visible:false},
+			{Name: "0.9", Visible: false},
+			{Name: "0.925", Visible: false}
+		]
+	},
+
+	{
 		Group: "Eyes",
 		Priority: 8,
 		AllowNone: false,

--- a/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
+++ b/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
@@ -113,7 +113,7 @@ function ChatRoomDrawCharacter(DoClick) {
 			if ((C == 5) && (Player.Effect.indexOf("BlindHeavy") < 0) && (Player.Effect.indexOf("BlindNormal") < 0)) DrawImageZoomCanvas("Backgrounds/" + ChatRoomData.Background + ((Player.Effect.indexOf("BlindLight") < 0) ? "" : "Dark") + ".jpg", MainCanvas, 0, 0, 2000, 1000, 0, 500, 1000, 500);
 
 			// Draw the character
-			DrawCharacter(ChatRoomCharacter[C], (C % 5) * Space + X, Y + Math.floor(C / 5) * 500, Zoom);
+			DrawCharacter(ChatRoomCharacter[C],(C % 5) * Space + (ChatRoomCharacter.length >= 5 ? X * 4 : (ChatRoomCharacter.length == 4 ? X * 2.5 : ChatRoomCharacter.length == 3 ? X * 1.25 : X)),Y - 980*(1-Zoom) + Math.floor(C / 5) * 500, Zoom, true);
 			if (ChatRoomTargetMemberNumber == ChatRoomCharacter[C].MemberNumber) DrawImage("Icons/Small/Whisper.png", (C % 5) * Space + X + 75 * Zoom, Y + Math.floor(C / 5) * 500 + 950 * Zoom);
 			
 			// Draw the friendlist / blacklist / whitelist icons

--- a/BondageClub/Scripts/Drawing.js
+++ b/BondageClub/Scripts/Drawing.js
@@ -103,8 +103,8 @@ function DrawGetImageOnError(Img, IsAsset) {
 
 // Refreshes the character if not all images are loaded and draw the character canvas on the main game screen
 function DrawCharacter(C, X, Y, Zoom, IsHeightResizeAllowed) {
-	if (Zoom == 1){ IsHeightResizeAllowed=true; }
-	if (C != undefined){ Zoom *= CharacterAppearanceGetCurrentValue(C,"Height","Asset").Name; }
+	if (Zoom == 1){ IsHeightResizeAllowed = true; }
+	if (C != undefined && IsHeightResizeAllowed){ Zoom *= CharacterAppearanceGetCurrentValue(C,"Height","Asset").Name; }
 
 	// Make sure we have a character
 	if (C != null)

--- a/BondageClub/Scripts/Drawing.js
+++ b/BondageClub/Scripts/Drawing.js
@@ -102,7 +102,9 @@ function DrawGetImageOnError(Img, IsAsset) {
 }
 
 // Refreshes the character if not all images are loaded and draw the character canvas on the main game screen
-function DrawCharacter(C, X, Y, Zoom) {
+function DrawCharacter(C, X, Y, Zoom, IsHeightResizeAllowed) {
+	if (Zoom == 1){ IsHeightResizeAllowed=true; }
+	if (C != undefined){ Zoom *= CharacterAppearanceGetCurrentValue(C,"Height","Asset").Name; }
 
 	// Make sure we have a character
 	if (C != null)
@@ -141,8 +143,8 @@ function DrawCharacter(C, X, Y, Zoom) {
 			}
 
 			// Draw the character
-			if ((Zoom == undefined) || (Zoom == 1))
-				DrawCanvas(Canvas, X, Y - C.HeightModifier);
+			if (IsHeightResizeAllowed)
+				DrawCanvasZoom(Canvas, X + Canvas.width * (1-Zoom)/2, Y + (Canvas.height-46) * (1-Zoom) - (C.HeightModifier * Zoom), Zoom);
 			else
 				DrawCanvasZoom(Canvas, X, Y - (C.HeightModifier * Zoom), Zoom);
 
@@ -158,7 +160,7 @@ function DrawCharacter(C, X, Y, Zoom) {
 			if ((C.Name != "") && ((CurrentModule == "Room") || (CurrentModule == "Online") || ((CurrentScreen == "Wardrobe") && (C.ID != 0))) && (CurrentScreen != "Private"))
 				if (!Player.IsBlind()) {
 					MainCanvas.font = "30px Arial";
-					DrawText(C.Name, X + 255 * Zoom, Y + 980 * Zoom, (CommonIsColor(C.LabelColor)) ? C.LabelColor : "White", "Black");
+					DrawText(C.Name, X + 255, Y + 980, (CommonIsColor(C.LabelColor)) ? C.LabelColor : "White", "Black");
 					MainCanvas.font = "36px Arial";
 				}
 
@@ -190,11 +192,6 @@ function DrawImageCanvas(Source, Canvas, X, Y) {
 	if (!Img.naturalWidth) return true;
 	Canvas.drawImage(Img, X, Y);
 	return true;
-}
-
-// Draw a specific canvas on the main canvas
-function DrawCanvas(Canvas, X, Y) {
-	MainCanvas.drawImage(Canvas, X, Y);
 }
 
 // Draw a specific canvas with a zoom on the main canvas


### PR DESCRIPTION
will scale the characters depending on a setting available in the appearance menu from 90% to 100% of original size.
works well when basic zoom is at 1.0 but requires manual adjustements for others kind of zoom (see chatroom's drawCharacter call to have an idea of that). Far from perfect so I might work on it later but it works for now.