### PR TITLE
Feature: Adds additional levels of speech garbling for very heavy deafness

### DIFF
--- a/BondageClub/Scripts/Speech.js
+++ b/BondageClub/Scripts/Speech.js
@@ -56,7 +56,7 @@ function SpeechGarble(C, CD) {
 	GagEffect += SpeechGetGagLevel(C, "ItemAddon");
 
 	// GagTotal4 always returns mmmmm and muffles some frequent letters entirely, 75% least frequent letters
-	if (GagEffect >= 20) {
+	if (GagEffect >= 20  || ((C.ID != 0) && (Player.GetDeafLevel() >= 7))) {
 		for (var L = 0; L < CD.length; L++) {
 			var H = CD.charAt(L).toLowerCase();
 			if (H == "(") Par = true;
@@ -75,7 +75,7 @@ function SpeechGarble(C, CD) {
 	}
 
 	// GagTotal3 always returns mmmmm and muffles some relatively frequent letters entirely, 50% least frequent letters
-	if (GagEffect >= 16  || ((C.ID != 0) && (Player.GetDeafLevel() >= 5))) {
+	if (GagEffect >= 16  || ((C.ID != 0) && (Player.GetDeafLevel() >= 6))) {
 		for (var L = 0; L < CD.length; L++) {
 			var H = CD.charAt(L).toLowerCase();
 			if (H == "(") Par = true;
@@ -94,7 +94,7 @@ function SpeechGarble(C, CD) {
 	}
 
 	// GagTotal2 always returns mmmmm and muffles some less frequent letters entirely; 25% least frequent letters
-	if (GagEffect >= 12) {
+	if (GagEffect >= 12  || ((C.ID != 0) && (Player.GetDeafLevel() >= 5))) {
 		for (var L = 0; L < CD.length; L++) {
 			var H = CD.charAt(L).toLowerCase();
 			if (H == "(") Par = true;

--- a/BondageClub/Scripts/Speech.js
+++ b/BondageClub/Scripts/Speech.js
@@ -75,7 +75,7 @@ function SpeechGarble(C, CD) {
 	}
 
 	// GagTotal3 always returns mmmmm and muffles some relatively frequent letters entirely, 50% least frequent letters
-	if (GagEffect >= 16) {
+	if (GagEffect >= 16  || ((C.ID != 0) && (Player.GetDeafLevel() >= 5))) {
 		for (var L = 0; L < CD.length; L++) {
 			var H = CD.charAt(L).toLowerCase();
 			if (H == "(") Par = true;


### PR DESCRIPTION
# Summary

With the new stackable deafness levels, it is now relatively easy to stack deafness levels of 5 or over. This is a simple change that adds additional levels of speech garbling for deafness levels of 5 or more.

# Testing

I've tested this with all levels of deafness currently attainable in the game, and garbling looks like this:

| Deafness Level | Speech |
| ---------------- | -------- |
| 0 | T-The quick b-brown f-fox jumped over the lazy dog |
| 1 | e-ehe kuiek b-baown h-hok aumpem ovea ehe aasy mom |
| 2 | e-ehe kuiek e-eaoan m-mok aumfem oeea ehe aaha mon |
| 3 | e-ehe keeka f-faeam m-mek aemfem efea ehe aehe mem |
| 4 | m-mmm mmmmm m-mmmmm m-mmm mmmmmm mmmm mmm mmmm mmm |
| 5 | m-mmm mmm m-mmmmm m-mm mmmmm m mm mmm mm m mmm |
| 6 | m-mmm mmm m-mm m-m m mm mm m mm mmm mm mm |
| 7 | m-m m m-m m-m m m m m m m m m m m |