### PR TITLE
Fix: Wand crash

### DIFF
--- a/BondageClub/Screens/Inventory/ItemVulva/FullLatexSuitWand/FullLatexSuitWand.js
+++ b/BondageClub/Screens/Inventory/ItemVulva/FullLatexSuitWand/FullLatexSuitWand.js
@@ -3,6 +3,7 @@
 // Loads the item extension properties
 function InventoryItemVulvaFullLatexSuitWandLoad() {
 	if (DialogFocusItem.Property == null) DialogFocusItem.Property = { Intensity: -1 };
+	if (DialogFocusItem.Property.Intensity == null) DialogFocusItem.Property.Intensity = -1;
 }
 
 // Draw the item extension screen


### PR DESCRIPTION
Fixed a bug where  locks and vibrations on the lockdown suit would collide and make the inventory crash (Like the spreader bar was fixed a couple days ago)