### PR TITLE
Fix breaking whispers when using HTML characters

### DIFF
--- a/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
+++ b/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
@@ -245,6 +245,11 @@ function ChatRoomSendChat() {
 		// Keeps the chat log in memory so it can be accessed with pageup/pagedown
 		ChatRoomLastMessage.push(msg);
 		ChatRoomLastMessageIndex = ChatRoomLastMessage.length;
+
+		// Replace < and > characters to prevent HTML injections
+		while (msg.indexOf("<") > -1) msg = msg.replace("<", "&lt;");
+		while (msg.indexOf(">") > -1) msg = msg.replace(">", "&gt;");
+
 		var m = msg.toLowerCase().trim();
 		
 		// Some custom functions like /dice or /coin are implemented for randomness


### PR DESCRIPTION
It has been brought to my attention that when using whispers in the chat, certain character sequences (like a broken heart, `</3`), would mess up the chat's HTML structure. On the senders end, all following messages would appear like whispers and be further indented, even if they exit whisper mode. These lines should fix that, although I wasn't sure if they should only be in effect when whispering, or always.