### PR TITLE
Fix: WebGL context

### DIFF
--- a/BondageClub/Scripts/GLDraw.js
+++ b/BondageClub/Scripts/GLDraw.js
@@ -29,6 +29,16 @@ function GLDrawLoad() {
 
     CharacterAppearanceBuildCanvas = GLDrawAppearanceBuild;
 
+    // Attach context listeners
+    GLDrawCanvas.addEventListener("webglcontextlost", function (event) {
+        event.preventDefault();
+        console.log("WebGL Drawing disabled: GPU ran out of resources. If the context does not restore itself, refresh your page.");
+    }, false);
+    GLDrawCanvas.addEventListener("webglcontextrestored", function () {
+        GLDrawLoad();
+        console.log("WebGL: Context restored after it was lost.");
+    }, false);
+    
     console.log("WebGL Drawing enabled: '" + GLVersion + "'");
 }
 

--- a/BondageClub/Scripts/GLDraw.js
+++ b/BondageClub/Scripts/GLDraw.js
@@ -32,11 +32,11 @@ function GLDrawLoad() {
     // Attach context listeners
     GLDrawCanvas.addEventListener("webglcontextlost", function (event) {
         event.preventDefault();
-        console.log("WebGL Drawing disabled: GPU ran out of resources. If the context does not restore itself, refresh your page.");
+        console.log("WebGL Drawing disabled: Context Lost. If the context does not restore itself, refresh your page.");
     }, false);
     GLDrawCanvas.addEventListener("webglcontextrestored", function () {
         GLDrawLoad();
-        console.log("WebGL: Context restored after it was lost.");
+        console.log("WebGL: Context restored.");
     }, false);
     
     console.log("WebGL Drawing enabled: '" + GLVersion + "'");


### PR DESCRIPTION
- fixed WebGL draw canvas missing relevant listeners for context lost/restoration which caused the club to be broken if your GPU runs out of resources

Tested and it works as intended. I also verified and the 3D Draw already properly listens for these events.
Note: if you test with the .loseContext() method, you need to use the .restoreContext() method on the same context afterwards as it won't come again by itself when you trigger it manually. (Otherwise you can always run a VM and crash the GPU on it to test in a real scenario.)

On this note, we should probably think about limiting the texture cache for those who stay on the club for a while. The more assets we had, the more often this will occur.

See issue [878403](http://www.hostedredmine.com/issues/878403)