### PR TITLE
Item Type Change Fix

### DIFF
--- a/BondageClub/Screens/Inventory/ItemMisc/LoversTimerPadlock/LoversTimerPadlock.js
+++ b/BondageClub/Screens/Inventory/ItemMisc/LoversTimerPadlock/LoversTimerPadlock.js
@@ -67,7 +67,7 @@ function InventoryItemMiscLoversTimerPadlockClick() {
             if ((MouseY >= 666) && (MouseY <= 730)) { DialogFocusSourceItem.Property.RemoveItem = !(DialogFocusSourceItem.Property.RemoveItem); }
             if ((MouseY >= 746) && (MouseY <= 810)) { DialogFocusSourceItem.Property.ShowTimer = !(DialogFocusSourceItem.Property.ShowTimer); }
             if ((MouseY >= 826) && (MouseY <= 890)) { DialogFocusSourceItem.Property.EnableRandomInput = !(DialogFocusSourceItem.Property.EnableRandomInput); }
-            if (CurrentScreen == "ChatRoom") ChatRoomCharacterItemUpdate(CurrentCharacter);
+            if (CurrentScreen == "ChatRoom") ChatRoomCharacterItemUpdate(CharacterGetCurrent());
         }
     }
 

--- a/BondageClub/Screens/Inventory/ItemMisc/MistressTimerPadlock/MistressTimerPadlock.js
+++ b/BondageClub/Screens/Inventory/ItemMisc/MistressTimerPadlock/MistressTimerPadlock.js
@@ -66,7 +66,7 @@ function InventoryItemMiscMistressTimerPadlockClick() {
             if ((MouseY >= 666) && (MouseY <= 730)) { DialogFocusSourceItem.Property.RemoveItem = !(DialogFocusSourceItem.Property.RemoveItem); }
             if ((MouseY >= 746) && (MouseY <= 810)) { DialogFocusSourceItem.Property.ShowTimer = !(DialogFocusSourceItem.Property.ShowTimer); }
             if ((MouseY >= 826) && (MouseY <= 890)) { DialogFocusSourceItem.Property.EnableRandomInput = !(DialogFocusSourceItem.Property.EnableRandomInput); }
-            if (CurrentScreen == "ChatRoom") ChatRoomCharacterItemUpdate(CurrentCharacter);
+            if (CurrentScreen == "ChatRoom") ChatRoomCharacterItemUpdate(CharacterGetCurrent());
         }
     }
 

--- a/BondageClub/Screens/Inventory/ItemMisc/OwnerTimerPadlock/OwnerTimerPadlock.js
+++ b/BondageClub/Screens/Inventory/ItemMisc/OwnerTimerPadlock/OwnerTimerPadlock.js
@@ -67,7 +67,7 @@ function InventoryItemMiscOwnerTimerPadlockClick() {
             if ((MouseY >= 666) && (MouseY <= 730)) { DialogFocusSourceItem.Property.RemoveItem = !(DialogFocusSourceItem.Property.RemoveItem); }
             if ((MouseY >= 746) && (MouseY <= 810)) { DialogFocusSourceItem.Property.ShowTimer = !(DialogFocusSourceItem.Property.ShowTimer); }
             if ((MouseY >= 826) && (MouseY <= 890)) { DialogFocusSourceItem.Property.EnableRandomInput = !(DialogFocusSourceItem.Property.EnableRandomInput); }
-            if (CurrentScreen == "ChatRoom") ChatRoomCharacterItemUpdate(CurrentCharacter);
+            if (CurrentScreen == "ChatRoom") ChatRoomCharacterItemUpdate(CharacterGetCurrent());
         }
     }
 

--- a/BondageClub/Screens/Inventory/ItemMisc/TimerPadlock/TimerPadlock.js
+++ b/BondageClub/Screens/Inventory/ItemMisc/TimerPadlock/TimerPadlock.js
@@ -30,7 +30,7 @@ function InventoryItemMiscTimerPadlockClick() {
 	if ((MouseX >= 1885) && (MouseX <= 1975) && (MouseY >= 25) && (MouseY <= 110)) InventoryItemMiscTimerPadlockExit();
 	if ((MouseX >= 1100) && (MouseX <= 1164) && (MouseY >= 836) && (MouseY <= 900) && (Player.MemberNumber == DialogFocusSourceItem.Property.LockMemberNumber) && Player.CanInteract()) {
 		DialogFocusSourceItem.Property.RemoveItem = !(DialogFocusSourceItem.Property.RemoveItem);
-		if (CurrentScreen == "ChatRoom") ChatRoomCharacterItemUpdate(CurrentCharacter);
+		if (CurrentScreen == "ChatRoom") ChatRoomCharacterItemUpdate(CharacterGetCurrent());
 	}
 	if ((MouseX >= 1350) && (MouseX <= 1650) && (MouseY >= 910) && (MouseY <= 975) && Player.CanInteract()) InventoryItemMiscTimerPadlockReset();
 }

--- a/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
+++ b/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
@@ -585,9 +585,10 @@ function ChatRoomCharacterItemUpdate(C, Group) {
 // Publishes a custom action to the chat
 function ChatRoomPublishCustomAction(msg, LeaveDialog, Dictionary) {
 	if (CurrentScreen == "ChatRoom") {
-		ServerSend("ChatRoomChat", { Content: msg, Type: "Action", Dictionary: Dictionary} );
-		ChatRoomCharacterItemUpdate(CurrentCharacter);
-		if (LeaveDialog && (CurrentCharacter != null)) DialogLeave();
+		ServerSend("ChatRoomChat", { Content: msg, Type: "Action", Dictionary: Dictionary });
+		var C = CharacterGetCurrent();
+		ChatRoomCharacterItemUpdate(C);
+		if (LeaveDialog && (C != null)) DialogLeave();
 	}
 }
 


### PR DESCRIPTION
An error occured whenever a player was wearing an item that has different type options, selected another character to open the character viewing screen, clicked on themselves on the left, and changed the type of their item. The item change would appear on the player's screen but not anyone else's, because the code was referencing the other character instead of the one actually affected.