### PR TITLE
Bugfix: Client-side check for spaces in account name during account creation

### DIFF
--- a/BondageClub/Screens/Character/Creation/Creation.js
+++ b/BondageClub/Screens/Character/Creation/Creation.js
@@ -127,7 +127,7 @@ function CreationClick() {
 		if (Password1 == Password2) {
 
 			// Makes sure the data is valid
-			var LN = /^[a-zA-Z0-9 ]+$/;
+			var LN = /^[a-zA-Z0-9]+$/;
 			var LS = /^[a-zA-Z ]+$/;
 			var E = /^[a-zA-Z0-9@.!#$%&'*+/=?^_`{|}~-]+$/;
 			if (CharacterName.match(LS) && Name.match(LN) && Password1.match(LN) && (Email.match(E) || Email == "") && (CharacterName.length > 0) && (CharacterName.length <= 20) && (Name.length > 0) && (Name.length <= 20) && (Password1.length > 0) && (Password1.length <= 20) && (Email.length <= 100)) {


### PR DESCRIPTION
# Summary

Currently, the server uses the following regex to validate account names:

```js
/^[a-zA-Z0-9]+$/
```

Whereas the client uses this regex:

```js
/^[a-zA-Z0-9 ]+$/
```

This means that users can attempt to create an account with a space in the account name, receive a "Creating your character..." message, but the server will silently reject the account creation, making the screen appear to hang.

This changes the client-side regex to line up with the server-side one, so users will now receive the "Invalid character, account name, password or email" message instead.