### PR TITLE
Bugfix: Exception and potential game crash when cancelling out of the color picker

### DIFF
--- a/BondageClub/Scripts/Dialog.js
+++ b/BondageClub/Scripts/Dialog.js
@@ -184,6 +184,7 @@ function DialogLeaveItemMenu() {
 	DialogTextDefaultTimer = 0;
 	ElementRemove("InputColor");
 	AudioDialogStop();
+	ColorPickerEndPick();
 }
 
 // Leaves the item menu of the focused item


### PR DESCRIPTION
As reported by Ace in discord [here](https://discordapp.com/channels/554377975714414605/554378725916147722/722614848374046792).

## Steps to reproduce

1. Inside a chatroom, click a character
2. Click an item slot on that character
3. Click the color picker, but **do not** click inside the color picker square or otherwise select a color
4. Hit the escape key
5. You should now be back in the character dialog menu - click **anywhere** on the screen
6. The following will be printed in the console every frame:

```
Uncaught TypeError: Cannot read property 'Name' of null
at DialogChangeItemColor (Dialog.js:992)
at Dialog.js:1056
at ColorPickerNotify (ColorPicker.js:128)
at HTMLDocument.ColorPickerPickSV (ColorPicker.js:114)
```

This is due to the color picker mouse event listeners not being removed when it is closed via the escape key, and can cause the game to crash completely under certain circumstances.

This PR ensures that all color picker event listeners are removed when the item menu is closed by adding a call to `ColorPickerEndPick()` to the `DialogLeaveItemMenu()` function.