### PR TITLE
Up Button Refresh Fix

### DIFF
--- a/BondageClub/Screens/Character/Appearance/Appearance.js
+++ b/BondageClub/Screens/Character/Appearance/Appearance.js
@@ -14,7 +14,7 @@ var CharacterAppearanceReturnModule = "Room";
 var CharacterAppearanceWardrobeOffset = 0;
 var CharacterAppearanceWardrobeMode = false;
 var CharacterAppearanceWardrobeText = "";
-var CharacterAppearanceForceTopPosition = false;
+var CharacterAppearanceForceUpCharacter = 0;
 
 // Builds all the assets that can be used to dress up the character
 function CharacterAppearanceBuildAssets(C) {
@@ -274,7 +274,7 @@ function CharacterAppearanceVisible(C, AssetName, GroupName) {
 
 // Sets the height modifier which determines the character's vertical position on screen
 function CharacterApperanceSetHeightModifier(C) {
-	if (CharacterAppearanceForceTopPosition == true) {
+	if (CharacterAppearanceForceUpCharacter == C.MemberNumber) {
 		C.HeightModifier = 0;
 	} else {
 		var Height = 0;

--- a/BondageClub/Scripts/Dialog.js
+++ b/BondageClub/Scripts/Dialog.js
@@ -771,7 +771,7 @@ function DialogClick() {
 
 	// If the user clicked the Up button, move the character up to the top of the screen
 	if ((CurrentCharacter.HeightModifier < -90) && (CurrentCharacter.FocusGroup != null) && (MouseX >= 510) && (MouseX < 600) && (MouseY >= 25) && (MouseY < 115)) {
-		CharacterAppearanceForceTopPosition = true;
+		CharacterAppearanceForceUpCharacter = CurrentCharacter.MemberNumber;
 		CurrentCharacter.HeightModifier = 0;
 		return;
 	}
@@ -801,8 +801,8 @@ function DialogClick() {
 	}
 
 	// If the user clicked anywhere outside the current character item zones, ensure the position is corrected
-	if (CharacterAppearanceForceTopPosition == true && ((MouseX < 500) || (MouseX > 1000) || (CurrentCharacter.FocusGroup == null))) {
-		CharacterAppearanceForceTopPosition = false;
+	if (CharacterAppearanceForceUpCharacter == CurrentCharacter.MemberNumber && ((MouseX < 500) || (MouseX > 1000) || (CurrentCharacter.FocusGroup == null))) {
+		CharacterAppearanceForceUpCharacter = 0;
 		CharacterApperanceSetHeightModifier(CurrentCharacter);
 	}
 
@@ -1141,8 +1141,8 @@ function DialogDrawItemMenu(C) {
 			} else ChatRoomPublishAction(C, DialogProgressPrevItem, DialogProgressNextItem, true);
 
 			// Reset the the character's position
-			if (CharacterAppearanceForceTopPosition == true) {
-				CharacterAppearanceForceTopPosition = false;
+			if (CharacterAppearanceForceUpCharacter == C.MemberNumber) {
+				CharacterAppearanceForceUpCharacter = 0;
 				CharacterApperanceSetHeightModifier(C);
 			}
 


### PR DESCRIPTION
If viewing one character with the Up button, and other characters refresh during that time, those other characters are also moved up and then left hovering in the chat room (for the viewing player only) until refreshed again.
Now the variable tracks the currently viewed character's number, so that only that character is moved up.