### PR TITLE
Improvement: Character array optimizations

### DIFF
--- a/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
+++ b/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
@@ -826,6 +826,10 @@ function ChatRoomSync(data) {
 			if (ChatRoomCharacter.length == data.Character.length + 1) {
 				ChatRoomCharacter = ChatRoomCharacter.filter(A => data.Character.some(B => A.MemberNumber == B.MemberNumber));
 				ChatRoomData = data;
+				// Remove non-present chatroom characters from the characters array as they are no longer needed
+				for (var C = 0; C < Character.length; C++)
+					if (Character[C].AccountName.startsWith("Online-") && data.Character.find(DC => DC.MemberNumber == Character[C].MemberNumber) == null)
+						CharacterDelete(Character[C].AccountName);
 				return;
 			}
 			else if (ChatRoomCharacter.length == data.Character.length - 1) {				

--- a/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
+++ b/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
@@ -330,6 +330,7 @@ function ChatRoomClick() {
 		ElementRemove("TextAreaChatLog");
 		ServerSend("ChatRoomLeave", "");
 		CommonSetScreen("Online", "ChatSearch");
+		CharacterDeleteAllOnline();
 	}
 
 	// When the user wants to remove the top part of his chat to speed up the screen, we only keep the last 20 entries
@@ -1214,6 +1215,7 @@ function ChatRoomSetRule(data) {
 			ElementRemove("InputChat");
 			ElementRemove("TextAreaChatLog");
 			ServerSend("ChatRoomLeave", "");
+			CharacterDeleteAllOnline();
 			CellLock(TimerCell);
 		}
 
@@ -1225,6 +1227,7 @@ function ChatRoomSetRule(data) {
 			ElementRemove("InputChat");
 			ElementRemove("TextAreaChatLog");
 			ServerSend("ChatRoomLeave", "");
+			CharacterDeleteAllOnline();
 			CommonSetScreen("Room", "MaidQuarters");
 			CharacterSetCurrent(MaidQuartersMaid);
 			MaidQuartersMaid.CurrentDialog = D;

--- a/BondageClub/Screens/Online/ChatSearch/ChatSearch.js
+++ b/BondageClub/Screens/Online/ChatSearch/ChatSearch.js
@@ -129,6 +129,7 @@ function ChatSearchResponse(data) {
 			ElementRemove("InputChat");
 			ElementRemove("TextAreaChatLog");
 			CommonSetScreen("Online", "ChatSearch");
+			CharacterDeleteAllOnline();
 		}
 		ChatSearchMessage = "Response" + data;
 	}

--- a/BondageClub/Scripts/Character.js
+++ b/BondageClub/Scripts/Character.js
@@ -357,6 +357,16 @@ function CharacterDelete(NPCType) {
 		}
 }
 
+/**
+ * Deletes all online characters from the character array
+ * @returns {void} - Nothing
+ */
+function CharacterDeleteAllOnline() { 
+	for (var C = Character.length - 1; C >= 0; C--)
+		if (Character[C].AccountName.startsWith("Online-"))
+			CharacterDelete(Character[C].AccountName);
+}
+
 // Adds new effects on a character if it's not already there
 function CharacterAddPose(C, NewPose) {
 	for (var E = 0; E < NewPose.length; E++)


### PR DESCRIPTION
- optimized how online characters are saved to removed instances of characters that are no longer present within your room. 

### The reason
A few functions require to loop through the character array, and it would quickly grow over several hundreds easily the longer you stayed online and the more rooms you went in.

There was also an oversight where if you log back in, a new entry would be created for you in everyone's character array since your online ID changed.

### Potential solutions
There are a few ways to go on about it, I thought about just fixing the duplication problem, but then I thought about saving only X amount max and get rid of the old ones, but in the end, I found no good reason as to why we would need to keep online characters that are not within the room so I went with trimming as much as possible to optimize things.

Nowhere in the code it seemed to be useful to keep track of all online players met. We already receive the data, so this is not like we would query the server more frequently

### Explanations
This way, it means there will ever only be NPCs you saw and the current chatroom's character inside the array, so it will never be in the 100-1000s and will reduce the time it takes to iterate through the array since there wont be 100s of useless iterations

I've tested with several accounts by leaving/entering/dcing, joining rooms and moving around. There was no visible side effects from this change

If you have a preferred way of handling this, or if you have any ideas as to why we would need to save hundreds of characters, let me know. I'll alter this PR if we identify something better to do with this.