### PR TITLE
LARP - Restrain legs item name fix

### DIFF
--- a/BondageClub/Screens/Online/GameLARP/GameLARP.js
+++ b/BondageClub/Screens/Online/GameLARP/GameLARP.js
@@ -518,7 +518,7 @@ function GameLARPProcessAction(Action, ItemName, Source, Target, RNG) {
 	var ItemDesc = "N/A";
 	if (ItemName != "") {
 		var A;
-		if ((Action == "RestrainLegs") || (Action == "Immobilize")) A = AssetGet(Target.AssetFamily, "ItemLegs", ItemName);
+		if ((Action == "RestrainLegs") || (Action == "Immobilize")) A = AssetGet(Target.AssetFamily, "ItemFeet", ItemName);
 		if ((Action == "RestrainArms") || (Action == "Detain")) A = AssetGet(Target.AssetFamily, "ItemArms", ItemName);
 		if ((Action == "RestrainMouth") || (Action == "Silence")) A = AssetGet(Target.AssetFamily, "ItemMouth", ItemName);
 		if ((Action == "Dress") || (Action == "Costume")) A = AssetGet(Target.AssetFamily, "Cloth", ItemName);


### PR DESCRIPTION
The item name for the RestrainLegs chat message is showing as "N/A" because it's checking ItemLegs instead of ItemFeet.