### PR TITLE
Bugfix: Fix to limited item permissions for bondage bench/gas mask addons

### DIFF
--- a/BondageClub/Screens/Inventory/ItemDevices/BondageBench/BondageBench.js
+++ b/BondageClub/Screens/Inventory/ItemDevices/BondageBench/BondageBench.js
@@ -15,12 +15,13 @@ function InventoryItemDevicesBondageBenchLoad() {
 
 // Draw the item extension screen
 function InventoryItemDevicesBondageBenchDraw() {
-	
+
 	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
 	var strapsBlocked = InventoryGet(C, "Cloth") != null || InventoryGet(C, "ClothLower") != null;
 	var itemBlocked = InventoryGet(C, "ItemAddon") != null;
-	var itemPermissionBlocked = InventoryIsPermissionBlocked(C, "BondageBenchStraps", "ItemAddon") || InventoryIsPermissionLimited(C, "BondageBenchStraps", "ItemAddon");
-	
+	var BondageBenchStraps = InventoryItemCreate(C, "ItemAddon", "BondageBenchStraps");
+	var itemPermissionBlocked = InventoryIsPermissionBlocked(C, "BondageBenchStraps", "ItemAddon") || !InventoryCheckLimitedPermission(C, BondageBenchStraps);
+
 	// Draw the header and item
 	DrawRect(1387, 125, 225, 275, "white");
 	DrawImageResize("Assets/" + DialogFocusItem.Asset.Group.Family + "/" + DialogFocusItem.Asset.Group.Name + "/Preview/" + DialogFocusItem.Asset.Name + ".png", 1389, 127, 221, 221);
@@ -58,11 +59,13 @@ function InventoryItemDevicesBondageBenchSetPose(NewPose) {
 		InventoryItemDevicesBondageBenchLoad();
 	}
 
+	var BondageBenchStraps = InventoryItemCreate(C, "ItemAddon", "BondageBenchStraps");
+
 	// Do not continue if the item is blocked
-	if (InventoryIsPermissionBlocked(C, "BondageBenchStraps", "ItemAddon") || InventoryIsPermissionLimited(C, "BondageBenchStraps", "ItemAddon")) return;
-	
+	if (InventoryIsPermissionBlocked(C, "BondageBenchStraps", "ItemAddon") || !InventoryCheckLimitedPermission(C, BondageBenchStraps)) return;
+
 	// Cannot be used with clothes or other addons
-	if ((InventoryGet(C, "Cloth") != null) || (InventoryGet(C, "ClothLower") != null)) return; 
+	if ((InventoryGet(C, "Cloth") != null) || (InventoryGet(C, "ClothLower") != null)) return;
 	if (InventoryGet(C, "ItemAddon") != null) return;
 
 	// Adds the strap and focus on it

--- a/BondageClub/Screens/Inventory/ItemHead/OldGasMask/OldGasMask.js
+++ b/BondageClub/Screens/Inventory/ItemHead/OldGasMask/OldGasMask.js
@@ -11,12 +11,17 @@ function InventoryItemHeadOldGasMaskDraw() {
 	DrawImageResize("Assets/" + DialogFocusItem.Asset.Group.Family + "/" + DialogFocusItem.Asset.Group.Name + "/Preview/" + DialogFocusItem.Asset.Name + ".png", 1389, 227, 221, 221);
 	DrawTextFit(DialogFocusItem.Asset.Description, 1500, 475, 221, "black");
 
-	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
+	var C = CharacterGetCurrent();
+	var tube1 = InventoryItemCreate(C, "ItemAddon", "OldGasMaskTube1");
+	var tube2 = InventoryItemCreate(C, "ItemAddon", "OldGasMaskTube2");
+	var rebreather = InventoryItemCreate(C, "ItemAddon", "OldGasMaskRebreather");
+	var lenses = InventoryItemCreate(C, "ItemAddon", "OldGasMaskLenses");
+
 	var itemBlocked = InventoryGet(C, "ItemAddon") != null;
-	var tube1IsBlocked = InventoryIsPermissionLimited(C, "OldGasMaskTube1", "ItemAddon") || InventoryIsPermissionLimited(C, "OldGasMaskTube1", "ItemAddon");
-	var tube2IsBlocked = InventoryIsPermissionLimited(C, "OldGasMaskTube2", "ItemAddon") || InventoryIsPermissionLimited(C, "OldGasMaskTube2", "ItemAddon");
-	var rebreatherIsBlocked = InventoryIsPermissionLimited(C, "OldGasMaskRebreather", "ItemAddon") || InventoryIsPermissionLimited(C, "OldGasMaskRebreather", "ItemAddon");
-	var lensesIsBlocked = InventoryIsPermissionBlocked(C, "OldGasMaskLenses", "ItemAddon") || InventoryIsPermissionLimited(C, "OldGasMaskLenses", "ItemAddon");
+	var tube1IsBlocked = InventoryIsPermissionBlocked(C, "OldGasMaskTube1", "ItemAddon") || !InventoryCheckLimitedPermission(C, tube1);
+	var tube2IsBlocked = InventoryIsPermissionBlocked(C, "OldGasMaskTube2", "ItemAddon") || !InventoryCheckLimitedPermission(C, tube2);
+	var rebreatherIsBlocked = InventoryIsPermissionBlocked(C, "OldGasMaskRebreather", "ItemAddon") || !InventoryCheckLimitedPermission(C, rebreather);
+	var lensesIsBlocked = InventoryIsPermissionBlocked(C, "OldGasMaskLenses", "ItemAddon") || !InventoryCheckLimitedPermission(C, lenses);
 
 	DrawButton(1250, 650, 200, 55, DialogFind(Player, "OldGasMaskLenses"), itemBlocked || lensesIsBlocked ? "#888" : "White");
 	DrawButton(1550, 650, 200, 55, DialogFind(Player, "OldGasMaskTubeA"), itemBlocked || tube1IsBlocked ? "#888" : "White");
@@ -33,7 +38,7 @@ function InventoryItemHeadOldGasMaskDraw() {
 
 // Catches the item extension clicks
 function InventoryItemHeadOldGasMaskClick() {
-	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
+	var C = CharacterGetCurrent();
 	var itemBlocked = InventoryGet(C, "ItemAddon") != null;
 	
 	if ((MouseX >= 1885) && (MouseX <= 1975) && (MouseY >= 25) && (MouseY <= 110)) DialogFocusItem = null;
@@ -47,26 +52,27 @@ function InventoryItemHeadOldGasMaskClick() {
 }
 
 // Sets the lenses
-function InventoryItemHeadOldGasMaskSetItem(Item) {
+function InventoryItemHeadOldGasMaskSetItem(itemName) {
 
 	// Loads the item
-	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
+	var C = CharacterGetCurrent();
 	if (CurrentScreen == "ChatRoom") {
 		DialogFocusItem = InventoryGet(C, C.FocusGroup.Name);
 		InventoryItemHeadOldGasMaskLoad();
 	}
-	
+
+	var item = InventoryItemCreate(C, "ItemAddon", itemName);
 	// Do not continue if the item is blocked by permissions
-	if (InventoryIsPermissionBlocked(C, Item, "ItemAddon") || InventoryIsPermissionLimited(C, Item, "ItemAddon")) return;
+	if (InventoryIsPermissionBlocked(C, itemName, "ItemAddon") || !InventoryCheckLimitedPermission(C, item)) return;
 	
 	// Wear the item
-	InventoryWear(C, Item, "ItemAddon", DialogColorSelect);
+	InventoryWear(C, itemName, "ItemAddon", DialogColorSelect);
 	DialogFocusItem = InventoryGet(C, "ItemAddon");
 	
 	// Refreshes the character and chatroom
 	CharacterRefresh(C);
 	CharacterLoadEffect(C);
-	var msg = "OldGasMaskUse" + Item;
+	var msg = "OldGasMaskUse" + itemName;
 	var Dictionary = [];
 	Dictionary.push({ Tag: "SourceCharacter", Text: Player.Name, MemberNumber: Player.MemberNumber });
 	Dictionary.push({ Tag: "DestinationCharacter", Text: C.Name, MemberNumber: C.MemberNumber });

--- a/BondageClub/Scripts/Inventory.js
+++ b/BondageClub/Scripts/Inventory.js
@@ -14,29 +14,17 @@ function InventoryAdd(C, NewItemName, NewItemGroup, Push) {
 		if ((C.Inventory[I].Name == NewItemName) && (C.Inventory[I].Group == NewItemGroup))
 			return;
 
-	// Searches to find the item asset in the current character assets family
-	var NewItemAsset = null;
-	for (var A = 0; A < Asset.length; A++)
-		if ((Asset[A].Name == NewItemName) && (Asset[A].Group.Name == NewItemGroup) && (Asset[A].Group.Family == C.AssetFamily)) {
-			NewItemAsset = Asset[A];
-			break;
-		}
+	// Create the new item for current character's asset family, group name and item name
+	var NewItem = InventoryItemCreate(C, NewItemGroup, NewItemName);
 
 	// Only add the item if we found the asset
-	if (NewItemAsset != null) {
-
-		// Creates the item and pushes it in the inventory queue
-		var NewItem = {
-			Name: NewItemName,
-			Group: NewItemGroup,
-			Asset: NewItemAsset
-		}
+	if (NewItem) {
+		// Pushes the new item to the inventory queue
 		C.Inventory.push(NewItem);
 
 		// Sends the new item to the server if it's for the current player
 		if ((C.ID == 0) && ((Push == null) || Push))
 			ServerPlayerInventorySync();
-
 	}
 }
 

--- a/BondageClub/Scripts/Inventory.js
+++ b/BondageClub/Scripts/Inventory.js
@@ -24,7 +24,7 @@ function InventoryAdd(C, NewItemName, NewItemGroup, Push) {
 
 	// Only add the item if we found the asset
 	if (NewItemAsset != null) {
-		
+
 		// Creates the item and pushes it in the inventory queue
 		var NewItem = {
 			Name: NewItemName,
@@ -38,7 +38,25 @@ function InventoryAdd(C, NewItemName, NewItemGroup, Push) {
 			ServerPlayerInventorySync();
 
 	}
+}
 
+/**
+ * Creates a new item for a character based on asset group and name
+ *
+ * @param {Character} C - The character to create the item for
+ * @param {string} Group - The name of the asset group the item belongs to
+ * @param {string} Name - The name of the asset for the item
+ *
+ * @return {Item} A new item for character using the specified asset name, or null if the specified asset could not be
+ * 		found in the named group
+ */
+function InventoryItemCreate(C, Group, Name) {
+	var NewItemAsset = AssetGet(C.AssetFamily, Group, Name);
+	if (NewItemAsset) {
+		// Only create the new inventory item if the asset was found
+		return { Name, Group, Asset: NewItemAsset };
+	}
+	return null;
 }
 
 /**


### PR DESCRIPTION
# Summary

There was an issue with the bondage bench straps and old gas mask addons that meant that if the player had the items set to limited permissions, then nobody would be able to use those addons (even if they were owner/lover/on the player's whitelist). This fixes that.

# Steps to reproduce

Requires 2 characters: character A, and character B

1. As character A, set global item permissions to "Everyone", "Everyone, except blacklist" or "Owner, Lover, whitelist & Dominants"
2. As character A, set item permissions for the bondage bench straps in the addon slot to limited
3. As character A, add character B to your whitelist
4. As character B, add the bondage bench to character A
5. As character B, attempt to add the bondage bench straps to character A
6. Notice that character B is unable to add the straps, despite being on character A's whitelist

The same issue exists with the old gas mask addons.

# Changes

## BondageBench.js and OldGasMask.js

* Uses `InventoryCheckLimitedPermission` instead of `InventoryIsPermissionLimited` when checking whether addons should be available
* Changes usages of `var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;` to `var C = CharacterGetCurrent();`, which is functionally equivalent

## Inventory.js

* Adds a new `InventoryItemCreate` function, used to generate `{Name, Group, Asset}` item objects
* Simplifies `InventoryAdd` by changing it to use the new `InventoryItemCreate` function (previously it was duplicating functionality with `AssetGet` anyway) - this change does not change the behaviour of `InventoryAdd`, just simplifies the code. This change was created as a separate commit, so can easily be rolled back if needed.