### PR TITLE
Improvement: Removed appearance blank pages

### DIFF
--- a/BondageClub/Screens/Character/Appearance/Appearance.js
+++ b/BondageClub/Screens/Character/Appearance/Appearance.js
@@ -611,11 +611,15 @@ function CharacterAppearanceNextColor(C, Group) {
 }
 
 // Moves the offset to get new character appearance items
-function CharacterAppearanceMoveOffset(Move) {
+function CharacterAppearanceMoveOffset(C, Move) {
+	// Get the amount of visible groups
+	var AssetGroupLength = C.ID == 0 ? AssetGroup.length : AssetGroup.filter(G => G.Clothing).length;
+	
+	// Calculate the offset
 	CharacterAppearanceOffset = CharacterAppearanceOffset + Move;
-	if (CharacterAppearanceOffset > AssetGroup.length) CharacterAppearanceOffset = 0;
+	if (CharacterAppearanceOffset > AssetGroupLength) CharacterAppearanceOffset = 0;
 	if ((AssetGroup[CharacterAppearanceOffset].Category != "Appearance") || !AssetGroup[CharacterAppearanceOffset].AllowCustomize) CharacterAppearanceOffset = 0;
-	if (CharacterAppearanceOffset < 0) CharacterAppearanceOffset = Math.floor(AssetGroup.length / CharacterAppearanceNumPerPage) * CharacterAppearanceNumPerPage;
+	if (CharacterAppearanceOffset < 0) CharacterAppearanceOffset = Math.floor(AssetGroupLength / CharacterAppearanceNumPerPage) * CharacterAppearanceNumPerPage;
 }
 
 // Sets the color for a specific group
@@ -673,7 +677,7 @@ function AppearanceClick() {
 		if ((MouseX >= 1417) && (MouseX < 1507) && (MouseY >= 25) && (MouseY < 115) && (C.ID == 0)) CharacterAppearanceFullRandom(C);
 		if ((MouseX >= 1417) && (MouseX < 1507) && (MouseY >= 25) && (MouseY < 115) && (C.ID != 0) && LogQuery("Wardrobe", "PrivateRoom")) CharacterAppearanceWardrobeLoad(C);
 		if ((MouseX >= 1534) && (MouseX < 1624) && (MouseY >= 25) && (MouseY < 115)) CharacterAppearanceStripLayer(C);
-		if ((MouseX >= 1651) && (MouseX < 1741) && (MouseY >= 25) && (MouseY < 115)) CharacterAppearanceMoveOffset(CharacterAppearanceNumPerPage);
+		if ((MouseX >= 1651) && (MouseX < 1741) && (MouseY >= 25) && (MouseY < 115)) CharacterAppearanceMoveOffset(C, CharacterAppearanceNumPerPage);
 		if ((MouseX >= 1768) && (MouseX < 1858) && (MouseY >= 25) && (MouseY < 115)) CharacterAppearanceExit(C);
 		if ((MouseX >= 1885) && (MouseX < 1975) && (MouseY >= 25) && (MouseY < 115)) CharacterAppearanceReady(C);
 


### PR DESCRIPTION
- made it so the amount of page is tied to the amount of groups you see, not the total amount of groups

Currently, if you go to change someone else's clothes, you will cycle through pages until you end up on a blank page because the body parts are not rendered. This removes any blank page(s) created by the non-rendered groups