### PR TITLE
Bugfix: Corrects the coordinates for click handlers in the chatroom admin screen

### DIFF
--- a/BondageClub/Screens/Online/ChatAdmin/ChatAdmin.js
+++ b/BondageClub/Screens/Online/ChatAdmin/ChatAdmin.js
@@ -1,7 +1,6 @@
 "use strict";
 var ChatAdminBackground = "Sheet";
 var ChatAdminMessage = "";
-var ChatAdminPrivate = false;
 var ChatAdminBackgroundIndex = 0;
 var ChatAdminBackgroundSelect = "";
 var ChatAdminPrivate = false;

--- a/BondageClub/Screens/Online/ChatAdmin/ChatAdmin.js
+++ b/BondageClub/Screens/Online/ChatAdmin/ChatAdmin.js
@@ -96,7 +96,7 @@ function ChatAdminClick() {
 	if (ChatRoomPlayerIsAdmin()) {
 
 		// When we select a new background
-		if ((MouseX >= 1350) && (MouseX <= 1850) && (MouseY >= 500) && (MouseY <= 565)) {
+		if ((MouseX >= 1350) && (MouseX <= 1850) && (MouseY >= 450) && (MouseY <= 515)) {
 			ChatAdminBackgroundIndex += ((MouseX < 1600) ? -1 : 1);
 			if (ChatAdminBackgroundIndex >= ChatCreateBackgroundList.length) ChatAdminBackgroundIndex = 0;
 			if (ChatAdminBackgroundIndex < 0) ChatAdminBackgroundIndex = ChatCreateBackgroundList.length - 1;
@@ -110,7 +110,7 @@ function ChatAdminClick() {
 		if ((MouseX >= 695) && (MouseX < 945) && (MouseY >= 770) && (MouseY < 835)) ElementValue("InputBanList", CommonConvertArrayToString(ChatRoomConcatenateBanList(true, false, CommonConvertStringToArray(ElementValue("InputBanList").trim()))));
 		if ((MouseX >= 975) && (MouseX < 1225) && (MouseY >= 770) && (MouseY < 835)) ElementValue("InputBanList", CommonConvertArrayToString(ChatRoomConcatenateBanList(false, true, CommonConvertStringToArray(ElementValue("InputBanList").trim()))));
 		
-		if ((MouseX >= 1450) && (MouseX <= 1750) && (MouseY >= 600) && (MouseY <= 665)) {
+		if ((MouseX >= 1450) && (MouseX <= 1750) && (MouseY >= 550) && (MouseY <= 615)) {
 			// Save the input values before entering background selection
 			ChatAdminTemporaryData = {
 				Name: ElementValue("InputName"),


### PR DESCRIPTION
# Summary

Follow-on fix to #1047 -  I moved the buttons, but forgot to move the click handlers for them! This fixes that.

This also removes a declaration of the `ChatAdminPrivate` variable, as it was being declared in two places (lines 4 and 7).