### PR TITLE
Fix: online dialog builder crash

### DIFF
--- a/BondageClub/Scripts/Character.js
+++ b/BondageClub/Scripts/Character.js
@@ -113,8 +113,9 @@ function CharacterRandomName(C) {
 // Builds the dialog objects from the CSV files
 function CharacterBuildDialog(C, CSV) {
 
-	// For each lines in the file
+	var OnlinePlayer = C.AccountName.indexOf("Online-") >= 0;
 	C.Dialog = [];
+	// For each lines in the file
 	for (var L = 0; L < CSV.length; L++)
 		if ((CSV[L][0] != null) && (CSV[L][0] != "")) {
 
@@ -124,7 +125,7 @@ function CharacterBuildDialog(C, CSV) {
 			if ((CSV[L][1] != null) && (CSV[L][1].trim() != "")) D.NextStage = CSV[L][1];
 			if ((CSV[L][2] != null) && (CSV[L][2].trim() != "")) D.Option = CSV[L][2].replace("DialogCharacterName", C.Name).replace("DialogPlayerName", Player.Name);
 			if ((CSV[L][3] != null) && (CSV[L][3].trim() != "")) D.Result = CSV[L][3].replace("DialogCharacterName", C.Name).replace("DialogPlayerName", Player.Name);
-			if ((CSV[L][4] != null) && (CSV[L][4].trim() != "")) D.Function = ((CSV[L][4].trim().substring(0, 6) == "Dialog") ? "" : CurrentScreen) + CSV[L][4];
+			if ((CSV[L][4] != null) && (CSV[L][4].trim() != "")) D.Function = ((CSV[L][4].trim().substring(0, 6) == "Dialog") ? "" : OnlinePlayer ? "ChatRoom" : CurrentScreen) + CSV[L][4];
 			if ((CSV[L][5] != null) && (CSV[L][5].trim() != "")) D.Prerequisite = CSV[L][5];
 			if ((CSV[L][6] != null) && (CSV[L][6].trim() != "")) D.Group = CSV[L][6];
 			if ((CSV[L][7] != null) && (CSV[L][7].trim() != "")) D.Trait = CSV[L][7];


### PR DESCRIPTION
- Fixed a bug where the client would crash when trying to click on an online player's dialog options

Due to how functions in the dialog sheet is built, online characters **entering a room you are in for the first time while you are logged in** while you are in a screen other than the chatroom screen (like your friend list) will build the dialog with the wrong function names, causing the dialog options to crash. This fix ensures that any Online character is loaded with the ChatRoom prefix instead of the CurrentScreen.

![Crash in action](https://user-images.githubusercontent.com/59637973/85518389-2e209880-b5ce-11ea-97cf-1dd337e0c474.PNG)

Tested with self dialog, NPCs and online characters with no apparent side effects.

See [issue 878282](http://www.hostedredmine.com/issues/878282)