### PR TITLE
Bugfix: Missing action text when changing web blindfold type

### DIFF
--- a/BondageClub/Screens/Inventory/ItemHead/WebBlindfold/WebBlindfold.js
+++ b/BondageClub/Screens/Inventory/ItemHead/WebBlindfold/WebBlindfold.js
@@ -30,8 +30,7 @@ function InventoryItemHeadWebBlindfoldClick() {
 	ExtendedItemClick(InventoryItemHeadWebBlindfoldOptions);
 }
 
-function InventoryItemHeadWebBlindfoldPublishAction(Option) {
-	var C = CharacterGetCurrent();
+function InventoryItemHeadWebBlindfoldPublishAction(C, Option) {
 	var msg = "HeadWebSet" + Option.Name;
 	var Dictionary = [
 		{ Tag: "SourceCharacter", Text: Player.Name, MemberNumber: Player.MemberNumber },


### PR DESCRIPTION
The web blindfold publish function was missing a parameter, resulting in "((You can use or remove items by selecting specific body regions on yourself.))" messages when its type was changed.