### PR TITLE
Fix: inventory screen crash

### DIFF
--- a/BondageClub/Screens/Inventory/ItemFeet/SpreaderVibratingDildoBar/SpreaderVibratingDildoBar.js
+++ b/BondageClub/Screens/Inventory/ItemFeet/SpreaderVibratingDildoBar/SpreaderVibratingDildoBar.js
@@ -3,6 +3,7 @@
 // Loads the item extension properties
 function InventoryItemFeetSpreaderVibratingDildoBarLoad() {
 	if (DialogFocusItem.Property == null) DialogFocusItem.Property = { Intensity: -1 };
+	if (DialogFocusItem.Property.Intensity == null) DialogFocusItem.Property.Intensity = -1;
 }
 
 // Draw the item extension screen


### PR DESCRIPTION
Load function was incompatible with locks. Should prevent all the reported menu crash/locks disappearing. (tested and it works fine with locks)