### PR TITLE
Bugfix: Adjusts the chatroom admin screen to prevent hover overlap with textarea

### DIFF
--- a/BondageClub/Screens/Online/ChatAdmin/ChatAdmin.js
+++ b/BondageClub/Screens/Online/ChatAdmin/ChatAdmin.js
@@ -69,11 +69,11 @@ function ChatAdminRun() {
 	DrawButton(975, 770, 250, 65, TextGet("QuickbanGhostList"), ChatRoomPlayerIsAdmin() ? "White" : "#ebebe4");
 
 	// Background selection
-	DrawImageResize("Backgrounds/" + ChatAdminBackgroundSelect + "Dark.jpg", 1300, 75, 600, 400);
-	DrawBackNextButton(1350, 500, 500, 65, DialogFind(Player, ChatAdminBackgroundSelect), ChatRoomPlayerIsAdmin() ? "White" : "#ebebe4", null,
+	DrawImageResize("Backgrounds/" + ChatAdminBackgroundSelect + "Dark.jpg", 1300, 75, 600, 350);
+	DrawBackNextButton(1350, 450, 500, 65, DialogFind(Player, ChatAdminBackgroundSelect), ChatRoomPlayerIsAdmin() ? "White" : "#ebebe4", null,
 		() => DialogFind(Player, (ChatAdminBackgroundIndex == 0) ? ChatCreateBackgroundList[ChatCreateBackgroundList.length - 1] : ChatCreateBackgroundList[ChatAdminBackgroundIndex - 1]),
 		() => DialogFind(Player, (ChatAdminBackgroundIndex >= ChatCreateBackgroundList.length - 1) ? ChatCreateBackgroundList[0] : ChatCreateBackgroundList[ChatAdminBackgroundIndex + 1]));
-	DrawButton(1450, 600, 300, 65, TextGet("ShowAll"),  ChatRoomPlayerIsAdmin() ? "White" : "#ebebe4");
+	DrawButton(1450, 550, 300, 65, TextGet("ShowAll"),  ChatRoomPlayerIsAdmin() ? "White" : "#ebebe4");
 
 	// Private and Locked check boxes
 	DrawText(TextGet("RoomPrivate"), 1384, 740, "Black", "Gray");


### PR DESCRIPTION
# Summary

When selecting a chatroom background via the back/forward buttons, the button hover displays underneath the ban list textarea. As it's currently impractical to display the hover text over the textarea (this would probably need another canvas to be temporarily rendered), this change adjusts the layout of the screen slightly to ensure that the hover doesn't overlap by slightly reducing the size of the background preview image. See screenshots below.

*Current layout:*

![hover-overlap](https://user-images.githubusercontent.com/62729616/87101267-91edc700-c246-11ea-8041-4eeeec8952e3.png)

*Adjusted layout:*

![background-hover-fix](https://user-images.githubusercontent.com/62729616/87101280-9e721f80-c246-11ea-9f76-faff515ad0aa.png)

