### PR TITLE
Bugfix: Behaviour of previous button in background selection

### DIFF
--- a/BondageClub/Screens/Character/BackgroundSelection/BackgroundSelection.js
+++ b/BondageClub/Screens/Character/BackgroundSelection/BackgroundSelection.js
@@ -101,7 +101,7 @@ function BackgroundSelectionClick() {
 	if ((MouseX >= 1585) && (MouseX < 1675) && (MouseY >= 25) && (MouseY < 115)) {
 		BackgroundSelectionOffset -= BackgroundSelectionSize;
 		if (BackgroundSelectionOffset < 0) {
-			BackgroundSelectionOffset = BackgroundSelectionView.length - BackgroundSelectionSize - (BackgroundSelectionView.length - BackgroundSelectionSize) % BackgroundSelectionSize;
+			BackgroundSelectionOffset = Math.ceil(BackgroundSelectionView.length / BackgroundSelectionSize - 1) * BackgroundSelectionSize;
 		}
 	}
 


### PR DESCRIPTION
# Summary

This fixes a small issue with the behaviour of the previous button in the background selection code, where clicking on the button when on the first page would take the user to the penultimate page rather than the last page.

# Steps to reproduce

1. Enter the background selection screen
2. Immediately press the "previous" button
3. Notice that the backgrounds displayed are not the last page of backgrounds, but the second last