### PR TITLE
Magic Theatre room gag slot fix

### DIFF
--- a/BondageClub/Screens/Room/Magic/Magic.js
+++ b/BondageClub/Screens/Room/Magic/Magic.js
@@ -36,11 +36,16 @@ function MagicAssistantIsntDressRestrain() {return (MagicShowIsState(8) && !Magi
 
 function MagicRestrainMinItem(C, MinItem) {
 	var CurItem = 0;
-	for(var E = 0; E < C.Appearance.length; E++)
-	if ((C.Appearance[E].Asset.Group.Name == "ItemMouth") || (C.Appearance[E].Asset.Group.Name == "ItemArms") || (C.Appearance[E].Asset.Group.Name == "ItemFeet") || (C.Appearance[E].Asset.Group.Name == "ItemLegs") || (C.Appearance[E].Asset.Group.Name == "ItemHead") || (C.Appearance[E].Asset.Group.Name == "ItemMisc")) {
-		CurItem++
+	var GagApplied = false;
+	for (var E = 0; E < C.Appearance.length; E++) {
+		if ((C.Appearance[E].Asset.Group.Name == "ItemMouth") || (C.Appearance[E].Asset.Group.Name == "ItemMouth2") || (C.Appearance[E].Asset.Group.Name == "ItemMouth3")) {
+			GagApplied = true;
+		}
+		else if ((C.Appearance[E].Asset.Group.Name == "ItemArms") || (C.Appearance[E].Asset.Group.Name == "ItemFeet") || (C.Appearance[E].Asset.Group.Name == "ItemLegs") || (C.Appearance[E].Asset.Group.Name == "ItemHead") || (C.Appearance[E].Asset.Group.Name == "ItemMisc")) {
+			CurItem++
+		}
 	}
-	return (CurItem >= MinItem) ? true : false;
+	return (CurItem + (GagApplied ? 1 : 0)) >= MinItem;
 }
 
 


### PR DESCRIPTION
Allowing the gag to be applied in any of the three ItemMouth slots instead of only the leftmost one when required for tricks.