### PR TITLE
Fix: Active pose

### DIFF
--- a/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
+++ b/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
@@ -1269,6 +1269,7 @@ function ChatRoomGameResponse(data) {
 function ChatRoomSafeword() {
 	if (ChatSearchSafewordAppearance != null) {
 		Player.Appearance = ChatSearchSafewordAppearance.slice(0);
+		CharacterSetActivePose(Player, ChatSearchSafewordPose);
 		CharacterRefresh(Player);
 		ChatRoomCharacterUpdate(Player);
 		ServerSend("ChatRoomChat", { Content: "ActionActivateSafeword", Type: "Action", Dictionary: [{Tag: "SourceCharacter", Text: Player.Name}] });

--- a/BondageClub/Screens/Online/ChatSearch/ChatSearch.js
+++ b/BondageClub/Screens/Online/ChatSearch/ChatSearch.js
@@ -4,10 +4,14 @@ var ChatSearchResult = [];
 var ChatSearchMessage = "";
 var ChatSearchLeaveRoom = "MainHall";
 var ChatSearchSafewordAppearance = null;
+var ChatSearchSafewordPose = null;
 
 // When the chat screens loads, we loads up to 24 public rooms
 function ChatSearchLoad() {
-	if (ChatSearchSafewordAppearance == null) ChatSearchSafewordAppearance = Player.Appearance.slice(0);
+	if (ChatSearchSafewordAppearance == null) {
+		ChatSearchSafewordAppearance = Player.Appearance.slice(0);
+		ChatSearchSafewordPose = Player.ActivePose;
+	}
 	ElementCreateInput("InputSearch", "text", "", "20");
 	ChatSearchQuery();
 	ChatSearchMessage = "";


### PR DESCRIPTION
- fixed an issue where item prerequisites were not taken into account when using the save state

The save state function did not reset the active pose. This means that many items were broken when they required the character to be kneeling/standing. Instead of bloating the asset files and creating a bunch of conflicts, and to be more futureproof, I've added the pose to the list of things it. This means all items will work retroactively, and new items won't need to worry about this feature.

To reproduce the current bug. You can wear a vacbed/stock/bed and many more in the main hall, go into a room, then remove the item, then kneel, then use your safeword. You'll be stuck

https://discord.com/channels/554377975714414605/731199817111568384/731478171349811230