### PR TITLE
Bugfix: Prevents the 3D canvas from blocking keyboard events on the main canvas

### DIFF
--- a/BondageClub/Scripts/Drawing3D.js
+++ b/BondageClub/Scripts/Drawing3D.js
@@ -11,6 +11,7 @@ function Draw3DLoad() {
 	camera = new THREE.PerspectiveCamera(45, 2, 0.1, 1000);
 	renderer = new THREE.WebGLRenderer({ alpha: true });
 	renderer.setSize(2000, 1000);
+	renderer.domElement.style.visibility = Draw3DEnabled ? "visible" : "hidden";
 	//renderer.setClearColor(0x000000, 0);
 	document.body.appendChild(renderer.domElement);
 
@@ -50,6 +51,7 @@ function Draw3DKeyDown(event) {
 
 function Draw3DEnable(Enable) {
 	Draw3DEnabled = Enable;
+	renderer.domElement.style.visibility = Enable ? "visible" : "hidden";
 	renderer.clear();
 }
 


### PR DESCRIPTION
# Summary

Many of the game's keyboard event listeners are added to the main game canvas element (i.e. anything added through `CommonKeyDown()` - the A/S key in the struggle dialog being a prime example). Because the new 3D canvas is rendered on top of the existing game canvas, it essentially traps keyboard events and prevents them triggering on the main canvas.

This is a simple fix that adds `visibility: hidden` to the 3D canvas when it is not being used, so that it will no longer capture events. It's not a particularly sophisticated fix, but I'm aware that the 3D stuff is very liable to change as it's so new, so this should be good enough to keep the main game working in the meantime.

# Steps to reproduce the bug

1. Equip/remove any item with a moderate wear/remove time
2. Attempt to speed up the process by pressing the A/S keys
3. Notice that the keys are having no effect on wear/remove time

More generally, note that after login the `KeyDown` callback defined in `index.html` is no longer being called. 