### PR TITLE
Fix LoveChastityBelt blocking

### DIFF
--- a/BondageClub/Screens/Inventory/ItemPelvis/LoveChastityBelt/LoveChastityBelt.js
+++ b/BondageClub/Screens/Inventory/ItemPelvis/LoveChastityBelt/LoveChastityBelt.js
@@ -44,7 +44,7 @@ function InventoryItemPelvisLoveChastityBeltDraw() {
       DrawButton(1200, 800, 250, 65, DialogFind(Player, "LoveChastityBeltUnlock" + DialogFocusItem.Property.Type), "White");
     } else {
       DrawButton(1200, 800, 250, 65, DialogFind(Player, "LoveChastityBeltAddShield"), "White");
-      if (InventoryGet(((Player.FocusGroup != null) ? Player : CurrentCharacter), "ItemVulva") == null) {
+      if (InventoryItemPelvisLoveChastityBeltCanInsert(CharacterGetCurrent())) {
         DrawButton(1200, 900, 250, 65, DialogFind(Player, "LoveChastityBeltAddVibe"), "White");
         DrawButton(1550, 900, 250, 65, DialogFind(Player, "LoveChastityBeltAddShock"), "White");
       }
@@ -94,7 +94,7 @@ function InventoryItemPelvisLoveChastityBeltClick() {
       if ((MouseX >= 1200) && (MouseX <= 1450) && (MouseY >= 800) && (MouseY <= 865)) {
         InventoryItemPelvisLoveChastityBeltSetTypeTo("Closed", "LoveChastityBeltAddShieldMessage");
       }
-      if (InventoryGet(C, "ItemVulva") == null) {
+      if (InventoryItemPelvisLoveChastityBeltCanInsert(C)) {
         if ((MouseX >= 1200) && (MouseX <= 1450) && (MouseY >= 900) && (MouseY <= 965)) {
           InventoryItemPelvisLoveChastityBeltSetTypeTo("Vibe", "LoveChastityBeltAddVibeMessage");
         }
@@ -104,6 +104,18 @@ function InventoryItemPelvisLoveChastityBeltClick() {
       }
     }
   }
+}
+
+// checks if "ItemVulva" is accessible
+function InventoryItemPelvisLoveChastityBeltCanInsert(C) {
+  for (var A = 0; A < C.Appearance.length; A++)
+    if ((C.Appearance[A].Asset != null) && (C.Appearance[A].Asset.Group.Family == C.AssetFamily)) {
+      if (C.Appearance[A].Asset.Group.Name == "ItemVulva")
+        return false;
+      if ((C.Appearance[A].Asset.Group.Name == "ItemVulvaPiercings") && (C.Appearance[A].Asset.Block != null) && C.Appearance[A].Asset.Block.includes("ItemVulva"))
+        return false;
+    }
+  return true;
 }
 
 // set the type on the belt
@@ -164,7 +176,7 @@ function InventoryItemPelvisLoveChastityBeltLoadType() {
     DialogFocusItem.Property.Block = null;
     if (DialogFocusItem.Property.LockButt == true) DialogFocusItem.Property.Block = ["ItemButt"];
   } else {
-    DialogFocusItem.Property.Block = ["ItemVulva"];
+    DialogFocusItem.Property.Block = ["ItemVulva", "ItemVulvaPiercings"];
     if (DialogFocusItem.Property.LockButt) DialogFocusItem.Property.Block.push("ItemButt");
     DialogFocusItem.Property.Effect = ["Chaste"];
     if (DialogFocusItem.Property.Type == "Vibe") {


### PR DESCRIPTION
ItemVulvaPiercings is now blocked,

if ItemVulvaPiercings as `Block:["ItemVulva"]` vibe or shock type can no longer be selected