### PR TITLE
Maid Combination Lock Removal

### DIFF
--- a/BondageClub/Screens/Room/MainHall/MainHall.js
+++ b/BondageClub/Screens/Room/MainHall/MainHall.js
@@ -239,6 +239,7 @@ function MainHallMaidReleasePlayer() {
 			if ((MainHallMaid.Dialog[D].Stage == "0") && (MainHallMaid.Dialog[D].Option == null))
 				MainHallMaid.Dialog[D].Result = DialogFind(MainHallMaid, "AlreadyReleased");
 		CharacterRelease(Player);
+		CharacterUnlock(Player);
 		MainHallMaid.Stage = "10";
 	} else MainHallMaid.CurrentDialog = DialogFind(MainHallMaid, "CannotRelease");
 }

--- a/BondageClub/Screens/Room/MainHall/MainHall.js
+++ b/BondageClub/Screens/Room/MainHall/MainHall.js
@@ -239,7 +239,7 @@ function MainHallMaidReleasePlayer() {
 			if ((MainHallMaid.Dialog[D].Stage == "0") && (MainHallMaid.Dialog[D].Option == null))
 				MainHallMaid.Dialog[D].Result = DialogFind(MainHallMaid, "AlreadyReleased");
 		CharacterRelease(Player);
-		CharacterUnlock(Player);
+		CharacterUnlockCombinationLock(Player);
 		MainHallMaid.Stage = "10";
 	} else MainHallMaid.CurrentDialog = DialogFind(MainHallMaid, "CannotRelease");
 }

--- a/BondageClub/Scripts/Character.js
+++ b/BondageClub/Scripts/Character.js
@@ -506,9 +506,9 @@ function CharacterRelease(C) {
 }
 
 // Removes all locks from the character except owner and lover locks
-function CharacterUnlock(C) {
+function CharacterUnlockCombinationLock(C) {
 	for (var A = 0; A < C.Appearance.length; A++)
-		if (C.Appearance[A].Property && C.Appearance[A].Property.LockedBy && C.Appearance[A].Property.LockedBy.indexOf("Owner") < 0 && C.Appearance[A].Property.LockedBy.indexOf("Lover") < 0) {
+		if (C.Appearance[A].Property && C.Appearance[A].Property.LockedBy == "CombinationPadlock") {
 			for (var E = 0; E < C.Appearance[A].Property.Effect.length; E++)
 				if (C.Appearance[A].Property.Effect == "Lock") C.Appearance[A].Property.Effect.splice(E, 1);
 			C.Appearance[A].Property.LockMemberNumber = null;

--- a/BondageClub/Scripts/Character.js
+++ b/BondageClub/Scripts/Character.js
@@ -505,6 +505,18 @@ function CharacterRelease(C) {
 	CharacterRefresh(C);
 }
 
+// Removes all locks from the character except owner and lover locks
+function CharacterUnlock(C) {
+	for (var A = 0; A < C.Appearance.length; A++)
+		if (C.Appearance[A].Property && C.Appearance[A].Property.LockedBy && C.Appearance[A].Property.LockedBy.indexOf("Owner") < 0 && C.Appearance[A].Property.LockedBy.indexOf("Lover") < 0) {
+			for (var E = 0; E < C.Appearance[A].Property.Effect.length; E++)
+				if (C.Appearance[A].Property.Effect == "Lock") C.Appearance[A].Property.Effect.splice(E, 1);
+			C.Appearance[A].Property.LockMemberNumber = null;
+			C.Appearance[A].Property.LockedBy = null;
+		}
+	CharacterRefresh(C);
+}
+
 // Removes any binding item from the character if there's no specific padlock on it
 function CharacterReleaseNoLock(C) {
 	for (var E = 0; E < C.Appearance.length; E++)


### PR DESCRIPTION
Certain assets which are lockable but are not restraints can effectively be permanently locked on right now using the combination lock. Management can remove some of these but not all of them. For example corsets and collars.
The main hall maid will not remove these and if they're locked by a combination lock by someone who won't share the code, they player is effectively stuck locked into the item unless they use the console.
With this change the maid will remove remaining combination locks after untying the player.