### PR TITLE
Feature: Hand restraints make struggling more difficult

### DIFF
--- a/BondageClub/Scripts/Character.js
+++ b/BondageClub/Scripts/Character.js
@@ -85,17 +85,14 @@ function CharacterReset(CharacterID, CharacterAssetFamily) {
 		 */
 		GetClumsiness: function () {
 			var clumsiness = 0;
-			var A = 0;
-			var found = false;
-			while (A < this.Appearance.length && !found) {
+			this.Appearance.some(Item => {
 				// get the difficulty of a hand restraint
-				if (this.Appearance[A].Asset.Group.Name != null && this.Appearance[A].Asset.Group.Name == "ItemHands") {
+				if (Item.Asset.Group.Name === "ItemHands") {
 					// half the itme difficulty for now
-					clumsiness = Math.ceil(this.Appearance[A].Asset.Difficulty / 2);
-					found = true;
+					clumsiness = Math.ceil(Item.Asset.Difficulty / 2);
+					return true;
 				} // if
-				A++;
-			} // while
+			});
 			return clumsiness;
 		},
 		IsLoverPrivate: function () { return ((NPCEventGet(this, "Girlfriend") > 0) || (Player.GetLoversNumbers().indexOf("NPC-" + this.Name) >= 0)); },

--- a/BondageClub/Scripts/Character.js
+++ b/BondageClub/Scripts/Character.js
@@ -44,11 +44,11 @@ function CharacterReset(CharacterID, CharacterAssetFamily) {
 		IsMounted: function () { return (this.Effect.indexOf("Mounted") >= 0) },
 		IsChaste: function () { return ((this.Effect.indexOf("Chaste") >= 0) || (this.Effect.indexOf("BreastChaste") >= 0)) },
 		IsVulvaChaste: function () { return (this.Effect.indexOf("Chaste") >= 0) },
-		IsPlugged: function() {return (this.Effect.indexOf("IsPlugged") >= 0) },
+		IsPlugged: function () { return (this.Effect.indexOf("IsPlugged") >= 0) },
 		IsBreastChaste: function () { return (this.Effect.indexOf("BreastChaste") >= 0) },
 		IsShackled: function () { return (this.Effect.indexOf("Shackled") >= 0) },
 		IsEgged: function () { return (this.Effect.indexOf("Egged") >= 0) },
-		IsMouthBlocked: function() { return this.Effect.indexOf("BlockMouth") >= 0 },
+		IsMouthBlocked: function () { return this.Effect.indexOf("BlockMouth") >= 0 },
 		IsOwned: function () { return ((this.Owner != null) && (this.Owner.trim() != "")) },
 		IsOwnedByPlayer: function () { return (((((this.Owner != null) && (this.Owner.trim() == Player.Name)) || (NPCEventGet(this, "EndDomTrial") > 0)) && (this.Ownership == null)) || ((this.Ownership != null) && (this.Ownership.MemberNumber != null) && (this.Ownership.MemberNumber == Player.MemberNumber))) },
 		IsOwner: function () { return ((NPCEventGet(this, "EndSubTrial") > 0) || (this.Name == Player.Owner.replace("NPC-", ""))) },
@@ -76,6 +76,27 @@ function CharacterReset(CharacterID, CharacterAssetFamily) {
 				}
 			}
 			return deafLevel;
+		},
+		/**
+		 * @description Evaluates the strictness of the hand binding of the current player and returns a value based on this. 
+		 * The higher the value, the more handicapped the player is
+		 * 
+		 * @returns {number} - The level of clumsiness of the current player. The higher the more clumsy
+		 */
+		GetClumsiness: function () {
+			var clumsiness = 0;
+			var A = 0;
+			var found = false;
+			while (A < this.Appearance.length && !found) {
+				// get the difficulty of a hand restraint
+				if (this.Appearance[A].Asset.Group.Name != null && this.Appearance[A].Asset.Group.Name == "ItemHands") {
+					// half the itme difficulty for now
+					clumsiness = Math.ceil(this.Appearance[A].Asset.Difficulty / 2);
+					found = true;
+				} // if
+				A++;
+			} // while
+			return clumsiness;
 		},
 		IsLoverPrivate: function () { return ((NPCEventGet(this, "Girlfriend") > 0) || (Player.GetLoversNumbers().indexOf("NPC-" + this.Name) >= 0)); },
 		IsKneeling: function () { return ((this.Pose != null) && (this.Pose.indexOf("Kneel") >= 0)) },
@@ -205,7 +226,7 @@ function CharacterArchetypeClothes(C, Archetype, ForceColor) {
 		InventoryAdd(C, "MistressBottom", "ClothLower", false);
 		InventoryWear(C, "MistressBottom", "ClothLower", Color);
 		InventoryAdd(C, "MistressPadlock", "ItemMisc", false);
-		InventoryAdd(C, "MistressTimerPadlock","ItemMisc", false);
+		InventoryAdd(C, "MistressTimerPadlock", "ItemMisc", false);
 		InventoryAdd(C, "MistressPadlockKey", "ItemMisc", false);
 		InventoryRemove(C, "ClothAccessory");
 		InventoryRemove(C, "HairAccessory1");
@@ -408,7 +429,7 @@ function CharacterLoadCanvas(C) {
 
 	// Sets the total height modifier for that character
 	CharacterApperanceSetHeightModifier(C);
-	
+
 	// Reload the canvas
 	CharacterAppearanceBuildCanvas(C);
 
@@ -634,7 +655,7 @@ function CharacterCompressWardrobe(Wardrobe) {
 		var CompressedWardrobe = [];
 		for (var W = 0; W < Wardrobe.length; W++) {
 			var Arr = [];
-			for (var A = 0; A < Wardrobe[W].length; A++)			
+			for (var A = 0; A < Wardrobe[W].length; A++)
 				Arr.push([Wardrobe[W][A].Name, Wardrobe[W][A].Group, Wardrobe[W][A].Color]);
 			CompressedWardrobe.push(Arr);
 		}

--- a/BondageClub/Scripts/Dialog.js
+++ b/BondageClub/Scripts/Dialog.js
@@ -161,13 +161,13 @@ function DialogEndExpression() {
 	if (DialogAllowEyebrows) {
 		TimerInventoryRemoveSet(Player, "Eyebrows", 5);
 		DialogAllowEyebrows = false;
-	}		
+	}
 	if (DialogAllowFluids) {
 		TimerInventoryRemoveSet(Player, "Fluids", 5);
 		DialogAllowFluids = false;
 	}
 }
-		
+
 // Leaves the item menu for both characters
 function DialogLeaveItemMenu() {
 	DialogEndExpression();
@@ -295,7 +295,7 @@ function DialogMenuButtonBuild(C) {
 
 // Sort the inventory list by SortOrder (a fixed number & current language description)
 function DialogInventorySort() {
-	DialogInventory.sort((a,b) => (a.SortOrder > b.SortOrder) ? 1 : ((b.SortOrder > a.SortOrder) ? -1 : 0));
+	DialogInventory.sort((a, b) => (a.SortOrder > b.SortOrder) ? 1 : ((b.SortOrder > a.SortOrder) ? -1 : 0));
 }
 
 // Build the inventory listing for the dialog which is what's equipped, the player inventory and the character inventory for that group
@@ -309,7 +309,7 @@ function DialogInventoryBuild(C) {
 		// First, we add anything that's currently equipped
 		var Item = null;
 		var CurItem = null;
-		for(var A = 0; A < C.Appearance.length; A++)
+		for (var A = 0; A < C.Appearance.length; A++)
 			if ((C.Appearance[A].Asset.Group.Name == C.FocusGroup.Name) && C.Appearance[A].Asset.DynamicAllowInventoryAdd(C)) {
 				DialogInventoryAdd(C, C.Appearance[A], true, 1);
 				CurItem = C.Appearance[A];
@@ -324,13 +324,13 @@ function DialogInventoryBuild(C) {
 						DialogInventory.push({ Asset: Asset[A], Worn: false, Icon: "", SortOrder: "1" + Asset[A].Description });
 		} else {
 			// Second, we add everything from the victim inventory
-			for(var A = 0; A < C.Inventory.length; A++)
+			for (var A = 0; A < C.Inventory.length; A++)
 				if ((C.Inventory[A].Asset != null) && (C.Inventory[A].Asset.Group.Name == C.FocusGroup.Name) && C.Inventory[A].Asset.DynamicAllowInventoryAdd(C))
 					DialogInventoryAdd(C, C.Inventory[A], false, 2);
 
 			// Third, we add everything from the player inventory if the player isn't the victim
 			if (C.ID != 0)
-				for(var A = 0; A < Player.Inventory.length; A++)
+				for (var A = 0; A < Player.Inventory.length; A++)
 					if ((Player.Inventory[A].Asset != null) && (Player.Inventory[A].Asset.Group.Name == C.FocusGroup.Name) && Player.Inventory[A].Asset.DynamicAllowInventoryAdd(C))
 						DialogInventoryAdd(C, Player.Inventory[A], false, 2);
 
@@ -422,6 +422,7 @@ function DialogProgressStart(C, PrevItem, NextItem) {
 	var S = 0;
 	if ((PrevItem != null) && (C.ID == 0)) {
 		S = S + SkillGetWithRatio("Evasion"); // Add the player evasion level (modified by the effectiveness ratio)
+		S = S - Player.GetClumsiness(); // make struggling harder if hands are restrained
 		if (PrevItem.Difficulty != null) S = S - PrevItem.Difficulty; // Subtract the item difficulty (regular difficulty + player that restrained difficulty)
 		if ((PrevItem.Property != null) && (PrevItem.Property.Difficulty != null)) S = S - PrevItem.Property.Difficulty; // Subtract the additional item difficulty for expanded items only
 	}
@@ -463,7 +464,7 @@ function DialogProgressStart(C, PrevItem, NextItem) {
 	// If there's no current blushing, we update the blushing state while struggling
 	DialogAllowBlush = ((DialogProgressAuto < 0) && (DialogProgressChallenge > 0) && (C.ID == 0) && ((InventoryGet(C, "Blush") == null) || (InventoryGet(C, "Blush").Property == null) || (InventoryGet(C, "Blush").Property.Expression == null)));
 	DialogAllowEyebrows = ((DialogProgressAuto < 0) && (DialogProgressChallenge > 0) && (C.ID == 0) && ((InventoryGet(C, "Eyebrows") == null) || (InventoryGet(C, "Eyebrows").Property == null) || (InventoryGet(C, "Eyebrows").Property.Expression == null)));
-	DialogAllowFluids = ((DialogProgressAuto < 0) && (DialogProgressChallenge > 0) && (C.ID == 0) && ((InventoryGet(C, "Fluids") == null) ||(InventoryGet(C, "Fluids").Property == null) || (InventoryGet(C, "Fluids").Property.Expression == null)));
+	DialogAllowFluids = ((DialogProgressAuto < 0) && (DialogProgressChallenge > 0) && (C.ID == 0) && ((InventoryGet(C, "Fluids") == null) || (InventoryGet(C, "Fluids").Property == null) || (InventoryGet(C, "Fluids").Property.Expression == null)));
 
 	// Applying or removing specific items can trigger an audio sound to play
 	if ((PrevItem && PrevItem.Asset) || (NextItem && NextItem.Asset)) {
@@ -487,7 +488,7 @@ function DialogMenuButtonClick() {
 	// Finds the current icon
 	for (var I = 0; I < DialogMenuButton.length; I++)
 		if ((MouseX >= 1885 - I * 110) && (MouseX <= 1975 - I * 110)) {
-			
+
 			// Gets the current character and item
 			var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
 			var Item = InventoryGet(C, C.FocusGroup.Name);
@@ -624,7 +625,7 @@ function DialogMenuButtonClick() {
 				ActivityDialogBuild(C);
 				return;
 			}
-			
+
 			// When we enter item permission mode, we rebuild the inventory to set permissions
 			else if (DialogMenuButton[I] == "DialogPermissionMode") {
 				DialogItemPermissionMode = true;
@@ -653,7 +654,7 @@ function DialogPublishAction(C, ClickItem) {
 			if (CurrentScreen == "ChatRoom") {
 				var intensity = TargetItem.Property ? TargetItem.Property.Intensity : 0;
 				InventoryExpressionTrigger(C, ClickItem);
-				ChatRoomPublishCustomAction(TargetItem.Asset.Name + "Trigger" + intensity, true, [{Tag: "DestinationCharacterName", Text: C.Name, MemberNumber: C.MemberNumber}]);
+				ChatRoomPublishCustomAction(TargetItem.Asset.Name + "Trigger" + intensity, true, [{ Tag: "DestinationCharacterName", Text: C.Name, MemberNumber: C.MemberNumber }]);
 			}
 			else {
 				var intensity = TargetItem.Property ? TargetItem.Property.Intensity : 0;
@@ -694,7 +695,7 @@ function DialogItemClick(ClickItem) {
 	// In permission mode, the player can allow or block items for herself
 	if ((C.ID == 0) && DialogItemPermissionMode) {
 		if (CurrentItem && (CurrentItem.Asset.Name == ClickItem.Asset.Name)) return;
-		if (InventoryIsPermissionBlocked(Player, ClickItem.Asset.Name, ClickItem.Asset.Group.Name)){
+		if (InventoryIsPermissionBlocked(Player, ClickItem.Asset.Name, ClickItem.Asset.Group.Name)) {
 			Player.BlockItems = Player.BlockItems.filter(B => B.Name != ClickItem.Asset.Name || B.Group != ClickItem.Asset.Group.Name);
 			Player.LimitedItems.push({ Name: ClickItem.Asset.Name, Group: ClickItem.Asset.Group.Name });
 		}
@@ -916,7 +917,7 @@ function DialogClick() {
 	// If the user clicked in the facial expression menu
 	if ((CurrentCharacter != null) && (CurrentCharacter.ID == 0) && (MouseX >= 0) && (MouseX <= 500)) {
 		if (CommonIsClickAt(15, 15, 90, 90)) {
-			DialogFacialExpressions.forEach(FE => { 
+			DialogFacialExpressions.forEach(FE => {
 				CharacterSetFacialExpression(Player, FE.Appearance.Asset.Group.Name);
 				FE.CurrentExpression = null;
 			});
@@ -1034,7 +1035,7 @@ function DialogDrawActivityMenu(C) {
 			Y = Y + 300;
 		}
 	}
-	
+
 }
 
 // Draw the item menu dialog
@@ -1071,7 +1072,7 @@ function DialogDrawItemMenu(C) {
 			var Block = InventoryIsPermissionBlocked(C, Item.Asset.DynamicName(Player), Item.Asset.DynamicGroupName);
 			var Limit = InventoryIsPermissionLimited(C, Item.Asset.Name, Item.Asset.Group.Name);
 			var Blocked = DialogInventory[I].SortOrder.startsWith("3");
-			DrawRect(X, Y, 225, 275, (DialogItemPermissionMode && C.ID == 0) ? 
+			DrawRect(X, Y, 225, 275, (DialogItemPermissionMode && C.ID == 0) ?
 				(DialogInventory[I].Worn ? "gray" : Block ? Hover ? "red" : "pink" : Limit ? Hover ? "orange" : "#fed8b1" : Hover ? "green" : "lime") :
 				((Hover && !Blocked) ? "cyan" : DialogInventory[I].Worn ? "pink" : Blocked ? "gray" : "white"));
 			if (Item.Worn && InventoryItemHasEffect(InventoryGet(C, Item.Asset.Group.Name), "Vibrating", true)) DrawImageResize("Assets/" + Item.Asset.Group.Family + "/" + Item.Asset.Group.Name + "/Preview/" + Item.Asset.Name + ".png", X + Math.floor(Math.random() * 3) + 1, Y + Math.floor(Math.random() * 3) + 1, 221, 221);
@@ -1246,7 +1247,7 @@ function DialogDraw() {
 
 // Draw the menu for changing facial expressions
 function DialogDrawExpressionMenu() {
-	
+
 	// Draw the expression groups
 	DrawText(DialogFind(Player, "FacialExpression"), 265, 62, "White", "Black");
 	DrawButton(15, 15, 90, 90, "", "White", "Icons/Reset.png", DialogFind(Player, "ClearFacialExpressions"));


### PR DESCRIPTION
# Summary
As of now, it's irrelevant wether the hands of a player are restrained, e.g. by mittens or tape, when they try to struggle out of some bindings. This PR changes this and adds half the difficulty (rounded up) of the player's hand restraints to the struggle challenge.
This resolves issue [#878284](http://www.hostedredmine.com/issues/878284)
# Details
## What it does
Changes occur in two files 
**`Character.js`**
* Adding the functions `GetClumsiness` that returns either 0 (if the player's hands are not restrained) or half (rounded up) of the player's hand restraint base difficulty
**`Dialog.js`**
* Changed the function `DialogProgressStart` so that the clumsiness of the player is taken into account when the challenge level is calculated
## Testing
* Tested that feature on my own server by letting a character struggle out of a restraint and comparing that challenge level with the one after a hand restraint was added
* Tested with the following restraints
    * Paw mittens
    * Padded mittens
    * Leather mittens
    * Padded leather mittens
    * Duct tape
    * Polished steel mittens