### PR TITLE
Fix: zipped suits behavior

### DIFF
--- a/BondageClub/Screens/Inventory/ItemArms/BitchSuit/BitchSuit.js
+++ b/BondageClub/Screens/Inventory/ItemArms/BitchSuit/BitchSuit.js
@@ -2,8 +2,7 @@
 
 // Loads the item extension properties
 function InventoryItemArmsBitchSuitLoad() {
-	if (DialogFocusItem.Property == null) DialogFocusItem.Property = {};
-	if (DialogFocusItem.Property.Type == null) DialogFocusItem.Property.Type = null ;
+	if (DialogFocusItem.Property == null) DialogFocusItem.Property = { Type: null };
 	if (DialogFocusItem.Property.Block == null) DialogFocusItem.Property.Block = DialogFocusItem.Property.Type ? [] : ["ItemBreast", "ItemNipples", "ItemNipplesPiercings", "ItemVulva", "ItemVulvaPiercings", "ItemButt"];
 }
 

--- a/BondageClub/Screens/Inventory/ItemArms/BitchSuit/BitchSuit.js
+++ b/BondageClub/Screens/Inventory/ItemArms/BitchSuit/BitchSuit.js
@@ -2,8 +2,9 @@
 
 // Loads the item extension properties
 function InventoryItemArmsBitchSuitLoad() {
-	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
-	if (DialogFocusItem.Property == null) DialogFocusItem.Property = { Type: null };
+	if (DialogFocusItem.Property == null) DialogFocusItem.Property = {};
+	if (DialogFocusItem.Property.Type == null) DialogFocusItem.Property.Type = null ;
+	if (DialogFocusItem.Property.Block == null) DialogFocusItem.Property.Block = DialogFocusItem.Property.Type ? [] : ["ItemBreast", "ItemNipples", "ItemNipplesPiercings", "ItemVulva", "ItemVulvaPiercings", "ItemButt"];
 }
 
 // Draw the item extension screen

--- a/BondageClub/Screens/Inventory/ItemArms/FullLatexSuit/FullLatexSuit.js
+++ b/BondageClub/Screens/Inventory/ItemArms/FullLatexSuit/FullLatexSuit.js
@@ -2,8 +2,9 @@
 
 // Loads the item extension properties
 function InventoryItemArmsFullLatexSuitLoad() {
-	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
-	if (DialogFocusItem.Property == null) DialogFocusItem.Property = { Type: null };
+	if (DialogFocusItem.Property == null) DialogFocusItem.Property = {};
+	if (DialogFocusItem.Property.Type == null) DialogFocusItem.Property.Type = null ;
+	if (DialogFocusItem.Property.Block == null) DialogFocusItem.Property.Block = DialogFocusItem.Property.Type ? [] : ["ItemBreast", "ItemNipples", "ItemNipplesPiercings", "ItemVulva", "ItemVulvaPiercings", "ItemButt"];
 }
 
 // Draw the item extension screen

--- a/BondageClub/Screens/Inventory/ItemArms/FullLatexSuit/FullLatexSuit.js
+++ b/BondageClub/Screens/Inventory/ItemArms/FullLatexSuit/FullLatexSuit.js
@@ -2,8 +2,7 @@
 
 // Loads the item extension properties
 function InventoryItemArmsFullLatexSuitLoad() {
-	if (DialogFocusItem.Property == null) DialogFocusItem.Property = {};
-	if (DialogFocusItem.Property.Type == null) DialogFocusItem.Property.Type = null ;
+	if (DialogFocusItem.Property == null) DialogFocusItem.Property = { Type: null };
 	if (DialogFocusItem.Property.Block == null) DialogFocusItem.Property.Block = DialogFocusItem.Property.Type ? [] : ["ItemBreast", "ItemNipples", "ItemNipplesPiercings", "ItemVulva", "ItemVulvaPiercings", "ItemButt"];
 }
 

--- a/BondageClub/Screens/Inventory/ItemArms/MermaidSuit/MermaidSuit.js
+++ b/BondageClub/Screens/Inventory/ItemArms/MermaidSuit/MermaidSuit.js
@@ -2,8 +2,7 @@
 
 // Loads the item extension properties
 function InventoryItemArmsMermaidSuitLoad() {
-	if (DialogFocusItem.Property == null) DialogFocusItem.Property = {};
-	if (DialogFocusItem.Property.Type == null) DialogFocusItem.Property.Type = null ;
+	if (DialogFocusItem.Property == null) DialogFocusItem.Property = { Type: null };
 	if (DialogFocusItem.Property.Block == null) DialogFocusItem.Property.Block = DialogFocusItem.Property.Type ? [] : ["ItemBreast", "ItemNipples", "ItemNipplesPiercings", "ItemVulva", "ItemVulvaPiercings", "ItemButt"];
 }
 

--- a/BondageClub/Screens/Inventory/ItemArms/MermaidSuit/MermaidSuit.js
+++ b/BondageClub/Screens/Inventory/ItemArms/MermaidSuit/MermaidSuit.js
@@ -2,8 +2,9 @@
 
 // Loads the item extension properties
 function InventoryItemArmsMermaidSuitLoad() {
-	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
-	if (DialogFocusItem.Property == null) DialogFocusItem.Property = { Type: null };
+	if (DialogFocusItem.Property == null) DialogFocusItem.Property = {};
+	if (DialogFocusItem.Property.Type == null) DialogFocusItem.Property.Type = null ;
+	if (DialogFocusItem.Property.Block == null) DialogFocusItem.Property.Block = DialogFocusItem.Property.Type ? [] : ["ItemBreast", "ItemNipples", "ItemNipplesPiercings", "ItemVulva", "ItemVulvaPiercings", "ItemButt"];
 }
 
 // Draw the item extension screen


### PR DESCRIPTION
- fixed an issue where the suits would not load with their intended effects

The normal petsuit, the latex lockdown suit and the mermaid suit currently render the zip state first but do not block the zones until we unzip/zip them again. This fixes the issue