### PR TITLE
Bugfix: Collar restraint removal in kidnap minigame

### DIFF
--- a/BondageClub/Screens/MiniGame/Kidnap/Kidnap.js
+++ b/BondageClub/Screens/MiniGame/Kidnap/Kidnap.js
@@ -142,8 +142,11 @@ function KidnapUpperHandMoveAvailable(MoveType, DoMove) {
 		var I = InventoryGet(C, KidnapUpperHandMoveType[MoveType].replace("Undo", ""));
 		if ((I != null) && ((C.ID != 0) || !InventoryItemHasEffect(I, "Lock", true))) {
 			if (DoMove) InventoryRemove(C, KidnapUpperHandMoveType[MoveType].replace("Undo", ""));
-			// If removing a collar, also remove collar accessories
-			if (DoMove && MoveType == 5) InventoryRemove(C, "ItemNeckAccessories");
+			// If removing a collar, also remove collar accessories & restraints
+			if (DoMove && MoveType == 5) {
+				InventoryRemove(C, "ItemNeckAccessories");
+				InventoryRemove(C, "ItemNeckRestraints");
+			}
 			return true;
 		}
 	}


### PR DESCRIPTION
This is the same issue as #744 - ensures leashes and other collar restraints are removed at the same time as the collar.