### PR TITLE
Bugfix: Prevents vertical overflow when rendering the suspension pose

### DIFF
--- a/BondageClub/Scripts/Drawing.js
+++ b/BondageClub/Scripts/Drawing.js
@@ -155,7 +155,8 @@ function DrawCharacter(C, X, Y, Zoom, IsHeightResizeAllowed) {
 			CanvasH.height = Canvas.height;
 			CanvasH.getContext("2d").rotate(Math.PI);
 			CanvasH.getContext("2d").translate(-Canvas.width, -Canvas.height);
-			CanvasH.getContext("2d").drawImage(Canvas, 0, 0);
+			// Render to the flipped canvas, and crop off the height modifier to prevent vertical overflow
+			CanvasH.getContext("2d").drawImage(Canvas, 0, 0, Canvas.width, Canvas.height - C.HeightModifier, 0, 0, Canvas.width, Canvas.height - C.HeightModifier);
 			Canvas = CanvasH;
 		}
 


### PR DESCRIPTION
When rendering the suspension pose in a chatroom containing more than 5 people, if the character is on the bottom row of the chatroom, their feet will "overflow" and be rendered above portions of the top row.

This change crops the image to prevent this overflow. Visually, it looks like the image below. 

Tested in single player & multiplayer with rope/chain suspension, as well as the water torture cell. Also tested that the cropping only affects the "Suspension" pose - no other poses are rendered differently.

![this image](https://user-images.githubusercontent.com/62729616/82707524-25a60c80-9c74-11ea-97f9-c6fb6c268def.png)
