### PR TITLE
hotfix : lovers stuck

### DIFF
--- a/BondageClub/Screens/Character/Login/Login.js
+++ b/BondageClub/Screens/Character/Login/Login.js
@@ -248,8 +248,15 @@ function LoginResponse(C) {
 
 			// Loads the lovership data
 			Player.Lovership = Array.isArray(C.Lovership) ? C.Lovership.length > 0 ? C.Lovership[0] : null : C.Lovership;
-			if ((Player.Lovership != null) && (Player.Lovership.Name != null))
-				Player.Lover = Player.Lovership.Name;
+			if (((C.Lover != null) && (C.Lover != "undefined") && C.Lover.startsWith("NPC-")) ||
+				(Player.Lovership && ((Player.Lovership.Name.startsWith("NPC-") || ((Player.Lovership.Stage) && (Player.Lovership.Stage == 2)))))) {
+				Player.Lover = C.Lover;
+				ServerPlayerSync();
+			}
+			else {
+				Player.Lover = "";
+				ServerPlayerSync();
+			}
 
 			// Gets the online preferences
 			Player.LabelColor = C.LabelColor;
@@ -301,7 +308,6 @@ function LoginResponse(C) {
 			LoginStableItems();
 			LoginLoversItems();
 			LoginValideBuyGroups();
-			ServerPlayerSync();
 			CharacterAppearanceValidate(Player);
 
 			// If the player must log back in the cell


### PR DESCRIPTION
Due to my PR #882, lovers were unable to engage or marry after relogging.
Fixed that bug, but will require two relog (one in the new client, and another once the data has been updated).
The Multiple Lovers Server also fixes the problem.
This PR is intended as a hotfix, it will be useless once [#30](https://github.com/Ben987/Bondage-Club-Server/pull/30) is accepted