### PR TITLE
Fix: Maid responds wrongly if player cannot be freed

### DIFF
--- a/BondageClub/Screens/Room/MaidQuarters/MaidQuarters.js
+++ b/BondageClub/Screens/Room/MaidQuarters/MaidQuarters.js
@@ -2,7 +2,7 @@
 var MaidQuartersBackground = "MaidQuarters";
 var MaidQuartersMaid = null;
 var MaidQuartersMaidInitiation = null;
-var MaidQuartersItemClothPrev = {Cloth:null, Hat:null, ItemArms:null, ItemLegs:null, ItemFeet:null};
+var MaidQuartersItemClothPrev = { Cloth: null, Hat: null, ItemArms: null, ItemLegs: null, ItemFeet: null };
 var MaidQuartersMaidReleasedPlayer = false;
 var MaidQuartersCanBecomeMaid = false;
 var MaidQuartersCannotBecomeMaidYet = false;
@@ -22,21 +22,76 @@ var MaidQuartersOnlineDrinkCustomer = [];
 var MaidQuartersOnlineDrinkFromOwner = false;
 
 // Returns TRUE if the player is dressed in a maid uniform or can take a specific chore
+/**
+ * CHecks for appropriate dressing
+ * @returns {boolean} - Returns true if the player wears a maid dress and a maid hair band, false otherwise
+ */
 function MaidQuartersPlayerInMaidUniform() { return ((CharacterAppearanceGetCurrentValue(Player, "Cloth", "Name") == "MaidOutfit1") && (CharacterAppearanceGetCurrentValue(Player, "Hat", "Name") == "MaidHairband1")) }
+/**
+ * Checks, if the player is able to do the 'serve drinks' job
+ * @returns {boolean} - Returns true, if the player can do the job, false otherwise
+ */
 function MaidQuartersAllowMaidDrinks() { return (!Player.IsRestrained() && !MaidQuartersMaid.IsRestrained() && !LogQuery("ClubMistress", "Management")) }
+/**
+ * Checks, if the player can do the 'clean room job'
+ * @returns {boolean} - Returns true, if the player can do the job, false otherwise
+ */
 function MaidQuartersAllowMaidCleaning() { return (!Player.IsRestrained() && !MaidQuartersMaid.IsRestrained() && !LogQuery("ClubMistress", "Management")) }
+/**
+ * Checks, if the player can do the 'play music' job
+ * @returns {boolean} - Returns true, if the player can do the job, false otherwise
+ */
 function MaidQuartersAllowMaidPlayMusic() { return (!Player.IsRestrained()) }
+/**
+ * Checks, if the player can do a rescue mission
+ * @returns {boolean} - Returns true, if the player can do the job, false otherwise
+ */
 function MaidQuartersAllowRescue() { return (!Player.IsRestrained()) }
+/**
+ * Checks, if the player is on a running rescue mission
+ * @returns {boolean} - Returns true, if the player has a running but unfinished rescue mission, false otherwise
+ */
 function MaidQuartersAllowCancelRescue() { return (MaidQuartersCurrentRescueStarted && !MaidQuartersCurrentRescueCompleted) }
+/**
+ * Checks, if the 'Unlock Sarah' quest is available
+ * @returns {boolean} - Returns true, if the quest is available, false otherwise
+ */
 function MaidQuartersCanFreeSarah() { return (SarahUnlockQuest && LogQuery("LeadSorority", "Maid")) }
+/**
+ * Checks, if the maid can release the player from her restraint
+ * @returns {boolean} - Returns true, if the player can be released, false otherwise
+ */
 function MaidQuartersCanReleasePlayer() { return (Player.IsRestrained() && !InventoryCharacterHasOwnerOnlyRestraint(Player) && CurrentCharacter.CanTalk() && CurrentCharacter.CanInteract()) }
+/**
+ * Checks, if the maid is unable to free the player
+ * @returns {boolean} - Returns true, if the maid is unable to free the player, flase otherwise
+ */
 function MaidQuartersCannotReleasePlayer() { return (Player.IsRestrained() && (InventoryCharacterHasOwnerOnlyRestraint(Player) || !CurrentCharacter.CanTalk() || !CurrentCharacter.CanInteract())) }
