### PR TITLE
Handheld Toy Effect fix

### DIFF
--- a/BondageClub/Assets/Female3DCG/Female3DCG.js
+++ b/BondageClub/Assets/Female3DCG/Female3DCG.js
@@ -25,7 +25,8 @@ var AssetSpankingToys = {
 	DynamicName: C => "SpankingToys" + InventorySpankingToysGetType(C),
 	DynamicGroupName: "ItemHands",
 	DynamicActivity: C => InventorySpankingToysGetActivity(C),
-	IgnoreParentGroup: true
+	IgnoreParentGroup: true,
+	Effect: []
 };
 
 // 3D Custom Girl based assets

--- a/BondageClub/Scripts/Inventory.js
+++ b/BondageClub/Scripts/Inventory.js
@@ -369,7 +369,7 @@ function InventoryGroupIsBlocked(C, GroupName) {
 function InventoryItemHasEffect(Item, Effect, CheckProperties) {
 	if (!Item) return null;
 	if (!Effect) {
-		if ((Item.Asset && Item.Asset.Effect) || (CheckProperties && Item.Property && Item.Property.Effect)) return true;
+		if ((Item.Asset && Item.Asset.Effect && Item.Asset.Effect.length > 0) || (CheckProperties && Item.Property && Item.Property.Effect)) return true;
 		else return false;
 	}
 	else {


### PR DESCRIPTION
A recent change to have assets inherit the Effect property from their asset group caused an issue with handheld toys. They're getting effects such as Prone on legs, which is preventing the message/activity from being sent to the chat.
The effect check will now look at the length so that the asset-group-level setting can be overridden at asset-level with an empty array.