### PR TITLE
Bugfix: Prevents errors in audio playback

### DIFF
--- a/BondageClub/Scripts/Audio.js
+++ b/BondageClub/Scripts/Audio.js
@@ -168,7 +168,7 @@ function AudioPlayContent(data) {
 	var targetIsPlayer = target.MemberNumber == Player.MemberNumber;
 
 	// If the player is the target, increase volume
-	if (targetIsPlayer) noiseLevelModifier += 3
+	if (targetIsPlayer) noiseLevelModifier += 3;
 
 	// If the player is blindfolded, increase volume based on blindfold level
 	if (Player.Effect.indexOf("BlindHeavy") >= 0) noiseLevelModifier += 4;

--- a/BondageClub/Scripts/Audio.js
+++ b/BondageClub/Scripts/Audio.js
@@ -5,7 +5,7 @@ var AudioDialog = new Audio();
 function AudioPlayInstantSound(src, volume) {
 	var audio = new Audio();
 	audio.src = src;
-	audio.volume = volume;
+	audio.volume = Math.max(0, Math.min(volume, 1));
 	audio.play();
 }
 
@@ -165,25 +165,22 @@ function AudioPlayContent(data) {
 	var target = data.Dictionary.find(function (el) {return el.Tag == "DestinationCharacter" || el.Tag == "DestinationCharacterName" || el.Tag == "TargetCharacter";});
 	if (!target || !target.MemberNumber) return;
 
-	// Changes the volume based on sensory deprivation
-	if (target.MemberNumber == Player.MemberNumber) {
-		noiseLevelModifier += 2;
-		if (Player.Effect.indexOf("BlindHeavy") >= 0) noiseLevelModifier += 5;
-		else if (Player.Effect.indexOf("BlindNormal") >= 0) noiseLevelModifier += 3;
-		else if (Player.Effect.indexOf("BlindLight") >= 0) noiseLevelModifier += 1;
-		if (Player.Effect.indexOf("DeafTotal") >= 0) noiseLevelModifier += 6;
-		else if (Player.Effect.indexOf("DeafHeavy") >= 0) noiseLevelModifier += 5;
-		else if (Player.Effect.indexOf("DeafNormal") >= 0) noiseLevelModifier += 3;
-		else if (Player.Effect.indexOf("DeafLight") >= 0) noiseLevelModifier += 1;
-	} else {
-		if (Player.Effect.indexOf("DeafTotal") >= 0) noiseLevelModifier -= 4;
-		else if (Player.Effect.indexOf("DeafHeavy") >= 0) noiseLevelModifier -= 3;
-		else if (Player.Effect.indexOf("DeafNormal") >= 0) noiseLevelModifier -= 2;
-		else if (Player.Effect.indexOf("DeafLight") >= 0) noiseLevelModifier -= 1;
-	}
+	var targetIsPlayer = target.MemberNumber == Player.MemberNumber;
+
+	// If the player is the target, increase volume
+	if (targetIsPlayer) noiseLevelModifier += 3
+
+	// If the player is blindfolded, increase volume based on blindfold level
+	if (Player.Effect.indexOf("BlindHeavy") >= 0) noiseLevelModifier += 4;
+	else if (Player.Effect.indexOf("BlindNormal") >= 0) noiseLevelModifier += 2;
+	else if (Player.Effect.indexOf("BlindLight") >= 0) noiseLevelModifier += 1;
+
+	// Reduce volume based on player's deafness level
+	noiseLevelModifier -= (3 * Player.GetDeafLevel());
+
+	// Reduce volume a little if the player was neither the sender nor target
+	if (data.Sender != Player.MemberNumber && !targetIsPlayer) noiseLevelModifier -= 3;
 
 	// Sends the audio file to be played
-	if (data.Sender != Player.MemberNumber && target.MemberNumber != Player.MemberNumber) noiseLevelModifier -= 2;
-	AudioPlayInstantSound(audioFile, Player.AudioSettings.Volume * (.1 + noiseLevelModifier / 30));
-
+	AudioPlayInstantSound(audioFile, Player.AudioSettings.Volume * (.2 + noiseLevelModifier / 40));
 }


### PR DESCRIPTION
# Summary

This PR does two things:
1. Prevents javascript errors in audio playback that would occur under certain circumstances
2. Reworks the audio playback level calculation a little for slightly finer-grained audio level differences, and also to incorporate the new stackable character deafness levels

# Steps to reproduce the bug

This requires 2 characters in a chatroom: A and B (have the console open on character A's browser tab/window).

1. Apply any item that has the `DeafHeavy` effect (e.g. heavy duty earplugs) to character A
2. As character B, equip a vibrating item on yourself
3. As character B, set the vibrating item to "Low"
4. Observe that no sound plays for character A, and character A's console displays the following error:

```
Uncaught DOMException: Failed to set the 'volume' property on 'HTMLMediaElement': The volume provided (-0.0666667) is outside the range [0, 1].
    at AudioPlayInstantSound (https://www.bondageprojects.com/college/R58/BondageClub/Scripts/Audio.js:8:15)
    at AudioPlayContent (https://www.bondageprojects.com/college/R58/BondageClub/Scripts/Audio.js:185:2)
    at ChatRoomMessage (https://www.bondageprojects.com/college/R58/BondageClub/Screens/Online/ChatRoom/ChatRoom.js:722:7)
    at r.<anonymous> (https://www.bondageprojects.com/college/R58/BondageClub/Scripts/Server.js:27:55)
    at r.emit (https://www.bondageprojects.com/college/R58/BondageClub/Scripts/socket.io/socket.io.js:6:13528)
    at r.onevent (https://www.bondageprojects.com/college/R58/BondageClub/Scripts/socket.io/socket.io.js:8:10717)
    at r.onpacket (https://www.bondageprojects.com/college/R58/BondageClub/Scripts/socket.io/socket.io.js:8:10339)
    at r.<anonymous> (https://www.bondageprojects.com/college/R58/BondageClub/Scripts/socket.io/socket.io.js:8:12513)
    at r.emit (https://www.bondageprojects.com/college/R58/BondageClub/Scripts/socket.io/socket.io.js:6:13528)
    at r.ondecoded (https://www.bondageprojects.com/college/R58/BondageClub/Scripts/socket.io/socket.io.js:6:19521)
```

# Changes

* The bug stems from a negative `volume` parameter being passed into the `AudioPlayInstantSound` function. This PR clamps the `volume` parameter to ensure that it always stays within the `[0, 1]` range, to make it more tolerant of negative values, or values greater than 1.
* Volume calculation now makes use of the new `Character.GetDeafLevel()` function, to allow volume to continue to decrease beyond the `DeafHeavy` or `DeafTotal` thresholds - when the player's deafness level stacks beyond a certain point, some volume levels will become completely muted
* Accordingly, I've also made some adjustments to some of the volume level calculations to account for this wider range of possible volume values
* I've also changed the sensory deprivation modifiers a little - this was personal preference, but I think they make more sense, and are somewhat more satisfying (I also feel they simplify the code a little):
    * being blindfolded now *always* increases volume level (depending on blindfold level)
    * being deafened now *always* decreases volume level (depending on level of deafness)