### PR TITLE
Fix: null text

### DIFF
--- a/BondageClub/Screens/Inventory/ItemFeet/HempRope/HempRope.js
+++ b/BondageClub/Screens/Inventory/ItemFeet/HempRope/HempRope.js
@@ -51,9 +51,10 @@ function InventoryItemFeetHempRopeDraw() {
 		var X = 1200 + (offset % 2 * 387);
 		var Y = 550 + (Math.floor(offset / 2) * 300);
 		var FailSkillCheck = (HempRopeFeetOptions[I].RequiredBondageLevel != null && SkillGetLevelReal(Player, "Bondage") < HempRopeFeetOptions[I].RequiredBondageLevel);
+		var requirementText = HempRopeFeetOptions[I].RequiredBondageLevel ? DialogFind(Player, "RequireBondageLevel").replace("ReqLevel", HempRopeFeetOptions[I].RequiredBondageLevel) : DialogFind(Player, "NoRequirement");
 
 		DrawText(DialogFind(Player, "RopeBondage" + HempRopeFeetOptions[I].Name), X + 113, Y - 20, "white", "gray");
-		DrawText(DialogFind(Player, "RequireBondageLevel").replace("ReqLevel", HempRopeFeetOptions[I].RequiredBondageLevel), X + 113, Y + 250, "white", "gray");
+		DrawText(requirementText, X + 113, Y + 250, "white", "gray");
 		DrawButton(X, Y, 225, 225, "", ((DialogFocusItem.Property.Type == HempRopeFeetOptions[I].Property.Type)) ? "#888888" : FailSkillCheck ? "Pink" : "White");
 		DrawImage("Screens/Inventory/" + DialogFocusItem.Asset.Group.Name + "/" + DialogFocusItem.Asset.Name + "/" + HempRopeFeetOptions[I].Name + ".png", X, Y + 1);
 	}

--- a/BondageClub/Screens/Inventory/ItemFeet/HempRope/HempRope.js
+++ b/BondageClub/Screens/Inventory/ItemFeet/HempRope/HempRope.js
@@ -51,10 +51,10 @@ function InventoryItemFeetHempRopeDraw() {
 		var X = 1200 + (offset % 2 * 387);
 		var Y = 550 + (Math.floor(offset / 2) * 300);
 		var FailSkillCheck = (HempRopeFeetOptions[I].RequiredBondageLevel != null && SkillGetLevelReal(Player, "Bondage") < HempRopeFeetOptions[I].RequiredBondageLevel);
-		var requirementText = HempRopeFeetOptions[I].RequiredBondageLevel ? DialogFind(Player, "RequireBondageLevel").replace("ReqLevel", HempRopeFeetOptions[I].RequiredBondageLevel) : DialogFind(Player, "NoRequirement");
+		var RequirementText = HempRopeFeetOptions[I].RequiredBondageLevel ? DialogFind(Player, "RequireBondageLevel").replace("ReqLevel", HempRopeFeetOptions[I].RequiredBondageLevel) : DialogFind(Player, "NoRequirement");
 
 		DrawText(DialogFind(Player, "RopeBondage" + HempRopeFeetOptions[I].Name), X + 113, Y - 20, "white", "gray");
-		DrawText(requirementText, X + 113, Y + 250, "white", "gray");
+		DrawText(RequirementText, X + 113, Y + 250, "white", "gray");
 		DrawButton(X, Y, 225, 225, "", ((DialogFocusItem.Property.Type == HempRopeFeetOptions[I].Property.Type)) ? "#888888" : FailSkillCheck ? "Pink" : "White");
 		DrawImage("Screens/Inventory/" + DialogFocusItem.Asset.Group.Name + "/" + DialogFocusItem.Asset.Name + "/" + HempRopeFeetOptions[I].Name + ".png", X, Y + 1);
 	}

--- a/BondageClub/Screens/Inventory/ItemLegs/Chains/Chains.js
+++ b/BondageClub/Screens/Inventory/ItemLegs/Chains/Chains.js
@@ -19,7 +19,7 @@ function InventoryItemLegsChainsDraw() {
 		DrawButton(1175, 550, 225, 225, "", (DialogFocusItem.Property.Type == null || DialogFocusItem.Property.Type == "Basic") ? "#888888" : "White");
 		DrawImage("Screens/Inventory/" + DialogFocusItem.Asset.Group.Name + "/" + DialogFocusItem.Asset.Name + "/Basic.png", 1175, 551);
 		DrawText(DialogFind(Player, "ChainBondageBasic"), 1288, 800, "white", "gray");
-		DrawText(DialogFind(Player, "NoRequirement").replace("ReqLevel", "2"), 1288, 850, "white", "gray");
+		DrawText(DialogFind(Player, "NoRequirement"), 1288, 850, "white", "gray");
 		DrawButton(1600, 550, 225, 225, "", ((DialogFocusItem.Property.Type != null) && (DialogFocusItem.Property.Type == "Strict")) ? "#888888" : (SkillGetLevelReal(Player, "Bondage") < 2) ? "Pink" : "White");
 		DrawImage("Screens/Inventory/" + DialogFocusItem.Asset.Group.Name + "/" + DialogFocusItem.Asset.Name + "/Strict.png", 1600, 551);
 		DrawText(DialogFind(Player, "ChainBondageStrict"), 1713, 800, "white", "gray");

--- a/BondageClub/Screens/Inventory/ItemLegs/HempRope/HempRope.js
+++ b/BondageClub/Screens/Inventory/ItemLegs/HempRope/HempRope.js
@@ -45,9 +45,10 @@ function InventoryItemLegsHempRopeDraw() {
 		var X = 1200 + (offset % 2 * 387);
 		var Y = 550 + (Math.floor(offset / 2) * 300);
 		var FailSkillCheck = (HempRopeLegsOptions[I].RequiredBondageLevel != null && SkillGetLevelReal(Player, "Bondage") < HempRopeLegsOptions[I].RequiredBondageLevel);
-
+		var RequirementText = HempRopeLegsOptions[I].RequiredBondageLevel ? DialogFind(Player, "RequireBondageLevel").replace("ReqLevel", HempRopeLegsOptions[I].RequiredBondageLevel) : DialogFind(Player, "NoRequirement");
+			
 		DrawText(DialogFind(Player, "RopeBondage" + HempRopeLegsOptions[I].Name), X + 113, Y - 20, "white", "gray");
-		DrawText(DialogFind(Player, "RequireBondageLevel").replace("ReqLevel", HempRopeLegsOptions[I].RequiredBondageLevel), X + 113, Y + 250, "white", "gray");
+		DrawText(RequirementText, X + 113, Y + 250, "white", "gray");
 		DrawButton(X, Y, 225, 225, "", ((DialogFocusItem.Property.Type == HempRopeLegsOptions[I].Property.Type)) ? "#888888" : FailSkillCheck ? "Pink" : "White");
 		DrawImage("Screens/Inventory/" + DialogFocusItem.Asset.Group.Name + "/" + DialogFocusItem.Asset.Name + "/" + HempRopeLegsOptions[I].Name + ".png", X, Y + 1);
 	}


### PR DESCRIPTION
- Fixed the displayed text for hemp rope feet 

(It said "required level null" instead of "no requirement" like everything else does)