### PR TITLE
Bugfix android copy colorcode

### DIFF
--- a/BondageClub/Screens/Character/Appearance/Appearance.js
+++ b/BondageClub/Screens/Character/Appearance/Appearance.js
@@ -434,10 +434,6 @@ function AppearanceRun() {
 
 	}
 
-	if (HideColorPicker) {
-		ColorPickerHide();
-	}
-
 	// Hides the color picker if needed
 	if (HideColorPicker) ColorPickerHide();
 

--- a/BondageClub/Scripts/ColorPicker.js
+++ b/BondageClub/Scripts/ColorPicker.js
@@ -17,7 +17,9 @@ var ColorPickerLayout = {
 
 function ColorPickerAttachEventListener() {
     var CanvasElement = document.getElementById("MainCanvas");
-    CanvasElement.addEventListener("mousedown", ColorPickerStartPick);
+    if (!CommonIsMobile) {
+        CanvasElement.addEventListener("mousedown", ColorPickerStartPick);
+    }
     CanvasElement.addEventListener("touchstart", ColorPickerStartPick);
 }
 


### PR DESCRIPTION
Way to reproduce the bug:

1. An android chrome browser (or desktop chrome with mobile mode turned on in devtools)
2. Enter appearance screen
3. Tap on any one of 2nd - 7th color picker button
4. Color positioned exactly under the tap position will be selected immediately

This will make it hard to copy existing clothing color