### PR TITLE
#755 Fix: Override Priority setting to fix Rope/Chain Cuff clipping

### DIFF
--- a/BondageClub/Screens/Character/Appearance/Appearance.js
+++ b/BondageClub/Screens/Character/Appearance/Appearance.js
@@ -191,7 +191,10 @@ function CharacterAppearanceSort(AP) {
 	var Arr = [];
 	for (var P = 0; P < 50; P++)
 		for (var A = 0; A < AP.length; A++)
-			if (AP[A].Asset.DrawingPriority != null) {
+			if (AP[A].Property != null && AP[A].Property.OverridePriority != null) {
+				if (AP[A].Property.OverridePriority == P)
+					Arr.push(AP[A]);
+			} else if (AP[A].Asset.DrawingPriority != null) {
 				if (AP[A].Asset.DrawingPriority == P)
 					Arr.push(AP[A]);
 			} else

--- a/BondageClub/Screens/Inventory/ItemArms/Chains/Chains.js
+++ b/BondageClub/Screens/Inventory/ItemArms/Chains/Chains.js
@@ -15,7 +15,7 @@ const ChainsArmsOptions = [
 	}, {
 		Name: "ChainCuffs",
 		RequiredBondageLevel: null,
-		Property: { Type: "ChainCuffs", Effect: ["Block", "Prone"], SetPose: ["BackCuffs"], Difficulty: 1 },
+		Property: { Type: "ChainCuffs", Effect: ["Block", "Prone"], SetPose: ["BackCuffs"], Difficulty: 1, OverridePriority: 30 },
 		Expression: [{ Group: "Blush", Name: "Low", Timer: 5 }],
 		ArmsOnly: true
 	}, {

--- a/BondageClub/Screens/Inventory/ItemArms/HempRope/HempRope.js
+++ b/BondageClub/Screens/Inventory/ItemArms/HempRope/HempRope.js
@@ -13,11 +13,11 @@ const HempRopeArmsOptions = [
 		Expression: [{ Group: "Blush", Name: "Low", Timer: 5 }],
 		ArmsOnly: true
 	}, {
-        Name: "RopeCuffs",
-        RequiredBondageLevel: null,
-        Property: { Type: "RopeCuffs", Effect: ["Block", "Prone"], SetPose: ["BackCuffs"], Difficulty: 1 },
-        Expression: [{ Group: "Blush", Name: "Low", Timer: 5 }],
-        ArmsOnly: true
+		Name: "RopeCuffs",
+		RequiredBondageLevel: null,
+		Property: { Type: "RopeCuffs", Effect: ["Block", "Prone"], SetPose: ["BackCuffs"], Difficulty: 1, OverridePriority: 30 },
+		Expression: [{ Group: "Blush", Name: "Low", Timer: 5 }],
+		ArmsOnly: true
 	}, {
 		Name: "WristElbowTie",
 		RequiredBondageLevel: 2,


### PR DESCRIPTION
Added an OverridePriority setting for appearance item properties that will be checked first before the Asset's DrawingPriority and the Group's DrawingPriority.
In the case of the RopeCuffs and ChainCuffs options, the override priority will be set to 30 similar to MetalCuffs, instead of the default ItemArms' 32, so that the item is hidden behind clothes.