### PR TITLE
Fix: pony training dialog crash

### DIFF
--- a/BondageClub/Screens/Room/Stable/Stable.js
+++ b/BondageClub/Screens/Room/Stable/Stable.js
@@ -361,7 +361,7 @@ function StablePlayerTrainingTreadmill(Behavior) {
 }
 
 //Start Traning Strong Treadmill
-function StablePlayerTrainingStongTreadmill(Behavior) {
+function StablePlayerTrainingStrongTreadmill(Behavior) {
 	StablePlayerTrainingBehavior += parseInt(Behavior);
 	var StableDressage = SkillGetLevel(Player, "Dressage");
 	var StableDifficulty = 2;


### PR DESCRIPTION
- Fixed a typo in a stable.js function that caused the dialog to crash when it was called

https://discord.com/channels/554377975714414605/554378725916147722/725455652196974672