### PR TITLE
Check at login for stable items

### DIFF
--- a/BondageClub/Screens/Character/Login/Login.js
+++ b/BondageClub/Screens/Character/Login/Login.js
@@ -115,7 +115,6 @@ function LoginMistressItems() {
 		InventoryAdd(Player, "MistressBottom", "ClothLower", false);
 		InventoryAdd(Player, "MistressPadlock", "ItemMisc", false);
 		InventoryAdd(Player, "MistressPadlockKey", "ItemMisc", false);
-		ServerPlayerInventorySync();
 	} else {
 		InventoryDelete(Player, "MistressPadlock", "ItemMisc", false);
 		InventoryDelete(Player, "MistressPadlockKey", "ItemMisc", false);
@@ -123,8 +122,22 @@ function LoginMistressItems() {
 		InventoryDelete(Player, "MistressBoots", "Shoes", false);
 		InventoryDelete(Player, "MistressTop", "Cloth", false);
 		InventoryDelete(Player, "MistressBottom", "ClothLower", false);
-		ServerPlayerInventorySync();
 	}
+	ServerPlayerInventorySync();
+}
+
+// Only players that are ponies or trainers can have the pony equipment
+function LoginStableItems() {
+	if (LogQuery("JoinedStable", "PonyExam") || LogQuery("JoinedStable", "TrainerExam")) {
+		InventoryAdd(Player, "HarnessPonyBits", "ItemMouth", false);
+		InventoryAdd(Player, "PonyBoots", "Shoes", false);
+		InventoryAdd(Player, "PonyBoots", "ItemBoots", false);
+	} else {
+		InventoryDelete(Player, "HarnessPonyBits", "ItemMouth", false);
+		InventoryDelete(Player, "PonyBoots", "Shoes", false);
+		InventoryDelete(Player, "PonyBoots", "ItemBoots", false);
+	}
+	ServerPlayerInventorySync();
 }
 
 // When the character logs, we analyze the data
@@ -198,6 +211,7 @@ function LoginResponse(C) {
 			if ((InventoryGet(Player, "ItemArms") != null) && (InventoryGet(Player, "ItemArms").Asset.Name == "FourLimbsShackles")) InventoryRemove(Player, "ItemArms");
 			LoginValidCollar();
 			LoginMistressItems();
+			LoginStableItems();
 			CharacterAppearanceValidate(Player);
 
 			// If the player must log back in the cell


### PR DESCRIPTION
-Will check at login that the player has indeed passed the exam and adds stable items in her inventory (bit gag and pony boots), also add lockable pony boots in her inventory if the case.
-Won't remove restraints currently used, but players will still have them deleted from their inventory.

disclaimer : locking pony boots and clothing pony boots can seem a bit redundant for the moment, but it won't be when there will exist some itemboots not hiding shoes.