### PR TITLE
BUGFIX: Edge compatibility of color picker

### DIFF
--- a/BondageClub/Scripts/ColorPicker.js
+++ b/BondageClub/Scripts/ColorPicker.js
@@ -95,7 +95,7 @@ function ColorPickerGetCoordinates(Event) {
 function ColorPickerPickHue(Event) {
     var C = ColorPickerGetCoordinates(Event);
     ColorPickerHSV.H = Math.max(0, Math.min(1, (C.X - ColorPickerX) / ColorPickerWidth));
-    ColorPickerLastHSV = { ...ColorPickerHSV };
+    ColorPickerLastHSV = Object.assign({}, ColorPickerHSV);
     ColorPickerNotify();
 }
 
@@ -108,7 +108,7 @@ function ColorPickerPickSV(Event) {
     var V = 1 - (C.Y - SVPanelOffset) / SVPanelHeight;
     ColorPickerHSV.S = Math.max(0, Math.min(1, S));
     ColorPickerHSV.V = Math.max(0, Math.min(1, V));
-    ColorPickerLastHSV = { ...ColorPickerHSV };
+    ColorPickerLastHSV = Object.assign({}, ColorPickerHSV);
     ColorPickerNotify();
 }
 
@@ -116,7 +116,7 @@ function ColorPickerSelectFromPallete(Event) {
     var C = ColorPickerGetCoordinates(Event);
     var P = Math.max(0, Math.min(1, (C.X - ColorPickerX) / ColorPickerWidth));
     var HSV = P > 0.5 ? ColorPickerInitialHSV : ColorPickerLastHSV;
-    ColorPickerHSV = { ...HSV };
+    ColorPickerHSV = Object.assign({}, HSV);
     ColorPickerNotify();
 }
 
@@ -179,9 +179,9 @@ function ColorPickerDraw(X, Y, Width, Height, Src, Callback) {
         }
 
         HSV = ColorPickerCSSToHSV(Color);
-        ColorPickerInitialHSV = { ...HSV };
-        ColorPickerLastHSV = { ...HSV };
-        ColorPickerHSV = { ...HSV };
+        ColorPickerInitialHSV = Object.assign({}, HSV);
+        ColorPickerLastHSV =  Object.assign({}, HSV);
+        ColorPickerHSV =  Object.assign({}, HSV);
         ColorPickerRemoveEventListener();   // remove possible duplicated attached event listener, just in case
         ColorPickerAttachEventListener();
     } else {

--- a/BondageClub/Scripts/Dialog.js
+++ b/BondageClub/Scripts/Dialog.js
@@ -556,7 +556,7 @@ function DialogMenuButtonClick() {
 				if (Item != null && DialogFocusItemOriginalColor != Item.Color) {
 					// FocusItem color changed, sync to server
 					if (C.ID == 0) ServerPlayerAppearanceSync();
-					ChatRoomPublishAction(C, { ...Item, Color: DialogFocusItemOriginalColor }, Item, false);
+					ChatRoomPublishAction(C, Object.assign({}, Item, { Color: DialogFocusItemOriginalColor }), Item, false);
 					ChatRoomCharacterUpdate(C);
 				}
 				return;


### PR DESCRIPTION
TestCase Passed:
- Pick color for next item
- Pick color for current item on the fly
- Send action messages upon item color change in chatroom

Tested using: 
Microsoft Edge 44.18362.449.0
Microsoft EdgeHTML 18.18362
Google Chrome 79.0.3945.130
