### PR TITLE
Improvement: Auto focus text area in chat

### DIFF
--- a/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
+++ b/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
@@ -185,7 +185,7 @@ function ChatRoomDrawCharacter(DoClick) {
 						ChatRoomCompleteSwap(ChatRoomCharacter[C].MemberNumber);
 						break;
 					}
-					
+
 					// Intercepts the online game character clicks if we need to
 					if (DoClick && OnlineGameClickCharacter(ChatRoomCharacter[C])) return;
 
@@ -239,7 +239,7 @@ function ChatRoomCheckRelationships() {
 // Displays /help content to the player if it's their first visit to a chatroom this session
 function ChatRoomFirstTimeHelp() {
 	if (!ChatRoomHelpSeen) {
-		ChatRoomMessage({Content: "ChatRoomHelp", Type: "Action", Sender: Player.MemberNumber});
+		ChatRoomMessage({ Content: "ChatRoomHelp", Type: "Action", Sender: Player.MemberNumber });
 		ChatRoomHelpSeen = true;
 	}
 }
@@ -349,7 +349,7 @@ function ChatRoomClick() {
 
 	// When the user character kneels
 	if ((MouseX >= 1353) && (MouseX < 1473) && (MouseY >= 0) && (MouseY <= 62) && Player.CanKneel()) {
-		ServerSend("ChatRoomChat", { Content: (Player.ActivePose == null) ? "KneelDown": "StandUp", Type: "Action", Dictionary: [{Tag: "SourceCharacter", Text: Player.Name, MemberNumber: Player.MemberNumber}]} );
+		ServerSend("ChatRoomChat", { Content: (Player.ActivePose == null) ? "KneelDown" : "StandUp", Type: "Action", Dictionary: [{ Tag: "SourceCharacter", Text: Player.Name, MemberNumber: Player.MemberNumber }] });
 		CharacterSetActivePose(Player, (Player.ActivePose == null) ? "Kneel" : null);
 		ServerSend("ChatRoomCharacterPoseUpdate", { Pose: Player.ActivePose });
 	}
@@ -358,11 +358,11 @@ function ChatRoomClick() {
 	if ((MouseX >= 1527) && (MouseX < 1647) && (MouseY >= 0) && (MouseY <= 62) && Player.CanChange() && OnlineGameAllowChange()) {
 		document.getElementById("InputChat").style.display = "none";
 		document.getElementById("TextAreaChatLog").style.display = "none";
-		CharacterAppearanceReturnRoom = "ChatRoom"; 
+		CharacterAppearanceReturnRoom = "ChatRoom";
 		CharacterAppearanceReturnModule = "Online";
 		CharacterAppearanceLoadCharacter(Player);
 	}
-	
+
 	// When the user checks her profile
 	if ((MouseX >= 1701) && (MouseX < 1821) && (MouseY >= 0) && (MouseY <= 62)) {
 		document.getElementById("InputChat").style.display = "none";
@@ -391,6 +391,9 @@ function ChatRoomCanLeave() {
 
 // Chat room keyboard shortcuts
 function ChatRoomKeyDown() {
+
+	// If the input textfield is not focussed at the moment, set the focus to it.
+	if (document.activeElement.id != "InputChat") document.getElementById("InputChat").focus();
 
 	// The ENTER key sends the chat.  The "preventDefault" is needed for <textarea>, otherwise it adds a new line after clearing the field
 	if (KeyPress == 13) {
@@ -436,13 +439,13 @@ function ChatRoomSendChat() {
 			if (/(^\d+)[dD](\d+$)/.test(msg.substring(5, 50).trim())) {
 				var Roll = /(^\d+)[dD](\d+$)/.exec((msg.substring(5, 50).trim()));
 				var DiceNumber = (!Roll) ? 1 : parseInt(Roll[1]);
-				var DiceSize =  (!Roll) ? 6 : parseInt(Roll[2]);
+				var DiceSize = (!Roll) ? 6 : parseInt(Roll[2]);
 				if ((DiceNumber < 1) || (DiceNumber > 100)) DiceNumber = 1;
 			}
 			else if (/(^\d+$)/.test((msg.substring(5, 50).trim()))) {
 				var Roll = /(^\d+)/.exec((msg.substring(5, 50).trim()));
 				var DiceNumber = 1;
-				var DiceSize =  (!Roll) ? 6 : parseInt(Roll[1]);
+				var DiceSize = (!Roll) ? 6 : parseInt(Roll[1]);
 			}
 			else DiceNumber = 0;
 
@@ -460,14 +463,14 @@ function ChatRoomSendChat() {
 				}
 				msg = "ActionDice";
 				var Dictionary = [];
-				Dictionary.push({Tag: "SourceCharacter", Text: Player.Name});
-				Dictionary.push({Tag: "DiceType", Text: DiceNumber.toString() + "D" + DiceSize.toString()});
+				Dictionary.push({ Tag: "SourceCharacter", Text: Player.Name });
+				Dictionary.push({ Tag: "DiceType", Text: DiceNumber.toString() + "D" + DiceSize.toString() });
 				if (DiceNumber > 1) {
 					Result.sort((a, b) => a - b);
-					Dictionary.push({Tag: "DiceResult", Text: Result.toString() + " = " + Total.toString()});
+					Dictionary.push({ Tag: "DiceResult", Text: Result.toString() + " = " + Total.toString() });
 				}
-				else if (DiceNumber == 1) Dictionary.push({Tag: "DiceResult", Text: Total.toString()});
-				if (msg != "") ServerSend("ChatRoomChat", { Content: msg, Type: "Action", Dictionary: Dictionary} );
+				else if (DiceNumber == 1) Dictionary.push({ Tag: "DiceResult", Text: Total.toString() });
+				if (msg != "") ServerSend("ChatRoomChat", { Content: msg, Type: "Action", Dictionary: Dictionary });
 			}
 
 		} else if (m.indexOf("/coin") == 0) {
@@ -476,9 +479,9 @@ function ChatRoomSendChat() {
 			msg = "ActionCoin";
 			var Heads = (Math.random() >= 0.5);
 			var Dictionary = [];
-			Dictionary.push({Tag: "SourceCharacter", Text: Player.Name});
-			Dictionary.push({Tag: "CoinResult", TextToLookUp: Heads ? "Heads" : "Tails"});
-			if (msg != "") ServerSend("ChatRoomChat", { Content: msg, Type: "Action", Dictionary: Dictionary} );
+			Dictionary.push({ Tag: "SourceCharacter", Text: Player.Name });
+			Dictionary.push({ Tag: "CoinResult", TextToLookUp: Heads ? "Heads" : "Tails" });
+			if (msg != "") ServerSend("ChatRoomChat", { Content: msg, Type: "Action", Dictionary: Dictionary });
 
 		} else if ((m.indexOf("*") == 0) || (m.indexOf("/me ") == 0) || (m.indexOf("/action ") == 0)) {
 
@@ -487,10 +490,10 @@ function ChatRoomSendChat() {
 			msg = msg.replace("*", "");
 			msg = msg.replace(/\/me /g, "");
 			msg = msg.replace(/\/action /g, "*");
-			if (msg != "") ServerSend("ChatRoomChat", { Content: msg, Type: "Emote" } );
+			if (msg != "") ServerSend("ChatRoomChat", { Content: msg, Type: "Emote" });
 
 		}
-		else if (m.indexOf("/help") == 0) ServerSend("ChatRoomChat", { Content: "ChatRoomHelp", Type: "Action", Target: Player.MemberNumber});
+		else if (m.indexOf("/help") == 0) ServerSend("ChatRoomChat", { Content: "ChatRoomHelp", Type: "Action", Target: Player.MemberNumber });
 		else if (m.indexOf("/safeword") == 0) ChatRoomSafeword();
 		else if (m.indexOf("/friendlistadd ") == 0) ChatRoomListManipulation(Player.FriendList, null, msg);
 		else if (m.indexOf("/friendlistremove ") == 0) ChatRoomListManipulation(null, Player.FriendList, msg);
@@ -508,7 +511,7 @@ function ChatRoomSendChat() {
 		else {
 
 			// Regular chat can be garbled with a gag
-			if ((msg != "") && (ChatRoomTargetMemberNumber == null)) ServerSend("ChatRoomChat", { Content: msg, Type: "Chat" } );
+			if ((msg != "") && (ChatRoomTargetMemberNumber == null)) ServerSend("ChatRoomChat", { Content: msg, Type: "Chat" });
 
 			// The whispers get sent to the server and shown on the client directly
 			if ((msg != "") && (ChatRoomTargetMemberNumber != null)) {
@@ -523,7 +526,7 @@ function ChatRoomSendChat() {
 				div.setAttribute('data-time', ChatRoomCurrentTime());
 				div.setAttribute('data-sender', Player.MemberNumber.toString());
 				div.innerHTML = TextGet("WhisperTo") + " " + TargetName + ": " + msg;
-						
+
 				var Refocus = document.activeElement.id == "InputChat";
 				var ShouldScrollDown = ElementIsScrolledToEnd("TextAreaChatLog");
 				if (document.getElementById("TextAreaChatLog") != null) {
@@ -537,7 +540,7 @@ function ChatRoomSendChat() {
 
 		// Clears the chat text message
 		ElementValue("InputChat", "");
-	
+
 	}
 
 }
@@ -561,17 +564,17 @@ function ChatRoomPublishAction(C, DialogProgressPrevItem, DialogProgressNextItem
 		} else msg = Action;
 
 		// Replaces the action tags to build the phrase
-		Dictionary.push({Tag: "SourceCharacter", Text: Player.Name, MemberNumber: Player.MemberNumber});
-		Dictionary.push({Tag: "DestinationCharacter", Text: C.Name, MemberNumber: C.MemberNumber});
-		if (DialogProgressPrevItem != null) Dictionary.push({Tag: "PrevAsset", AssetName: DialogProgressPrevItem.Asset.Name});
-		if (DialogProgressNextItem != null) Dictionary.push({Tag: "NextAsset", AssetName: DialogProgressNextItem.Asset.Name});
-		if (C.FocusGroup != null) Dictionary.push({ Tag: "FocusAssetGroup", AssetGroupName: C.FocusGroup.Name});
+		Dictionary.push({ Tag: "SourceCharacter", Text: Player.Name, MemberNumber: Player.MemberNumber });
+		Dictionary.push({ Tag: "DestinationCharacter", Text: C.Name, MemberNumber: C.MemberNumber });
+		if (DialogProgressPrevItem != null) Dictionary.push({ Tag: "PrevAsset", AssetName: DialogProgressPrevItem.Asset.Name });
+		if (DialogProgressNextItem != null) Dictionary.push({ Tag: "NextAsset", AssetName: DialogProgressNextItem.Asset.Name });
+		if (C.FocusGroup != null) Dictionary.push({ Tag: "FocusAssetGroup", AssetGroupName: C.FocusGroup.Name });
 
 		// Prepares the item packet to be sent to other players in the chatroom
 		ChatRoomCharacterItemUpdate(C);
 
 		// Sends the result to the server and leaves the dialog if we need to
-		ServerSend("ChatRoomChat", { Content: msg, Type: "Action", Dictionary: Dictionary} );
+		ServerSend("ChatRoomChat", { Content: msg, Type: "Action", Dictionary: Dictionary });
 		if (LeaveDialog && (CurrentCharacter != null)) DialogLeave();
 
 	}
@@ -759,11 +762,11 @@ function ChatRoomMessage(data) {
 				var ActivityGroup = null;
 				if (data.Dictionary != null)
 					for (var D = 0; D < data.Dictionary.length; D++) {
-							if (data.Dictionary[D].MemberNumber != null) msg = msg.replace(data.Dictionary[D].Tag, (PreferenceIsPlayerInSensDep() && (data.Dictionary[D].MemberNumber != Player.MemberNumber)) ? DialogFind(Player, "Someone") : ChatRoomHTMLEntities(data.Dictionary[D].Text));
-							if ((data.Dictionary[D].MemberNumber != null) && (data.Dictionary[D].Tag == "TargetCharacter")) TargetMemberNumber = data.Dictionary[D].MemberNumber;
-							if (data.Dictionary[D].Tag == "ActivityName") ActivityName = data.Dictionary[D].Text;
-							if (data.Dictionary[D].Tag == "ActivityGroup") ActivityGroup = data.Dictionary[D].Text;
-						}
+						if (data.Dictionary[D].MemberNumber != null) msg = msg.replace(data.Dictionary[D].Tag, (PreferenceIsPlayerInSensDep() && (data.Dictionary[D].MemberNumber != Player.MemberNumber)) ? DialogFind(Player, "Someone") : ChatRoomHTMLEntities(data.Dictionary[D].Text));
+						if ((data.Dictionary[D].MemberNumber != null) && (data.Dictionary[D].Tag == "TargetCharacter")) TargetMemberNumber = data.Dictionary[D].MemberNumber;
+						if (data.Dictionary[D].Tag == "ActivityName") ActivityName = data.Dictionary[D].Text;
+						if (data.Dictionary[D].Tag == "ActivityGroup") ActivityGroup = data.Dictionary[D].Text;
+					}
 
 				// If the player does the activity on herself or an NPC, we calculate the result right away
 				if ((TargetMemberNumber == Player.MemberNumber) && (SenderCharacter.MemberNumber != Player.MemberNumber))
@@ -811,7 +814,7 @@ function ChatRoomSync(data) {
 					// Check if we should push banned members
 					if (Player.ChatSettings && data.Character.length == 1) {
 						var BanList = ChatRoomConcatenateBanList(Player.ChatSettings.AutoBanBlackList, Player.ChatSettings.AutoBanGhostList);
-						if (BanList.length > 0) { 
+						if (BanList.length > 0) {
 							data.Ban = BanList;
 							data.Limit = data.Limit.toString();
 							ServerSend("ChatRoomAdmin", { MemberNumber: Player.ID, Room: data, Action: "Update" });
@@ -828,7 +831,7 @@ function ChatRoomSync(data) {
 				ChatRoomData = data;
 				return;
 			}
-			else if (ChatRoomCharacter.length == data.Character.length - 1) {				
+			else if (ChatRoomCharacter.length == data.Character.length - 1) {
 				ChatRoomCharacter.push(CharacterLoadOnline(data.Character[data.Character.length - 1], data.SourceMemberNumber));
 				ChatRoomData = data;
 				return;
@@ -842,7 +845,7 @@ function ChatRoomSync(data) {
 
 		// Keeps a copy of the previous version
 		ChatRoomData = data;
-		
+
 		// Reloads the online game statuses if needed
 		OnlineGameLoadStatus();
 
@@ -1016,16 +1019,16 @@ function ChatRoomViewProfile() {
 // The player can assist another player to struggle out, the bonus is evasion / 2 + 1, with penalties if the player is restrained
 function ChatRoomStruggleAssist() {
 	var Dictionary = [];
-	Dictionary.push({Tag: "SourceCharacter", Text: Player.Name, MemberNumber: Player.MemberNumber});
-	Dictionary.push({Tag: "TargetCharacter", Text: CurrentCharacter.Name, MemberNumber: CurrentCharacter.MemberNumber});
+	Dictionary.push({ Tag: "SourceCharacter", Text: Player.Name, MemberNumber: Player.MemberNumber });
+	Dictionary.push({ Tag: "TargetCharacter", Text: CurrentCharacter.Name, MemberNumber: CurrentCharacter.MemberNumber });
 	var Bonus = SkillGetLevelReal(Player, "Evasion") / 2 + 1;
 	if (!Player.CanInteract()) {
 		if (InventoryItemHasEffect(InventoryGet(Player, "ItemArms"), "Block", true)) Bonus = Bonus / 1.5;
 		if (InventoryItemHasEffect(InventoryGet(Player, "ItemHands"), "Block", true)) Bonus = Bonus / 1.5;
 		if (!Player.CanTalk()) Bonus = Bonus / 1.25;
 	}
-	ServerSend("ChatRoomChat", { Content: "StruggleAssist", Type: "Action", Dictionary: Dictionary} );
-    ServerSend("ChatRoomChat", { Content: "StruggleAssist" + Math.round(Bonus).toString(), Type: "Hidden", Target: CurrentCharacter.MemberNumber } );
+	ServerSend("ChatRoomChat", { Content: "StruggleAssist", Type: "Action", Dictionary: Dictionary });
+	ServerSend("ChatRoomChat", { Content: "StruggleAssist" + Math.round(Bonus).toString(), Type: "Hidden", Target: CurrentCharacter.MemberNumber });
 	DialogLeave();
 }
 
@@ -1052,13 +1055,13 @@ function ChatRoomAdminAction(ActionType, Publish) {
 function ChatRoomCompleteSwap(MemberNumber) {
 	if (ChatRoomSwapTarget == null) return;
 	ServerSend("ChatRoomAdmin",
-	{
-		MemberNumber: Player.ID,
-		TargetMemberNumber: ChatRoomSwapTarget,
-		DestinationMemberNumber: MemberNumber,
-		Action: "Swap",
-		Publish: true
-	});
+		{
+			MemberNumber: Player.ID,
+			TargetMemberNumber: ChatRoomSwapTarget,
+			DestinationMemberNumber: MemberNumber,
+			Action: "Swap",
+			Publish: true
+		});
 	ChatRoomSwapTarget = null;
 }
 
@@ -1147,12 +1150,12 @@ function ChatRoomSendLovershipRequest(RequestType) {
 // When the player picks a drink from a maid platter
 function ChatRoomDrinkPick(DrinkType, Money) {
 	if (ChatRoomCanTakeDrink()) {
-	    var Dictionary = [];
-	    Dictionary.push({Tag: "SourceCharacter", Text: Player.Name, MemberNumber: Player.MemberNumber});
-	    Dictionary.push({Tag: "DestinationCharacter", Text: CurrentCharacter.Name, MemberNumber: CurrentCharacter.MemberNumber});
-	    Dictionary.push({Tag: "TargetCharacter", Text: CurrentCharacter.Name, MemberNumber: CurrentCharacter.MemberNumber});
-		ServerSend("ChatRoomChat", { Content: "MaidDrinkPick" + DrinkType, Type: "Action", Dictionary: Dictionary} );
-        ServerSend("ChatRoomChat", { Content: "MaidDrinkPick" + Money.toString(), Type: "Hidden", Target: CurrentCharacter.MemberNumber } );
+		var Dictionary = [];
+		Dictionary.push({ Tag: "SourceCharacter", Text: Player.Name, MemberNumber: Player.MemberNumber });
+		Dictionary.push({ Tag: "DestinationCharacter", Text: CurrentCharacter.Name, MemberNumber: CurrentCharacter.MemberNumber });
+		Dictionary.push({ Tag: "TargetCharacter", Text: CurrentCharacter.Name, MemberNumber: CurrentCharacter.MemberNumber });
+		ServerSend("ChatRoomChat", { Content: "MaidDrinkPick" + DrinkType, Type: "Action", Dictionary: Dictionary });
+		ServerSend("ChatRoomChat", { Content: "MaidDrinkPick" + Money.toString(), Type: "Hidden", Target: CurrentCharacter.MemberNumber });
 		CharacterChangeMoney(Player, Money * -1);
 		DialogLeave();
 	}
@@ -1160,7 +1163,7 @@ function ChatRoomDrinkPick(DrinkType, Money) {
 
 // Sends a rule / restriction / punishment to the slave character client, it will be handled from there
 function ChatRoomSendRule(RuleType, Option) {
-	ServerSend("ChatRoomChat", { Content: "OwnerRule" + RuleType, Type: "Hidden", Target: CurrentCharacter.MemberNumber } );
+	ServerSend("ChatRoomChat", { Content: "OwnerRule" + RuleType, Type: "Hidden", Target: CurrentCharacter.MemberNumber });
 	if (Option == "Quest") {
 		if (ChatRoomQuestGiven.indexOf(CurrentCharacter.MemberNumber) >= 0) ChatRoomQuestGiven.splice(ChatRoomQuestGiven.indexOf(CurrentCharacter.MemberNumber), 1);
 		ChatRoomQuestGiven.push(CurrentCharacter.MemberNumber);
@@ -1170,7 +1173,7 @@ function ChatRoomSendRule(RuleType, Option) {
 
 // Sends the rule / restriction / punishment from the owner
 function ChatRoomSetRule(data) {
-	
+
 	// Only works if the sender is the player, and the player is fully collared
 	if ((data != null) && (Player.Ownership != null) && (Player.Ownership.Stage == 1) && (Player.Ownership.MemberNumber == data.Sender)) {
 
@@ -1206,7 +1209,7 @@ function ChatRoomSetRule(data) {
 		if (data.Content == "OwnerRuleTimerCell30") TimerCell = 30;
 		if (data.Content == "OwnerRuleTimerCell60") TimerCell = 60;
 		if (TimerCell > 0) {
-			ServerSend("ChatRoomChat", { Content: "ActionGrabbedForCell", Type: "Action", Dictionary: [{Tag: "TargetCharacterName", Text: Player.Name, MemberNumber: Player.MemberNumber}]} );
+			ServerSend("ChatRoomChat", { Content: "ActionGrabbedForCell", Type: "Action", Dictionary: [{ Tag: "TargetCharacterName", Text: Player.Name, MemberNumber: Player.MemberNumber }] });
 			ElementRemove("InputChat");
 			ElementRemove("TextAreaChatLog");
 			ServerSend("ChatRoomLeave", "");
@@ -1217,7 +1220,7 @@ function ChatRoomSetRule(data) {
 		if (data.Content == "OwnerRuleLaborMaidDrinks" && Player.CanTalk()) {
 			CharacterSetActivePose(Player, null);
 			var D = TextGet("ActionGrabbedToServeDrinksIntro");
-			ServerSend("ChatRoomChat", { Content: "ActionGrabbedToServeDrinks", Type: "Action", Dictionary: [{Tag: "TargetCharacterName", Text: Player.Name, MemberNumber: Player.MemberNumber}]} );
+			ServerSend("ChatRoomChat", { Content: "ActionGrabbedToServeDrinks", Type: "Action", Dictionary: [{ Tag: "TargetCharacterName", Text: Player.Name, MemberNumber: Player.MemberNumber }] });
 			ElementRemove("InputChat");
 			ElementRemove("TextAreaChatLog");
 			ServerSend("ChatRoomLeave", "");
@@ -1241,8 +1244,8 @@ function ChatRoomSetRule(data) {
 // When a slave gives her salary to her owner
 function ChatRoomGiveMoneyForOwner() {
 	if (ChatRoomCanGiveMoneyForOwner()) {
-		ServerSend("ChatRoomChat", { Content: "ActionGiveEnvelopeToOwner", Type: "Action", Dictionary: [{Tag: "TargetCharacterName", Text: Player.Name, MemberNumber: Player.MemberNumber}]} );
-		ServerSend("ChatRoomChat", { Content: "PayQuest" + ChatRoomMoneyForOwner.toString(), Type: "Hidden", Target: CurrentCharacter.MemberNumber } );
+		ServerSend("ChatRoomChat", { Content: "ActionGiveEnvelopeToOwner", Type: "Action", Dictionary: [{ Tag: "TargetCharacterName", Text: Player.Name, MemberNumber: Player.MemberNumber }] });
+		ServerSend("ChatRoomChat", { Content: "PayQuest" + ChatRoomMoneyForOwner.toString(), Type: "Hidden", Target: CurrentCharacter.MemberNumber });
 		ChatRoomMoneyForOwner = 0;
 		DialogLeave();
 	}
@@ -1272,7 +1275,7 @@ function ChatRoomSafeword() {
 		CharacterSetActivePose(Player, ChatSearchSafewordPose);
 		CharacterRefresh(Player);
 		ChatRoomCharacterUpdate(Player);
-		ServerSend("ChatRoomChat", { Content: "ActionActivateSafeword", Type: "Action", Dictionary: [{Tag: "SourceCharacter", Text: Player.Name}] });
+		ServerSend("ChatRoomChat", { Content: "ActionActivateSafeword", Type: "Action", Dictionary: [{ Tag: "SourceCharacter", Text: Player.Name }] });
 		if (Player.ItemPermission < 3) {
 			Player.ItemPermission = 3;
 			ServerSend("AccountUpdate", { ItemPermission: Player.ItemPermission });


### PR DESCRIPTION
# Summary
When a player changes clothes, applies a restraint or activates the whisper function (for example), the text input field looses its focus and the player has to actively click into it, before entering their chat message.
This change catches the keyDown event and activates the text area before sending the key there, thus helping the game flow.

# What it does
* added an if statement to `ChatRoomKeyDown` in the `ChatRoom` script that transfers focus to the text area

# Testing
* tested it locally with one player, as this only changes the client behavior