### PR TITLE
Bugfix: Allows inventory clicks on the current item to bypass prerequisite checks

### DIFF
--- a/BondageClub/Scripts/Dialog.js
+++ b/BondageClub/Scripts/Dialog.js
@@ -725,7 +725,7 @@ function DialogItemClick(ClickItem) {
 	// Cannot change item if the previous one is locked or blocked by another group
 	if ((CurrentItem == null) || !InventoryItemHasEffect(CurrentItem, "Lock", true)) {
 		if (!InventoryGroupIsBlocked(C))
-			if (InventoryAllow(C, ClickItem.Asset.Prerequisite))
+			if ((CurrentItem != null && (CurrentItem.Asset.Name == ClickItem.Asset.Name)) || InventoryAllow(C, ClickItem.Asset.Prerequisite))
 				if ((CurrentItem == null) || (CurrentItem.Asset.Name != ClickItem.Asset.Name)) {
 					if (ClickItem.Asset.Wear) {
 


### PR DESCRIPTION
# Problem

The web bondage item currently uses the `NotSuspended` prerequisite, but one of the extended variants for it adds the `Suspension` pose. This means that after selecting the web suspension option and clicking on the web item in the inventory menu, the "Remove suspension first" message would be displayed and the extended item screen would not be displayed.

As far as I'm aware, the web item is the first item that has an extended type whose pose configuration conflicts with the prerequisites of the base item, which explains why this issue has not been seen before.

# Solution

This PR adds an additional check which bypasses the prerequisite check if the clicked item is the same as the currently equipped item.