### PR TITLE
Bugfix: Hides boots (and some other items) with the new web cocoon

### DIFF
--- a/BondageClub/Screens/Inventory/ItemArms/Web/Web.js
+++ b/BondageClub/Screens/Inventory/ItemArms/Web/Web.js
@@ -72,7 +72,7 @@ var InventoryItemArmsWebOptions = [
 			Difficulty: 8,
 			SetPose: ["LegsClosed", "BackElbowTouch", "Suspension"],
 			Effect: ["Block", "Freeze", "Prone"],
-			Hide: ["BodyLower", "Cloth", "ClothLower", "Shoes", "SuitLower", "Panties", "Socks", "Pussy", "ItemFeet", "ItemLegs", "ItemVulva", "ItemVulvaPiercings", "ItemButt", "ItemPelvis"],
+			Hide: ["BodyLower", "Cloth", "ClothLower", "Shoes", "SuitLower", "Panties", "Socks", "Pussy", "ItemFeet", "ItemLegs", "ItemVulva", "ItemVulvaPiercings", "ItemButt", "ItemPelvis", "ItemBoots", "ItemHands", "ItemNipples", "ItemNipplesPiercings", "ItemBreast"],
 			Block: ["ItemVulva", "ItemVulvaPiercings", "ItemButt", "ItemPelvis", "ItemTorso", "ItemHands", "ItemLegs", "ItemFeet", "ItemBoots", "ItemNipples", "ItemNipplesPiercings", "ItemBreast"],
 		},
 	},


### PR DESCRIPTION
# Summary

The new web cocoon type doesn't currently hide the `ItemBoots` slot. This fixes that, and also hides a few other slots that shouldn't be visible.