### PR TITLE
Admin Actions on Self

### DIFF
--- a/BondageClub/Screens/Character/Player/Dialog_Player.csv
+++ b/BondageClub/Screens/Character/Player/Dialog_Player.csv
@@ -2,6 +2,7 @@ PlayerGagged,,,(You can use or remove items by selecting specific body regions o
 0,,,(You can use or remove items by selecting specific body regions on yourself.),,
 0,10,(Adjust your bondage skill.),"(By default, you restrain using your full bondage skill.  You can use less of your skill and make it easier for your victims to escape.)",,"DialogSkillGreater(""Bondage"", 1)"
 0,20,(Adjust your evasion skill.),"(By default, you struggle using your full evasion skill.  You can use less of your skill and make it harder for you to struggle free.)",,"DialogSkillGreater(""Evasion"", 1)"
+0,30,(Room administrator action.),"(As a room administrator, you can take these actions.)",,ChatRoomPlayerIsAdmin()
 10,,,"(By default, you restrain using your full bondage skill.  You can use less of your skill and make it easier for your victims to escape.)",,
 10,0,(Use your full bondage skill.  100%),(You will now use your full bondage skill when using a restraint.  100%),"DialogSetSkillRatio(""Bondage"", 100)",
 10,0,(Use most of your bondage skill.  75%),(You will now use most of your bondage skill when using a restraint.  75%),"DialogSetSkillRatio(""Bondage"", 75)",
@@ -16,6 +17,15 @@ PlayerGagged,,,(You can use or remove items by selecting specific body regions o
 20,0,(Use very little of your evasion skill.  25%),(You will now use very little of your evasion skill when trying to struggle free.  25%),"DialogSetSkillRatio(""Evasion"", 25)",
 20,0,(Use none of your evasion skill.  0%),(You will now use none of your evasion skill when trying to struggle free.  0%),"DialogSetSkillRatio(""Evasion"", 0)",
 20,0,(Don't change your skill.),(You can use or remove items by selecting specific body regions on yourself.),,
+30,0,(Swap position with someone else.),,"DialogChatRoomAdminAction(""Swap"")",!DialogChatRoomHasSwapTarget()
+30,0,(Cancel position swap.),,"DialogChatRoomAdminAction(""SwapCancel"")",DialogChatRoomHasSwapTarget()
+30,31,(Move to the left.),(You have moved to the left at position CharacterPosition.  Would you like to move further?),"DialogChatRoomAdminAction(""MoveLeft"")",
+30,31,(Move to the right.),(You have moved to the right at position CharacterPosition.  Would you like to move further?),"DialogChatRoomAdminAction(""MoveRight"")",
+30,0,(Back to main menu.),(Main menu.),,
+31,,(Move to the left.),(You have moved to the left at position CharacterPosition.  Would you like to move further?),"DialogChatRoomAdminAction(""MoveLeft"", ""false"")",
+31,,(Move to the right.),(You have moved to the right at position CharacterPosition.  Would you like to move further?),"DialogChatRoomAdminAction(""MoveRight"", ""false"")",
+31,0,(Back to main menu.),,,
+31,0,(Leave this menu.),,DialogLeave(),
 SelectItem,,,Select an item to use.,,
 SelectItemGroup,,,Select an item to use on the GroupName.,,
 SelectActivity,,,Select an activity.,,

--- a/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
+++ b/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
@@ -31,7 +31,7 @@ function ChatRoomCanTakeDrink() { return ((CurrentCharacter != null) && (Current
 function ChatRoomIsCollaredByPlayer() { return ((CurrentCharacter != null) && (CurrentCharacter.Ownership != null) && (CurrentCharacter.Ownership.Stage == 1) && (CurrentCharacter.Ownership.MemberNumber == Player.MemberNumber)) }
 function ChatRoomCanServeDrink() { return ((CurrentCharacter != null) && CurrentCharacter.CanWalk() && (ReputationCharacterGet(CurrentCharacter, "Maid") > 0) && CurrentCharacter.CanTalk()) }
 function ChatRoomCanGiveMoneyForOwner() { return ((ChatRoomMoneyForOwner > 0) && (CurrentCharacter != null) && (Player.Ownership != null) && (Player.Ownership.Stage == 1) && (Player.Ownership.MemberNumber == CurrentCharacter.MemberNumber)) }
-function ChatRoomPlayerIsAdmin() { return ((ChatRoomData.Admin != null) && (ChatRoomData.Admin.indexOf(Player.MemberNumber) >= 0)) }
+function ChatRoomPlayerIsAdmin() { return ((ChatRoomData != null && ChatRoomData.Admin != null) && (ChatRoomData.Admin.indexOf(Player.MemberNumber) >= 0)) }
 function ChatRoomCurrentCharacterIsAdmin() { return ((CurrentCharacter != null) && (ChatRoomData.Admin != null) && (ChatRoomData.Admin.indexOf(CurrentCharacter.MemberNumber) >= 0)) }
 function ChatRoomHasSwapTarget() { return ChatRoomSwapTarget != null }
 

--- a/BondageClub/Scripts/Dialog.js
+++ b/BondageClub/Scripts/Dialog.js
@@ -1280,3 +1280,13 @@ function DialogDrawExpressionMenu() {
 function DialogSetSkillRatio(SkillType, NewRatio) {
 	SkillSetRatio(SkillType, parseInt(NewRatio) / 100);
 }
+
+// Sends an administrative command to the server for the chat room from the player dialog
+function DialogChatRoomAdminAction(ActionType, Publish) {
+	ChatRoomAdminAction(ActionType, Publish);
+}
+
+// Checks if a chat room player swap is in progress
+function DialogChatRoomHasSwapTarget() {
+	return ChatRoomHasSwapTarget();
+}


### PR DESCRIPTION
This is linked to the server PR [#33](https://github.com/Ben987/Bondage-Club-Server/pull/33)

This allows the administrator of a chat room to click on themselves and perform the Swap, Move Left or Move Right admin actions.
This prevents the fairly regular occurence of admins who disconnect and want to move back to the top-left having to move every other character to the right to do so.