### PR TITLE
Improvement: Quickban

### DIFF
--- a/BondageClub/Screens/Online/ChatAdmin/ChatAdmin.js
+++ b/BondageClub/Screens/Online/ChatAdmin/ChatAdmin.js
@@ -55,24 +55,26 @@ function ChatAdminLoad() {
 function ChatAdminRun() {
 
 	// Draw the main controls
-	DrawText(TextGet(ChatAdminMessage), 650, 870, "Black", "Gray");
+	DrawText(TextGet(ChatAdminMessage), 650, 885, "Black", "Gray");
 	DrawText(TextGet("RoomName"), 535, 110, "Black", "Gray");
 	ElementPosition("InputName", 535, 170, 820);
 	DrawText(TextGet("RoomSize"), 1100, 110, "Black", "Gray");
 	ElementPosition("InputSize", 1100, 170, 250);
-	DrawText(TextGet("RoomDescription"), 675, 265, "Black", "Gray");
-	ElementPosition("InputDescription", 675, 380, 1100, 160);
-	DrawText(TextGet("RoomAdminList"), 390, 530, "Black", "Gray");
-	ElementPosition("InputAdminList", 390, 680, 530, 230);
-	DrawText(TextGet("RoomBanList"), 960, 530, "Black", "Gray");
-	ElementPosition("InputBanList", 960, 680, 530, 230);
+	DrawText(TextGet("RoomDescription"), 675, 255, "Black", "Gray");
+	ElementPosition("InputDescription", 675, 350, 1100, 140);
+	DrawText(TextGet("RoomAdminList"), 390, 490, "Black", "Gray");
+	ElementPosition("InputAdminList", 390, 685, 530, 300);
+	DrawText(TextGet("RoomBanList"), 960, 490, "Black", "Gray");
+	ElementPosition("InputBanList", 960, 640, 530, 210);
+	DrawButton(700, 780, 250, 65, TextGet("QuickbanBlackList"), ChatRoomPlayerIsAdmin() ? "White" : "#ebebe4");
+	DrawButton(965, 780, 250, 65, TextGet("QuickbanGhostList"), ChatRoomPlayerIsAdmin() ? "White" : "#ebebe4");
 
 	// Background selection
 	DrawImageResize("Backgrounds/" + ChatAdminBackgroundSelect + "Dark.jpg", 1300, 75, 600, 400);
 	DrawBackNextButton(1350, 500, 500, 65, DialogFind(Player, ChatAdminBackgroundSelect), ChatRoomPlayerIsAdmin() ? "White" : "#ebebe4", null,
 		() => DialogFind(Player, (ChatAdminBackgroundIndex == 0) ? ChatCreateBackgroundList[ChatCreateBackgroundList.length - 1] : ChatCreateBackgroundList[ChatAdminBackgroundIndex - 1]),
 		() => DialogFind(Player, (ChatAdminBackgroundIndex >= ChatCreateBackgroundList.length - 1) ? ChatCreateBackgroundList[0] : ChatCreateBackgroundList[ChatAdminBackgroundIndex + 1]));
-	DrawButton(1450, 600, 300, 65, TextGet("ShowAll"), "White");
+	DrawButton(1450, 600, 300, 65, TextGet("ShowAll"),  ChatRoomPlayerIsAdmin() ? "White" : "#ebebe4");
 
 	// Private and Locked check boxes
 	DrawText(TextGet("RoomPrivate"), 1384, 740, "Black", "Gray");
@@ -102,11 +104,13 @@ function ChatAdminClick() {
 			ChatAdminBackgroundSelect = ChatCreateBackgroundList[ChatAdminBackgroundIndex];
 		}
 
-		// Private & Locked check boxes + save button
+		// Private & Locked check boxes + save button + quickban buttons
 		if ((MouseX >= 1486) && (MouseX <= 1550) && (MouseY >= 708) && (MouseY <= 772)) ChatAdminPrivate = !ChatAdminPrivate;
 		if ((MouseX >= 1786) && (MouseX <= 1850) && (MouseY >= 708) && (MouseY <= 772)) ChatAdminLocked = !ChatAdminLocked;
 		if ((MouseX >= 1325) && (MouseX < 1575) && (MouseY >= 840) && (MouseY < 905) && ChatRoomPlayerIsAdmin()) ChatAdminUpdateRoom();
-
+		if ((MouseX >= 700) && (MouseX < 950) && (MouseY >= 780) && (MouseY < 845)) ElementValue("InputBanList", CommonConvertArrayToString(ChatRoomConcatenateBanList(true, false, CommonConvertStringToArray(ElementValue("InputBanList").trim()))));
+		if ((MouseX >= 965) && (MouseX < 1215) && (MouseY >= 780) && (MouseY < 845)) ElementValue("InputBanList", CommonConvertArrayToString(ChatRoomConcatenateBanList(false, true, CommonConvertStringToArray(ElementValue("InputBanList").trim()))));
+		
 		if ((MouseX >= 1450) && (MouseX <= 1750) && (MouseY >= 600) && (MouseY <= 665)) {
 			ElementRemove("InputName");
 			ElementRemove("InputDescription");

--- a/BondageClub/Screens/Online/ChatAdmin/Text_ChatAdmin.csv
+++ b/BondageClub/Screens/Online/ChatAdmin/Text_ChatAdmin.csv
@@ -6,6 +6,8 @@ RoomPrivate,Private
 RoomLocked,Locked
 RoomSize,Size (2-10)
 UseMemberNumbers,"Use member numbers, separated by commas (ex: 3571,541,7001)"
+QuickbanBlackList,Ban blacklist
+QuickbanGhostList,Ban ghostlist
 AdminOnly,Room settings can only be updated by administrators
 Background,Background
 ShowAll,Selection

--- a/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
+++ b/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
@@ -802,13 +802,7 @@ function ChatRoomSync(data) {
 					ChatRoomPlayerJoiningAsAdmin = false;
 					// Check if we should push banned members
 					if (Player.ChatSettings && data.Character.length == 1) {
-						var BanList = [];
-						if (Player.ChatSettings.AutoBanBlackList) {
-							BanList = BanList.concat(Player.BlackList);
-						}
-						if (Player.ChatSettings.AutoBanGhostList) {
-							BanList = BanList.concat(Player.GhostList);
-						}
+						var BanList = ChatRoomConcatenateBanList(Player.ChatSettings.AutoBanBlackList, Player.ChatSettings.AutoBanGhostList);
 						if (BanList.length > 0) { 
 							data.Ban = BanList;
 							ServerSend("ChatRoomAdmin", { MemberNumber: Player.ID, Room: data, Action: "Update" });
@@ -1244,4 +1238,22 @@ function ChatRoomPayQuest(data) {
 // When a game message comes in, we forward it to the current online game being played
 function ChatRoomGameResponse(data) {
 	if (OnlineGameName == "LARP") GameLARPProcess(data);
+}
+
+/** 
+ * Concatenates the list of users to ban.
+ * @param {boolean} IncludesBlackList - Adds the blacklist to the banlist
+ * @param {boolean} IncludesGhostList - Adds the ghostlist to the banlist
+ * @param {number[]} [ExistingList] - The existing Banlist, if applicable
+ * @returns {number[]} Complete array of members to ban
+ */
+function ChatRoomConcatenateBanList(IncludesBlackList, IncludesGhostList, ExistingList) { 
+	var BanList = Array.isArray(ExistingList) ? ExistingList : [];
+	if (IncludesBlackList) {
+		BanList = BanList.concat(Player.BlackList);
+	}
+	if (IncludesGhostList) {
+		BanList = BanList.concat(Player.GhostList);
+	}
+	return BanList.filter((MemberNumber, Idx, Arr) => Arr.indexOf(MemberNumber) == Idx);
 }


### PR DESCRIPTION
- added the ability to manually ban your ghostlist and blacklist after a room was created.
- improved the logic of autoban/quickban to remove duplicate numbers
- extracted it into a function
- changed the "selection" button so it is now properly grayed out like the rest for non-admins

![](https://cdn.discordapp.com/attachments/721493158625804298/725408739963961444/Capture.PNG)

As pointed out to me by others after adding auto-ban, this is useful when you recently ghosted/blacklisted someone, but it is especially useful for when there are more than 1 admin. It concatenates new numbers to the list to avoid duplicates and provides for an easier way to ban. Truly removing the need to maintain a separate list of member numbers for trolls.