### PR TITLE
Fix: Infinite refreshes

### DIFF
--- a/BondageClub/Screens/Character/Login/Login.js
+++ b/BondageClub/Screens/Character/Login/Login.js
@@ -120,7 +120,7 @@ function LoginValidCollar() {
 	}
 	if ((InventoryGet(Player, "ItemNeck") == null) && (Player.Owner != "")) {
 		InventoryWear(Player, "SlaveCollar", "ItemNeck");
-		if (CurrentScreen == "ChatRoom") ChatRoomCharacterUpdate(Player);
+		if (CurrentScreen == "ChatRoom") ChatRoomCharacterItemUpdate(Player, "ItemNeck");
 	}
 }
 


### PR DESCRIPTION
The slave collar check would cause infinite refreshes if the collar was invalid (something coming from NPCs) when in chatrooms. This only syncs the slave collar to make sure the whole character does not keep being refreshed back and forth. This way people don't have to break with a NPC if they want to go in a chatroom

Tested with someone who had the "can't kneel or do anything" bug and it fixed it. 