+/**
+ * Checks, if the player can get the duster gag
+ * @returns {boolean} - Returns true, if the player can get the duster gag, false otherwise
+ */
 function MaidQuartersCanGetDusterGag() { return (!SarahUnlockQuest && LogQuery("JoinedSorority", "Maid") && Player.CanTalk() && CurrentCharacter.CanTalk() && CurrentCharacter.CanInteract() && (!InventoryAvailable(Player, "DusterGag", "ItemMouth") || !InventoryAvailable(Player, "DusterGag", "ItemMouth2") || !InventoryAvailable(Player, "DusterGag", "ItemMouth3"))) }
+/**
+ * Checks, if the player has finished the 'serve drinks' job
+ * @returns {boolean} - Returns true, if the job is finished, false otherwise
+ */
 function MaidQuartersOnlineDrinkCompleted() { return (MaidQuartersOnlineDrinkCount >= 5) }
+/**
+ * Checks if the player can get ungagged by the maids
+ * @returns {boolean} - Returns true, if the maids can remove the gag, false otherwise
+ */
 function MaidQuartersCanUngag() { return (!Player.CanTalk() && !InventoryCharacterHasOwnerOnlyRestraint(Player)) }
+/**
+ * Checks, if the maids are unable to remove the gag (if there is one)
+ * @returns {boolean} - Returns true, if the player cannot be ungagged by the mauds, flase otherwise
+ */
 function MaidQuartersCannotUngag() { return (!Player.CanTalk() && InventoryCharacterHasOwnerOnlyRestraint(Player)) }
 
