### PR TITLE
Struggle Audio Fix

### DIFF
--- a/BondageClub/Scripts/Dialog.js
+++ b/BondageClub/Scripts/Dialog.js
@@ -183,6 +183,7 @@ function DialogLeaveItemMenu() {
 	DialogTextDefault = "";
 	DialogTextDefaultTimer = 0;
 	ElementRemove("InputColor");
+	AudioDialogStop();
 }
 
 // Leaves the item menu of the focused item
@@ -484,9 +485,6 @@ function DialogMenuButtonClick() {
 	for (var I = 0; I < DialogMenuButton.length; I++)
 		if ((MouseX >= 1885 - I * 110) && (MouseX <= 1975 - I * 110)) {
 			
-			// Stops the dialog sounds
-			AudioDialogStop();
-
 			// Gets the current character and item
 			var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
 			var Item = InventoryGet(C, C.FocusGroup.Name);


### PR DESCRIPTION
When the struggle screen is exited, either by escaping or hitting the Exit icon, any audio that's playing ends. However this didn't cover the case where the screen was exited by hitting the Esc key. This currently only occurs for hemp & nylon ropes which have a 37 second long audio file that would play in full. The call to end the audio has been moved and now all 3 exit methods are covered.