### PR TITLE
Date.now()

### DIFF
--- a/BondageClub/Scripts/Common.js
+++ b/BondageClub/Scripts/Common.js
@@ -214,7 +214,7 @@ function CommonSetScreen(NewModule, NewScreen) {
 
 // Return the current time
 function CommonTime() {
-	return new Date().getTime();
+	return Date.now();
 }
 
 // Returns TRUE if the string is a HEX color


### PR DESCRIPTION
`Date.now()` is faster than `new Date().getTime()` and works abolutaly the same

(the old one create an object each time with a frozen Date of the Date.now())