### PR TITLE
Resets character information sheet to page 1 upon exit

### DIFF
--- a/BondageClub/Screens/Character/InformationSheet/InformationSheet.js
+++ b/BondageClub/Screens/Character/InformationSheet/InformationSheet.js
@@ -178,6 +178,7 @@ function InformationSheetClick() {
 
 // when the user exit this screen
 function InformationSheetExit() {
+	InformationSheetSecondScreen = false;
 	CommonSetScreen(InformationSheetPreviousModule, InformationSheetPreviousScreen);
 }
 


### PR DESCRIPTION
Fixes a slightly unintuitive behaviour of the new character information sheet.

Steps to reproduce:

1. View a player's character information sheet
2. Change to page 2
3. Exit
4. View a different (or the same) player's information sheet
5. Notice that the information sheet is still on page 2
6. Change back to page 1
7. Exit and view a different (or the same) player's information sheet
8. Notice that the information sheet is back on page 1

I'd expect the information sheet to reset to page 1 each time, which is what this PR does.