### PR TITLE
Prison Gagged Fix

### DIFF
--- a/BondageClub/Screens/Room/Prison/Dialog_NPC_Prison_Police.csv
+++ b/BondageClub/Screens/Room/Prison/Dialog_NPC_Prison_Police.csv
@@ -22,6 +22,7 @@ Arrest4,Arrest4,Here are my keys.,Anything else?,ArrestHandoverKeys(),PrisonPlay
 Arrest4,Arrest4,Here are my sleeping pills.,Anything else?,ArrestHandoverSleepingPills(),PrisonPlayerHasSleepingPills()
 Arrest4,Arrest4,Here are my spanking toys.,Anything else?,ArrestHandoverSpankingToys(),PrisonPlayerHasSpankingToys()
 Arrest4,Arrest5,I don't have that.,"Well, let's get you strip-searched. Undress to check.",,
+Arrest4,Arrest5,(Silence),"Guess we'll have to strip-search you to find out.",,
 Arrest5,Arrest7,(Take off all your clothes.),There you go. Spread your legs and bend over.,ArrestStripUnderware(),
 Arrest5,Arrest6,(Take off your outer clothing.),Completely undress.,ArrestStripOuterCloth(),
 Arrest5,Arrest6,(Refuse and wait and see.),Will it be soon? We can do it differently!,SetBehavior(-2),


### PR DESCRIPTION
An issue occured if a player fought the prison guard, was gagged in the fight and then lost. One of the dialog stages had entirely speech-only answers, and since none could be selected the game was softlocked. Now every possible path should have a silent/action option included.