### PR TITLE
Up Button Fix

### DIFF
--- a/BondageClub/Scripts/Dialog.js
+++ b/BondageClub/Scripts/Dialog.js
@@ -1113,6 +1113,12 @@ function DialogDrawItemMenu(C) {
 				DialogExtendItem(InventoryGet(C, DialogProgressNextItem.Asset.Group.Name));
 			} else ChatRoomPublishAction(C, DialogProgressPrevItem, DialogProgressNextItem, true);
 
+			// Reset the the character's position
+			if (CharacterAppearanceForceTopPosition == true) {
+				CharacterAppearanceForceTopPosition = false;
+				CharacterApperanceSetHeightModifier(C);
+			}
+
 			// Rebuilds the menu
 			DialogEndExpression();
 			if (C.FocusGroup != null) DialogMenuButtonBuild(C);


### PR DESCRIPTION
Applying an item to a kneeling/hogtied/etc player then clicking the Up button left the player hovering in the chat room screen. The position was only being reset when clicking out of the menu, but will now be reset when exiting due to item progress completing as well.