### PR TITLE
Fix: Layers + AllowTypes

### DIFF
--- a/BondageClub/Screens/Character/Appearance/Appearance.js
+++ b/BondageClub/Screens/Character/Appearance/Appearance.js
@@ -372,7 +372,7 @@ function CharacterAppearanceBuildCanvas(C) {
 				var LayerType = Type;
 				if (CA.Asset.Layer != null) {
 					Layer = "_" + CA.Asset.Layer[L].Name;
-					if ((CA.Asset.Layer[L].AllowTypes != null) && (CA.Asset.Layer[L].AllowTypes.indexOf(Type) < 0)) continue;
+					if ((CA.Asset.Layer[L].AllowTypes != null) && (CA.Asset.Layer[L].AllowTypes.indexOf(Type) < 0 && Type != "")) continue;
 					if (!CA.Asset.Layer[L].HasExpression) Expression = "";
 					if (!CA.Asset.Layer[L].HasType) LayerType = "";
 					if ((CA.Asset.Layer[L].NewParentGroupName != null) && (CA.Asset.Layer[L].NewParentGroupName != CA.Asset.Group.ParentGroupName)) {

--- a/BondageClub/Scripts/GLDraw.js
+++ b/BondageClub/Scripts/GLDraw.js
@@ -345,7 +345,7 @@ function GLDrawAppearanceBuild(C) {
                 var LayerType = Type;
                 if (CA.Asset.Layer != null) {
                     Layer = "_" + CA.Asset.Layer[L].Name;
-                    if ((CA.Asset.Layer[L].AllowTypes != null) && (CA.Asset.Layer[L].AllowTypes.indexOf(Type) < 0)) continue;
+                    if ((CA.Asset.Layer[L].AllowTypes != null) && (CA.Asset.Layer[L].AllowTypes.indexOf(Type) < 0 && Type != "")) continue;
                     if (!CA.Asset.Layer[L].HasExpression) Expression = "";
                     if (!CA.Asset.Layer[L].HasType) LayerType = "";
                     if ((CA.Asset.Layer[L].NewParentGroupName != null) && (CA.Asset.Layer[L].NewParentGroupName != CA.Asset.Group.ParentGroupName)) {


### PR DESCRIPTION
- Addressed a concern where the AllowTypes property would not behave as intended on Layered items

The check for layers when an item had types was wrong, making it so the base type would never be rendered unless you knew about it and added *""* to types.

This will allow items with various states to also support layers which will make complex items much simpler (Like the gas mask I added a couple days ago... which I might update after this change)