### PR TITLE
Ban list size

### DIFF
--- a/BondageClub/Screens/Online/ChatAdmin/ChatAdmin.js
+++ b/BondageClub/Screens/Online/ChatAdmin/ChatAdmin.js
@@ -33,7 +33,7 @@ function ChatAdminLoad() {
 	document.getElementById("InputAdminList").setAttribute("autocomplete", "off");
 	ElementValue("InputAdminList", CommonConvertArrayToString(ChatRoomData.Admin));
 	ElementCreateTextArea("InputBanList");
-	document.getElementById("InputBanList").setAttribute("maxLength", 250);
+	document.getElementById("InputBanList").setAttribute("maxLength", 1000);
 	document.getElementById("InputBanList").setAttribute("autocomplete", "off");
 	ElementValue("InputBanList", CommonConvertArrayToString(ChatRoomData.Ban));
 	ChatAdminPrivate = ChatRoomData.Private;


### PR DESCRIPTION
Like we spoke It's been a frequently raised concern that the ban list only allows +/- 42 banned players considering the growing list of trolls. This has led many to use console to ban players to bypass this restriction caused by the UI.

I think it is a needed quality of life  change, and it will also be safer for people who are not familiar with the console.