### PR TITLE
Lock Permissions Blocking

### DIFF
--- a/BondageClub/Scripts/Dialog.js
+++ b/BondageClub/Scripts/Dialog.js
@@ -307,7 +307,6 @@ function DialogInventoryBuild(C) {
 	if (C.FocusGroup != null) {
 
 		// First, we add anything that's currently equipped
-		var Item = null;
 		var CurItem = null;
 		for(var A = 0; A < C.Appearance.length; A++)
 			if ((C.Appearance[A].Asset.Group.Name == C.FocusGroup.Name) && C.Appearance[A].Asset.DynamicAllowInventoryAdd(C)) {
@@ -316,12 +315,20 @@ function DialogInventoryBuild(C) {
 				break;
 			}
 
-		// In item permission mode, we add all the enable items, except the one already on
+		// In item permission mode, we add all the enable items, except the ones already on
 		if (DialogItemPermissionMode) {
 			for (var A = 0; A < Asset.length; A++)
-				if (Asset[A].Enable && (Asset[A].Wear || Asset[A].IsLock) && Asset[A].Group.Name == C.FocusGroup.Name)
-					if ((CurItem == null) || (CurItem.Asset.Name != Asset[A].Name) || (CurItem.Asset.Group.Name != Asset[A].Group.Name))
-						DialogInventory.push({ Asset: Asset[A], Worn: false, Icon: "", SortOrder: "1" + Asset[A].Description });
+				if (Asset[A].Enable && Asset[A].Group.Name == C.FocusGroup.Name) {
+					if (Asset[A].Wear) {
+						if ((CurItem == null) || (CurItem.Asset.Name != Asset[A].Name) || (CurItem.Asset.Group.Name != Asset[A].Group.Name))
+							DialogInventory.push({ Asset: Asset[A], Worn: false, Icon: "", SortOrder: "1" + Asset[A].Description });
+					}
+					else if (Asset[A].IsLock) {
+						var LockIsWorn = InventoryCharacterIsWearingLock(C, Asset[A].Name);
+						DialogInventory.push({ Asset: Asset[A], Worn: LockIsWorn, Icon: "", SortOrder: "1" + Asset[A].Description });
+					}
+				}
+					
 		} else {
 			// Second, we add everything from the victim inventory
 			for(var A = 0; A < C.Inventory.length; A++)

--- a/BondageClub/Scripts/Inventory.js
+++ b/BondageClub/Scripts/Inventory.js
@@ -449,6 +449,19 @@ function InventoryCharacterHasLockedRestraint(C) {
 }
 
 /**
+ *
+ * @param {Character} C - The character to scan
+ * @param {String} LockName - The type of lock to check for
+ * @returns {Boolean} - Returns TRUE if any item has the specified lock locked onto it
+ */
+function InventoryCharacterIsWearingLock(C, LockName) {
+	for (var A = 0; A < C.Appearance.length; A++)
+		if ((C.Appearance[A].Property != null) && (C.Appearance[A].Property.LockedBy == LockName))
+			return true;
+	return false;
+}
+
+/**
 * Returns TRUE if the character is wearing at least one item that's a restraint with a OwnerOnly flag, such as the owner padlock
 * @param {Character} C - The character to scan
 * @returns {Boolean} - TRUE if one owner only restraint is found


### PR DESCRIPTION
Unlike regular items, locks don't show as 'worn' in the inventory permissions screen at the moment, so they can always be changed. Since the lock validation removes locks the user has blocked, players can remove locks they're currently wearing by changing its permissions.
Now if a player is wearing a given lock anywhere, that lock will be greyed out in the permissions screen.