-// Loads the maid quarters room
+/**
+ * Loads the maid quarters. This function is called dynamically, as soon, as the player enters the maid quarters
+ * @returns {void} - Nothing
+ */
 function MaidQuartersLoad() {
 
 	// Creates the maid that gives work and the initiation maids
@@ -46,7 +101,11 @@ function MaidQuartersLoad() {
 
 }
 
-// Run the maid quarters, draw both characters (The screen can be used for the search daily job)
+/**
+ * Runs the maid quartes dialogs. 
+ * This function is called periodically so don't use it for extensive use or the call of other complex functions
+ * @returns {void} - Nothing
+ */
 function MaidQuartersRun() {
 	MaidQuartersCanBecomeMaid = (!LogQuery("JoinedSorority", "Maid") && (ReputationGet("Maid") >= 50));
 	MaidQuartersCannotBecomeMaidYet = ((ReputationGet("Maid") > 0) && (ReputationGet("Maid") < 50) && !LogQuery("JoinedSorority", "Maid"));
@@ -61,7 +120,10 @@ function MaidQuartersRun() {
 	DailyJobSubSearchRun();
 }
 
-// When the user clicks in the maid quarters
+/**
+ * Handles the click events of the maid quartest. Clicks are propageted from 'CommonClick()'
+ * @returns {void} - Nothing
+ */
 function MaidQuartersClick() {
 	if (!DailyJobSubSearchIsActive() && (MouseX >= 500) && (MouseX < 1000) && (MouseY >= 0) && (MouseY < 1000)) CharacterSetCurrent(Player);
 	if (!DailyJobSubSearchIsActive() && (MouseX >= 1000) && (MouseX < 1500) && (MouseY >= 0) && (MouseY < 1000)) {
@@ -74,7 +136,10 @@ function MaidQuartersClick() {
 	DailyJobSubSearchClick();
 }
 
-// The maid can ungag the player
+/**
+ * The maid ungags the player
+ * @returns {void} - Nothing
+ */
 function MaidQuartersMaidUngagPlayer() {
 	if (MaidQuartersMaid.CanInteract()) {
 		if (!MaidQuartersMaidReleasedPlayer) {
@@ -88,7 +153,10 @@ function MaidQuartersMaidUngagPlayer() {
 	} else MaidQuartersMaid.CurrentDialog = DialogFind(MaidQuartersMaid, "CantReleasePlayer");
 }
 
-// When the player dresses as a maid
+/**
+ * Dresses the player as a maid
+ * @returns {void} - Nothing
+ */
 function MaidQuartersWearMaidUniform() {
 	for (var ItemAssetGroupName in MaidQuartersItemClothPrev) {
 		MaidQuartersItemClothPrev[ItemAssetGroupName] = InventoryGet(Player, ItemAssetGroupName);
@@ -98,7 +166,10 @@ function MaidQuartersWearMaidUniform() {
 	InventoryWear(Player, "MaidHairband1", "Hat", "Default");
 }
 
-// When the player removes the maid uniform and dresses back
+/**
+ * Removes the maid uniform and dresses the character back
+ * @returns {void} - Nothing
+ */
 function MaidQuartersRemoveMaidUniform() {
 	CharacterReleaseNoLock(Player);
 	for (var ItemAssetGroupName in MaidQuartersItemClothPrev) {
@@ -112,12 +183,22 @@ function MaidQuartersRemoveMaidUniform() {
 	CharacterRefresh(Player);
 }
 
-// When the mini game / maid chore starts
+/**
+ * Starts a mini game or maid chore
+ * @param {string} GameType - Name of the mini-game to launch
+ * @param {number} Difficulty - Difficulty Ration for the mini-game
+ * @returns {void} - Nothing
+ */
 function MaidQuartersMiniGameStart(GameType, Difficulty) {
 	MiniGameStart(GameType, Difficulty, "MaidQuartersMiniGameEnd");
 }
 
 // When the mini game ends, we go back to the maid
+/**
+ * Is called when the mini game ends and sends the player back to the maid quarters. 
+ * Depending on the choosen game, the next dialog option is selected
+ * @returns {void} - Nothing
+ */
 function MaidQuartersMiniGameEnd() {
 	CommonSetScreen("Room", "MaidQuarters");
 	CharacterSetCurrent(MaidQuartersMaid);
@@ -130,7 +211,11 @@ function MaidQuartersMiniGameEnd() {
 	MaidQuartersMaid.CurrentDialog = DialogFind(MaidQuartersMaid, MiniGameType + (MiniGameVictory ? "Victory" : "Defeat"));
 }
 
-// When the mini game / maid chore is successful, the player gets paid
+
+/**
+ * When an ordinary  mini game / maid chore is successful, the player gets paid and the maid reputation increases
+ * @returns {void} - Nothing
+ */
 function MaidQuartersMiniGamePay() {
 	ReputationProgress("Maid", 4);
 	var M = 10;
@@ -141,7 +226,10 @@ function MaidQuartersMiniGamePay() {
 	IntroductionJobProgress("SubMaid");
 }
 
-// When the music mini game is successful, the player gets paid
+/**
+ * When the music mini game is successful, the player gets paid
+ * @returns {void} - Nothing
+ */
 function MaidQuartersMiniGamePayAdvanced() {
 	ReputationProgress("Maid", 4);
 	MaidQuartersMaid.CurrentDialog = MaidQuartersMaid.CurrentDialog.replace("REPLACEMONEY", MiniGameAdvancedPayment.toString());
@@ -149,7 +237,10 @@ function MaidQuartersMiniGamePayAdvanced() {
 	IntroductionJobProgress("SubMaid");
 }
 
-// When the rescue is successful, the player gets paid
+/**
+ * Handles the payment after a successful rescue mission
+ * @returns {void} - Nothing
+ */
 function MaidQuartersRescuePay() {
 	MaidQuartersRemoveMaidUniform();
 	ReputationProgress("Maid", 4);
@@ -159,7 +250,10 @@ function MaidQuartersRescuePay() {
 	IntroductionJobProgress("SubMaid");
 }
 
-// When the maid releases the player
+/**
+ * The maid releases the player, reduces her dominant score and assures that this option is only used once
+ * @returns {void} - Nothing
+ */
 function MaidQuartersMaidReleasePlayer() {
 	if (MaidQuartersMaid.CanInteract()) {
 		if (!MaidQuartersMaidReleasedPlayer) {
@@ -170,19 +264,30 @@ function MaidQuartersMaidReleasePlayer() {
 	} else MaidQuartersMaid.CurrentDialog = DialogFind(MaidQuartersMaid, "CantReleasePlayer");
 }
 
-// Prepares a counter that will affect the dominant reputation of the player
+/**
+ * Collects the dominant reputation change of a player during the course of the various dialog options.
+ * When the player becomes a maid, the change is applied
+ * @param {string} Value - The value by which the reputation is changed
+ * @returns {void} - Nothing
+ */
 function MaidQuartersDominantRepChange(Value) {
 	MaidQuartersDominantRep = MaidQuartersDominantRep + parseInt(Value);
 }
 
-// When we switch from one maid to another in the initiation
+/**
+ * Switches from one maid to another in the initiation
+ * @param {string} MaidType - Name of the current maid type
+ */
 function MaidQuartersInitiationTransition(MaidType) {
 	var C = ((MaidType == "MainMaid") ? MaidQuartersMaid : MaidQuartersMaidInitiation);
 	CharacterSetCurrent(C);
 	C.CurrentDialog = DialogFind(C, "MaidInitiationTransition");
 }
 
-// Change the initiation maid appearance on the spot to simulate a new character
+/**
+ * Change the initiation maid appearance on the spot to simulate a new character
+ * @returns {void} - Nothing
+ */
 function MaidQuartersChangeInitiationMaid() {
 	CharacterRandomName(MaidQuartersMaidInitiation);
 	CharacterAppearanceFullRandom(MaidQuartersMaidInitiation);
@@ -193,7 +298,10 @@ function MaidQuartersChangeInitiationMaid() {
 	InventoryWear(MaidQuartersMaidInitiation, "WoodenPaddle", "ItemMisc");
 }
 
-// When the player becomes a maid
+/**
+ * The player joins the maid sorority
+ * @returns {void} - Nothing
+ */
 function MaidQuartersBecomMaid() {
 	InventoryAdd(Player, "MaidOutfit1", "Cloth");
 	InventoryAdd(Player, "MaidOutfit2", "Cloth");
@@ -208,30 +316,39 @@ function MaidQuartersBecomMaid() {
 	MaidQuartersIsMaid = true;
 }
 
-// When the player becomes head maid
+/**
+ * The player is promoted to head maid
+ * @returns {void} - Nothing
+ */
 function MaidQuartersBecomHeadMaid() {
 	MaidQuartersIsHeadMaid = true;
 	MaidQuartersMaid.AllowItem = true;
 	LogAdd("LeadSorority", "Maid");
 }
 
-// Starts a maid rescue mission in a random room
+/**
+ * Starts a maid rescue mission in a random room. The same room is never selected twice and
+ * the player is not sent to the introduction room when doing the daily quest
+ * @returns {void} - Nothing
+ */
 function MaidQuartersStartRescue() {
-	
-	// Make sure we don't select the same room twice or sent rescue to the introduction room when doing the daily quest
+
 	MaidQuartersCurrentRescue = CommonRandomItemFromList(MaidQuartersCurrentRescue, MaidQuartersRescueList);
 	if ((MaidQuartersCurrentRescue == "IntroductionClass") && (IntroductionJobCurrent == "SubMaid")) MaidQuartersCurrentRescue = CommonRandomItemFromList(MaidQuartersCurrentRescue, ["ShibariDojo", "Shop", "Gambling"]);
 	MaidQuartersMaid.Stage = MaidQuartersRescueStage[MaidQuartersRescueList.indexOf(MaidQuartersCurrentRescue)];
 	MaidQuartersMaid.CurrentDialog = DialogFind(MaidQuartersMaid, "Rescue" + MaidQuartersCurrentRescue);
 	MaidQuartersCurrentRescueStarted = false;
 	MaidQuartersCurrentRescueCompleted = false;
-	
+
 	MaidQuartersItemClothPrev.Cloth = InventoryGet(Player, "Cloth");
 	MaidQuartersItemClothPrev.Hat = InventoryGet(Player, "Hat");
 
 }
 
-// Cancels the current rescue mission
+/**
+ * Cancels the current rescue mission
+ * @returns {void} - Nothing
+ */
 function MaidQuartersCancelRescue() {
 	MaidQuartersRemoveMaidUniform();
 	if (MaidQuartersCurrentRescue == "IntroductionClass") { IntroductionCompleteRescue(); IntroductionMaid.Stage = "0"; }
@@ -240,19 +357,28 @@ function MaidQuartersCancelRescue() {
 	if (MaidQuartersCurrentRescue == "Gambling") { GamblingCompleteRescue(); GamblingFirstSub.Stage = "0"; }
 }
 
-// The player as head maid can trick the maids into freeing Sarah
+/**
+ * The player as head maid can trick the maids into freeing Sarah
+ * @returns {void} - Nothing
+ */
 function MaidQuartersFreeSarah() {
 	SarahUnlock();
 }
 
-// The maid can give a duster gag to the player if she's in the sorority
+/**
+ * The maid gives a duster gag to the player if she's in the sorority
+ * @returns {void} - Nothing
+ */
 function MaidQuartersGetDusterGag() {
 	InventoryAdd(Player, "DusterGag", "ItemMouth");
 	InventoryAdd(Player, "DusterGag", "ItemMouth2");
 	InventoryAdd(Player, "DusterGag", "ItemMouth3");
 }
 
-// When the online drink mini game starts
+/**
+ * Starts the online drink serving game
+ * @returns {void} - Nothing
+ */
 function MaidQuartersOnlineDrinkStart() {
 	InventoryWear(Player, "WoodenMaidTrayFull", "ItemMisc");
 	MaidQuartersOnlineDrinkCount = 0;
@@ -261,7 +387,11 @@ function MaidQuartersOnlineDrinkStart() {
 	MaidQuartersOnlineDrinkCustomer = [];
 }
 
-// If an online player picked a drink from the maid tray, the same player/customer cannot pick twice
+/**
+ * On online player picks a drink from the plyers tray. She only gets credited, if it was a new customer
+ * @param {string} MemberNumber - The member ID of the customer
+ * @param {string} DrinkValue - The value of the picked drink
+ */
 function MaidQuartersOnlineDrinkPick(MemberNumber, DrinkValue) {
 	if ((MaidQuartersOnlineDrinkCount < 5) && (MaidQuartersOnlineDrinkCustomer.indexOf(MemberNumber) < 0)) {
 		MaidQuartersOnlineDrinkCount++;
@@ -275,7 +405,11 @@ function MaidQuartersOnlineDrinkPick(MemberNumber, DrinkValue) {
 	}
 }
 
-// When the maid tray is empty, the player can get paid (40% of drink value + 10$)
+/**
+ * Calculates the player's earnings from the online drink serving. 
+ * When the maid tray is empty, the player can get paid (40% of drink value + 10$)
+ * @returns {void} - Nothing
+ */
 function MaidQuartersOnlineDrinkPay() {
 	var M = 10 + Math.floor(MaidQuartersOnlineDrinkValue * 0.4);
 	MaidQuartersMaid.CurrentDialog = MaidQuartersMaid.CurrentDialog.replace("REPLACEMONEY", M.toString());
@@ -285,7 +419,10 @@ function MaidQuartersOnlineDrinkPay() {
 	IntroductionJobProgress("SubMaid");
 }
 
-// Flags the maid drink as not from the player owner
+/**
+ * Flags the online drink serving as not initiated by the player's owner
+ * @returns {void} - Nothing	
+ */
 function MaidQuartersNotFromOwner() {
 	MaidQuartersOnlineDrinkFromOwner = false;
 }

--- a/BondageClub/Screens/Room/MaidQuarters/MaidQuarters.js
+++ b/BondageClub/Screens/Room/MaidQuarters/MaidQuarters.js
@@ -61,12 +61,12 @@ function MaidQuartersCanFreeSarah() { return (SarahUnlockQuest && LogQuery("Lead
  * Checks, if the maid can release the player from her restraint
  * @returns {boolean} - Returns true, if the player can be released, false otherwise
  */
-function MaidQuartersCanReleasePlayer() { return (Player.IsRestrained() && !InventoryCharacterHasOwnerOnlyRestraint(Player) && CurrentCharacter.CanTalk() && CurrentCharacter.CanInteract()) }
+function MaidQuartersCanReleasePlayer() { return (Player.IsRestrained() && !InventoryCharacterHasOwnerOnlyRestraint(Player) && !InventoryCharacterHasLockedRestraint(Player) && CurrentCharacter.CanTalk() && CurrentCharacter.CanInteract()) }
 /**
  * Checks, if the maid is unable to free the player
  * @returns {boolean} - Returns true, if the maid is unable to free the player, flase otherwise
  */
-function MaidQuartersCannotReleasePlayer() { return (Player.IsRestrained() && (InventoryCharacterHasOwnerOnlyRestraint(Player) || !CurrentCharacter.CanTalk() || !CurrentCharacter.CanInteract())) }
+function MaidQuartersCannotReleasePlayer() { return !MaidQuartersCanReleasePlayer() }
 /**
  * Checks, if the player can get the duster gag
  * @returns {boolean} - Returns true, if the player can get the duster gag, false otherwise


### PR DESCRIPTION
# Summary
If a player, restrained with a locked item, asks the maid in the maid quarters to free her, the maid responds, that she freed the player, but in fact did nothing (or removed all safe the locked restraints from the player).
With this fix, the maid correctly shakes her head and does nothing.
This fixes [Bug #881335]( http://www.hostedredmine.com/issues/881335)
# Details
## What it does
This fix changes two functions in the script
* added a check for locked restraints in `MaidQuartersCanReleasePlayer`
* changed MaidQuartersCannotReleasePlayer` to return the inverted result of `MaidQuartersCanReleasePlayer` so that code maintenance gets easier
## Testing
Tested that on my local instance:
* a player with any locked item is sent away
* a player with unlocked items get freed