### PR TITLE
Fixes for the Short Chain to allow use with Bitchsuits & Strait Dresses 

### DIFF
--- a/BondageClub/Screens/Inventory/ItemButt/ButtPlugLock/ButtPlugLock.js
+++ b/BondageClub/Screens/Inventory/ItemButt/ButtPlugLock/ButtPlugLock.js
@@ -10,7 +10,7 @@ function InventoryItemButtButtPlugLockLoad() {
 // check, if a short chain can be applied
 function InventoryItemButtButtPlugLockChainShortPrerequesites(C) {
 	var ChainShortPrerequisites = true;
-	if (C.Pose.indexOf("Suspension") >= 0 || C.Pose.indexOf("StraitDressOpen") >= 0 || C.Pose.indexOf("SuspensionHogtied") >= 0 || C.Effect.indexOf("Mounted") >= 0) {
+	if (C.Pose.indexOf("Suspension") >= 0 || C.Effect.indexOf("BlockKneel") >= 0 || C.Pose.indexOf("SuspensionHogtied") >= 0 || C.Effect.indexOf("Mounted") >= 0) {
 		ChainShortPrerequisites = false;
 	} // if
 	return ChainShortPrerequisites;


### PR DESCRIPTION
Removed the seemingly uneeded check for "StraitDressOpen" and replaced it with "BlockKneel" as it made more sense and still prevents the Mermaid Suit from having issues.