### PR TITLE
Bugfix: Prevents the maid from removing owner-locked bindings after a maid job

### DIFF
--- a/BondageClub/Screens/Room/MaidQuarters/MaidQuarters.js
+++ b/BondageClub/Screens/Room/MaidQuarters/MaidQuarters.js
@@ -99,7 +99,7 @@ function MaidQuartersWearMaidUniform() {
 
 // When the player removes the maid uniform and dresses back
 function MaidQuartersRemoveMaidUniform() {
-	CharacterRelease(Player);
+	CharacterReleaseNonOwner(Player);
 	for(var ItemAssetGroupName in MaidQuartersItemClothPrev){
 		var PreviousItem = MaidQuartersItemClothPrev[ItemAssetGroupName];
 		InventoryRemove(Player, ItemAssetGroupName);

--- a/BondageClub/Scripts/Character.js
+++ b/BondageClub/Scripts/Character.js
@@ -489,14 +489,20 @@ function CharacterDress(C, Appearance) {
 	}
 }
 
-// Removes any binding item from the character
-function CharacterRelease(C) {
+// Removes any binding item from the character which matches the predicate, or all bindings if no predicate is passed
+function CharacterRelease(C, Predicate) {
+	Predicate = Predicate || (() => true);
 	for (var E = 0; E < C.Appearance.length; E++)
-		if (C.Appearance[E].Asset.IsRestraint) {
+		if (C.Appearance[E].Asset.IsRestraint && Predicate(C.Appearance[E])) {
 			C.Appearance.splice(E, 1);
 			E--;
 		}
 	CharacterRefresh(C);
+}
+
+// Removes any binding items from the character which are not owner locked
+function CharacterReleaseNonOwner(C) {
+	CharacterRelease(C, (Item) => (Item && Item.Property && Item.Property.LockedBy) !== "OwnerPadlock");
 }
 
 // Returns the best bonus factor available


### PR DESCRIPTION
#### Bug Description
After completing a job for the maid quarters, all character restraints were being removed, even if owner-locked. This PR changes the behaviour so that any owner-locked restraints are not removed after completing a job. This was mainly any issue for owner-locked heels and leashes (it's generally not possible to start maid jobs with other types of owner-locked restraint).

#### Notes
To avoid duplicating too much code, I've modified the `CharacterRelease` function to take a second optional `Predicate` argument, which is a function used to determine whether or not a given restraint should be removed. This argument defaults to `() => true`, so calling the function without the `Predicate` argument preserves the original functionality. I appreciate that this is a pretty commonly-called function, so if you'd rather not change it, I can revert that and duplicate the original function into the new `CharacterReleaseNonOwner` function.