### PR TITLE
Preference option to hide tip messages

### DIFF
--- a/BondageClub/Screens/Character/Preference/Preference.js
+++ b/BondageClub/Screens/Character/Preference/Preference.js
@@ -37,6 +37,11 @@ function PreferenceLoad() {
 		ForceFullHeight: false
 	};
 
+	// If the user never set the visual settings before, construct them to replicate the default behavior
+	if (!Player.VisualSettings) Player.VisualSettings = {
+		HideTipMessages: true
+	};
+
 	// If the user never set the audio settings before, construct them to replicate the default behavior
     if (!Player.AudioSettings || (typeof Player.AudioSettings.Volume !== "number") || (typeof Player.AudioSettings.PlayBeeps !== "boolean")) Player.AudioSettings = {
         Volume: 1,
@@ -97,7 +102,9 @@ function PreferenceRun() {
     DrawText(TextGet("DisableAutoRemoveLogin"), 600, 745, "Black", "Gray");
     DrawButton(500, 712, 64, 64, "", "White", (Player.GameplaySettings && Player.GameplaySettings.DisableAutoRemoveLogin) ? "Icons/Checked.png" : "");
     DrawText(TextGet("ForceFullHeight"), 600, 825, "Black", "Gray");
-    DrawButton(500, 792, 64, 64, "", "White", (Player.VisualSettings && Player.VisualSettings.ForceFullHeight) ? "Icons/Checked.png" : "");
+	DrawButton(500, 792, 64, 64, "", "White", (Player.VisualSettings && Player.VisualSettings.ForceFullHeight) ? "Icons/Checked.png" : "");
+	DrawText(TextGet("HideTipMessages"), 600, 905, "Black", "Gray");
+    DrawButton(500, 872, 64, 64, "", "White", (Player.VisualSettings && Player.VisualSettings.HideTipMessages) ? "Icons/Checked.png" : "");
 	MainCanvas.textAlign = "center";
     DrawBackNextButton(500, 392, 250, 64, Player.AudioSettings.Volume * 100 + "%", "White", "",
         () => PreferenceSettingsVolumeList[(PreferenceSettingsVolumeIndex + PreferenceSettingsVolumeList.length - 1) % PreferenceSettingsVolumeList.length] * 100 + "%",
@@ -159,6 +166,7 @@ function PreferenceClick() {
 		if ((MouseY >= 632) && (MouseY < 696)) Player.GameplaySettings.BlindDisableExamine = !Player.GameplaySettings.BlindDisableExamine;
         if ((MouseY >= 712) && (MouseY < 776)) Player.GameplaySettings.DisableAutoRemoveLogin = !Player.GameplaySettings.DisableAutoRemoveLogin;
 		if ((MouseY >= 792) && (MouseY < 856)) Player.VisualSettings.ForceFullHeight = !Player.VisualSettings.ForceFullHeight;
+		if ((MouseY >= 872) && (MouseY < 936)) Player.VisualSettings.HideTipMessages = !Player.VisualSettings.HideTipMessages;
 	}
 }
 

--- a/BondageClub/Screens/Character/Preference/Text_Preference.csv
+++ b/BondageClub/Screens/Character/Preference/Text_Preference.csv
@@ -31,3 +31,4 @@ SensDepTotal,Total
 BlindDisableExamine,Disable examining people when blind
 DisableAutoRemoveLogin,Keep all of your restraints when relogging
 ForceFullHeight,Display all characters at maximum height
+HideTipMessages,Hide tip messages

--- a/BondageClub/Screens/Room/MainHall/MainHall.js
+++ b/BondageClub/Screens/Room/MainHall/MainHall.js
@@ -64,8 +64,10 @@ function MainHallRun() {
 
 	// Draws the character and main hall buttons
 	DrawCharacter(Player, 750, 0, 1);
-	MainCanvas.font = "italic 30px Arial";	
-	DrawTextWrap(TextGet("Tip" + MainHallTip), 100, 800, 500, 200, "White");
+	if ((Player != null) && (Player.VisualSettings != null) && (Player.VisualSettings.HideTipMessages != null) && !Player.VisualSettings.HideTipMessages || (Player.VisualSettings.HideTipMessages == null) ) {
+		MainCanvas.font = "italic 30px Arial";	
+		DrawTextWrap(TextGet("Tip" + MainHallTip), 100, 800, 500, 200, "White");
+	}
 	MainCanvas.font = "36px Arial";	
 	
 	// Char, Dressing, Exit & Chat


### PR DESCRIPTION
The new tip messages offer good advice and state clear rules and boundaries, but they might be a bit immersion breaking for some visitors of the club.

Just imagine being in a first-class "adult établissement" and constantly being reminded by the staff or by signs that you could be robbed by the ladies that sit on your lap, or catch diseases, that you must be over the age of 21 (for the umpteenth time although you are clearly over 40), or that you should be polite to the working ladies (even if you are the nicest person on the planet).

Also for users that find the tips useful – and they all are – seeing them every time you visit the main hall could be just a little too often for some guests.
