### PR TITLE
New Character pose fix

### DIFF
--- a/BondageClub/Screens/Character/Appearance/Appearance.js
+++ b/BondageClub/Screens/Character/Appearance/Appearance.js
@@ -71,6 +71,7 @@ function CharacterAppearanceSetDefault(C) {
 
 	// Resets the current appearance and prepares the assets
 	C.Appearance = [];
+	C.Pose = [];
 	if (CharacterAppearanceAssets.length == 0) CharacterAppearanceBuildAssets(C);
 
 	// For each items in the character appearance assets


### PR DESCRIPTION
The default character in the New Character screen was mimicking the pose of the last shown sample character in the welcome screen, despite not wearing the items. Setting it to the default pose.