### PR TITLE
Change: Remove addon on remove

### DIFF
--- a/BondageClub/Assets/Female3DCG/Female3DCG.js
+++ b/BondageClub/Assets/Female3DCG/Female3DCG.js
@@ -2071,7 +2071,7 @@ var AssetFemale3DCG = [
 				{ Name: "Hook", AllowColorize: false },
 			] },
 			{ Name: "InflatedBallHood", Value: 65, Difficulty: 50, Time: 15, AllowLock: true, Prerequisite: ["GagUnique"], Hide: ["HairFront", "HairBack", "Glasses", "ItemMouth", "ItemMouth2", "ItemMouth3", "Eyes", "HairAccessory1", "HairAccessory2"], Effect: ["BlindHeavy", "DeafLight", "Prone"], AllowEffect: ["GagLight", "GagEasy", "GagMedium", "GagVeryHeavy"], Block: ["ItemMouth", "ItemMouth2", "ItemMouth3", "ItemEars", "ItemNeck"], Extended: true},
-			{ Name: "OldGasMask", Value: 85, Difficulty: 25, Time: 10, Random: false, AllowLock: true, Prerequisite: ["GasMask"], DefaultColor: "#888", DefaultColor: "#313131", Hide: ["HairFront", "HairBack", "Glasses", "ItemMouth", "ItemMouth2", "ItemMouth3", "HairAccessory1", "HairAccessory2"], Block: ["ItemMouth", "ItemMouth2", "ItemMouth3", "ItemEars", "ItemNeck"], Extended: true, Layer: [
+			{ Name: "OldGasMask", Value: 85, Difficulty: 25, Time: 10, Random: false, AllowLock: true, Prerequisite: ["GasMask"], DefaultColor: "#888", DefaultColor: "#313131", Hide: ["HairFront", "HairBack", "Glasses", "ItemMouth", "ItemMouth2", "ItemMouth3", "HairAccessory1", "HairAccessory2"], Block: ["ItemMouth", "ItemMouth2", "ItemMouth3", "ItemEars", "ItemNeck"], Extended: true, RemoveItemOnRemove: [{ Name: "OldGasMaskTube1", Group: "ItemAddon" }, { Name: "OldGasMaskTube2", Group: "ItemAddon" }, { Name: "OldGasMaskLenses", Group: "ItemAddon" }, { Name: "OldGasMaskRebreather", Group: "ItemAddon" }], Layer: [
 				{ Name: "Mask", AllowColorize: true },
 				{ Name: "Light", AllowColorize: false }
 			]},		
@@ -2192,10 +2192,10 @@ var AssetFemale3DCG = [
 		Zone: [[400, 0, 90, 200]],
 		Asset: [
 			{ Name: "BondageBenchStraps", Value: -1, Difficulty: 12, SelfBondage: 5, Time: 5, IsRestraint: true, AllowLock: true, Hide: ["HairBack", "Wings", "TailStraps", "ItemButt"], SetPose: ["LegsClosed"], Effect: ["Block", "Prone"], AllowType: ["Light", "Normal", "Heavy", "Full"], Block: ["ItemDevices"], Extended: true, RemoveAtLogin: true },
-			{ Name: "OldGasMaskLenses", Priority: 44, Value: -1, Difficulty: 12, SelfBondage: 5, Time: 5, AllowLock: true, Effect: ["BlindHeavy"], Block: ["ItemHead"] },
-			{ Name: "OldGasMaskTube1", Effect: ["GagEasy"], Priority: 43, Value: -1, Difficulty: 12, SelfBondage: 5, Time: 5, AllowLock: true, Block: ["ItemHead"]},
-			{ Name: "OldGasMaskTube2", Effect: ["GagEasy"], Priority: 43, Value: -1, Difficulty: 12, SelfBondage: 5, Time: 5, AllowLock: true, Block: ["ItemHead"] },
-			{ Name: "OldGasMaskRebreather", Priority: 43, Value: -1, Difficulty: 12, SelfBondage: 5, Time: 5, AllowLock: true, Effect: ["GagNormal"], Block: ["ItemHead"]}
+			{ Name: "OldGasMaskLenses", Priority: 44, Value: -1, Difficulty: 12, SelfBondage: 5, Time: 5, AllowLock: true, Effect: ["BlindHeavy"] },
+			{ Name: "OldGasMaskTube1", Effect: ["GagEasy"], Priority: 43, Value: -1, Difficulty: 12, SelfBondage: 5, Time: 5, AllowLock: true},
+			{ Name: "OldGasMaskTube2", Effect: ["GagEasy"], Priority: 43, Value: -1, Difficulty: 12, SelfBondage: 5, Time: 5, AllowLock: true },
+			{ Name: "OldGasMaskRebreather", Priority: 43, Value: -1, Difficulty: 12, SelfBondage: 5, Time: 5, AllowLock: true, Effect: ["GagNormal"]}
 		],
 		Color: ["Default"]
 	},

--- a/BondageClub/Screens/Inventory/ItemHead/OldGasMask/OldGasMask.js
+++ b/BondageClub/Screens/Inventory/ItemHead/OldGasMask/OldGasMask.js
@@ -2,12 +2,6 @@
 
 // Loads the item extension properties
 function InventoryItemHeadOldGasMaskLoad() {
-	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
-	var addonItem = InventoryGet(C, "ItemAddon");
-	if (addonItem != null && addonItem.Asset.Name.startsWith("OldGasMask")) {
-		DialogExtendItem(addonItem);
-		return;
-	}
 	if (DialogFocusItem.Property == null) DialogFocusItem.Property = {};
 }
 
@@ -60,7 +54,6 @@ function InventoryItemHeadOldGasMaskSetItem(Item) {
 	if (CurrentScreen == "ChatRoom") {
 		DialogFocusItem = InventoryGet(C, C.FocusGroup.Name);
 		InventoryItemHeadOldGasMaskLoad();
-	
 	}
 	
 	// Do not continue if the item is blocked by permissions


### PR DESCRIPTION
Made it so the mask addons do not block the mask itself, allowing you to lock both independently and to remove the mask while wearing an addon to avoid confusion 

We'll see, if there is more confusion during beta I'll think of what else can be done, for now I'm just thinking of a text message on the item menu to say x rectangle contains addons. This change is already much better regardless 

Only reason I did not add a "remove addon" button on the mask itself is because the lock for removing the item would need to be handled there and it's less future-proof and way messier. 

Maybe a button "go to addons" ? It would change the focus to null and display the addon section like if you clicked on it yourself. Let me know what you think.