### PR TITLE
Feature: Levels of deafness add up

### DIFF
--- a/BondageClub/Scripts/Character.js
+++ b/BondageClub/Scripts/Character.js
@@ -1,4 +1,10 @@
 "use strict";
+
+const CCharacterDeafLevelFactorLight  = 1;
+const CCharacterDeafLevelFactorNormal = 2;
+const CCharacterDeafLevelFactorHeavy  = 3;
+const CCharacterDeafLevelFactorTotal  = 4;
+
 var Character = [];
 
 // Loads a character in the buffer
@@ -62,6 +68,19 @@ function CharacterReset(CharacterID, CharacterAssetFamily) {
 				else if (this.Lovership[L].Name) { LoversNumbers.push(this.Lovership[L].Name); }
 			}
 			return LoversNumbers;
+		},
+		GetDeafLevel: function () {
+			var deafLevel =0;
+			for (var i = 0; i < this.Appearance.length; i++) {
+				// Sum up the various level of deafness. Light: 1, Normal: 2, Heavy: 3, Total: 4
+				if(this.Appearance[i].Asset.Effect != null){
+					if (this.Appearance[i].Asset.Effect.indexOf ("DeafLight") >= 0) deafLevel += CCharacterDeafLevelFactorLight;
+					else if (this.Appearance[i].Asset.Effect.indexOf ("DeafNormal") >= 0) deafLevel += CCharacterDeafLevelFactorNormal;
+					else if (this.Appearance[i].Asset.Effect.indexOf ("DeafHeavy") >= 0) deafLevel += CCharacterDeafLevelFactorHeavy;
+					else if (this.Appearance[i].Asset.Effect.indexOf ("DeafTotal") >= 0) deafLevel += CCharacterDeafLevelFactorTotal;
+				}
+			}
+			return deafLevel;
 		},
 		IsLoverPrivate: function () { return ((NPCEventGet(this, "Girlfriend") > 0) || (Player.GetLoversNumbers().indexOf("NPC-" + this.Name) >= 0)); },
 		IsKneeling: function () { return ((this.Pose != null) && (this.Pose.indexOf("Kneel") >= 0)) },

--- a/BondageClub/Scripts/Speech.js
+++ b/BondageClub/Scripts/Speech.js
@@ -1,5 +1,10 @@
 "use strict";
 
+const CSpeechDeafLevelTotal  = 4;
+const CSpeechDeafLevelHeavy  = 3;
+const CSpeechDeafLevelNormal = 2;
+const CSpeechDeafLevelLight  = 1;
+
 // Returns TRUE if the current speech phrase is a full emote (all between parentheses)
 function SpeechFullEmote(D) {
 	return ((D.indexOf("(") == 0) && (D.indexOf(")") == D.length - 1));
@@ -113,7 +118,7 @@ function SpeechGarble(C, CD) {
 	}	
 
 	// Total gags always returns mmmmm
-	if ((GagEffect >= 8) || ((C.ID != 0) && (Player.Effect.indexOf("DeafTotal") >= 0))) {
+	if ((GagEffect >= 8) || ((C.ID != 0) && (Player.GetDeafLevel() >= CSpeechDeafLevelTotal))) {
 		for (var L = 0; L < CD.length; L++) {
 			var H = CD.charAt(L).toLowerCase();
 			if (H == "(") Par = true;
@@ -166,7 +171,7 @@ function SpeechGarble(C, CD) {
 	}
 	
 	// Heavy garble - Almost no letter stays the same
-	if ((GagEffect >= 6) || ((C.ID != 0) && (Player.Effect.indexOf("DeafHeavy") >= 0))) {
+	if ((GagEffect >= 6) || ((C.ID != 0) && (Player.GetDeafLevel() >= CSpeechDeafLevelHeavy))) {
 		for (var L = 0; L < CD.length; L++) {
 			var H = CD.charAt(L).toLowerCase();
 			if (H == "(") Par = true;
@@ -240,7 +245,7 @@ function SpeechGarble(C, CD) {
 	}
 	
 	// Normal garble, keep vowels and a few letters the same
-	if ((GagEffect >= 4) || ((C.ID != 0) && (Player.Effect.indexOf("DeafNormal") >= 0))) {
+	if ((GagEffect >= 4) || ((C.ID != 0) && (Player.GetDeafLevel() >= CSpeechDeafLevelNormal))) {
 		for (var L = 0; L < CD.length; L++) {
 			var H = CD.charAt(L).toLowerCase();
 			if (H == "(") Par = true;
@@ -326,7 +331,7 @@ function SpeechGarble(C, CD) {
 	}
 	
 	// Light garble, half of the letters stay the same
-	if ((GagEffect >= 2) || ((C.ID != 0) && (Player.Effect.indexOf("DeafLight") >= 0))) {
+	if ((GagEffect >= 2) || ((C.ID != 0) && (Player.GetDeafLevel() >= CSpeechDeafLevelLight))) {
 		for (var L = 0; L < CD.length; L++) {
 			var H = CD.charAt(L).toLowerCase();
 			if (H == "(") Par = true;


### PR DESCRIPTION
# Summary
Unlike the various gagging items, multiple layers of deafening items do not add up. This PR changes this and solves issue [#877137](http://www.hostedredmine.com/issues/877137).

# Details
## What it does
This PR does two things

**`Character.js`**
* adds a function `GetDeafLevel` to the Character this function loops through the Appearance of the character and sums up the various deafening level. The function returns the current level of deafness
* The values are defined in constants:
  * `CCharacterDeafLevelFactorLight = 1`
  * `CCharacterDeafLevelFactorNormal = 2`
  * `CCharacterDeafLevelFactorHeavy = 3`
  * `CCharacterDeafLevelFactorTotal = 4`

**`Speech.js`**
* replaces the various calls of `IsDeaf` by `GetDeafLevel` and compares the result with the appropriate level of deafness. If a certain level is reached, the incoming messages are garbled, analog to speech garbling, when gagged
* The thresholds are defined in constants:
  * `CSpeechDeafLevelTotal = 4`
  * `CSpeechDeafLevelHeavy = 3`
  * `CSpeechDeafLevelNormal = 2`
  * `CSpeechDeafLevelLight = 1`

## Testing
The functionality was tested by two characters, one adding dealing items to herself and another repeatedly saying the same phrase. According to the level of deafness, the correctly garbled speech was received, up to "mmmm mmm" at the highest level.