### PR TITLE
Bugfix: Fix for the extended item script when a Property is present without a Type

### DIFF
--- a/BondageClub/Scripts/ExtendedItem.js
+++ b/BondageClub/Scripts/ExtendedItem.js
@@ -30,12 +30,14 @@ var ExtendedItemOffsets = {};
 
 /**
  * Loads the item extension properties
- * @param {ExtendedItemOption[]} Options - An Array of type definitions for each allowed extended type
+ * @param {ExtendedItemOption[]} Options - An Array of type definitions for each allowed extended type. The first item in the array should
+ *     be the default option.
  * @param {string} DialogKey - The dialog key for the message to display prompting the player to select an extended type
  * @returns {void} Nothing
  */
 function ExtendedItemLoad(Options, DialogKey) {
 	if (!DialogFocusItem.Property) {
+		// Default to the first option if no property is set
 		DialogFocusItem.Property = Options[0].Property;
 	}
 
@@ -48,7 +50,8 @@ function ExtendedItemLoad(Options, DialogKey) {
 
 /**
  * Draws the extended item type selection screen
- * @param {ExtendedItemOption[]} Options - An Array of type definitions for each allowed extended type
+ * @param {ExtendedItemOption[]} Options - An Array of type definitions for each allowed extended type. The first item in the array should
+ *     be the default option.
  * @param {string} DialogPrefix - The prefix to the dialog keys for the display strings describing each extended type.
  *     The full dialog key will be <Prefix><Option.Name>
  * @returns {void} Nothing
@@ -77,12 +80,13 @@ function ExtendedItemDraw(Options, DialogPrefix) {
 
 /**
  * Handles clicks on the extended item type selection screen
- * @param {ExtendedItemOption[]} Options - An Array of type definitions for each allowed extended type
+ * @param {ExtendedItemOption[]} Options - An Array of type definitions for each allowed extended type. The first item in the array should
+ *     be the default option.
  * @returns {void} Nothing
  */
 function ExtendedItemClick(Options) {
 	// Exit button
-	if (MouseX >= 1885 && MouseX <= 1975 && MouseY >= 25 && MouseY <= 110) {
+	if (CommonIsClickAt(1885, 25, 90, 85)) {
 		DialogFocusItem = null;
 		return;
 	}
@@ -98,7 +102,8 @@ function ExtendedItemClick(Options) {
 
 /**
  * Handler function for setting the type of an extended item
- * @param {ExtendedItemOption[]} Options - An Array of type definitions for each allowed extended type
+ * @param {ExtendedItemOption[]} Options - An Array of type definitions for each allowed extended type. The first item in the array should
+ *     be the default option.
  * @param {ExtendedItemOption} Option - The selected type definition
  * @returns {void} Nothing
  */
@@ -117,11 +122,13 @@ function ExtendedItemSetType(Options, Option) {
 		// Call the item's load function
 		CommonCallFunctionByName(FunctionPrefix + "Load");
 	}
-	var PreviousType = DialogFocusItem.Property.Type;
+	// Default the previous Property and Type to the first option if not found on the current item
+	var PreviousProperty = DialogFocusItem.Property || Options[0].Property;
+	var PreviousType = PreviousProperty.Type || Options[0].Property.Type;
 	var PreviousOption = Options.find(O => O.Property.Type === PreviousType);
 
 	// Create a new Property object based on the previous one
-	var NewProperty = Object.assign({}, DialogFocusItem.Property);
+	var NewProperty = Object.assign({}, PreviousProperty);
 	// Delete properties added by the previous option
 	Object.keys(PreviousOption.Property).forEach(key => delete NewProperty[key]);
 	// Clone the new properties and use them to extend the existing properties
@@ -155,7 +162,8 @@ function ExtendedItemSetType(Options, Option) {
 
 /**
  * Draws the extended item type selection screen when there are only two options
- * @param {ExtendedItemOption[]} Options - An Array of type definitions for each allowed extended type
+ * @param {ExtendedItemOption[]} Options - An Array of type definitions for each allowed extended type. The first item in the array should
+ *     be the default option.
  * @param {string} DialogPrefix - The prefix to the dialog keys for the display strings describing each extended type.
  *     The full dialog key will be <Prefix><Option.Name>
  * @param {boolean} IsSelfBondage - Whether or not the player is applying the item to themselves
@@ -179,7 +187,8 @@ function ExtendedItemDrawTwo(Options, DialogPrefix, IsSelfBondage) {
 /**
  * Draws the extended item type selection screen when there are more than two options. Options will be paginated if necessary, with four
  * options drawn per page in a 2x2 grid
- * @param {ExtendedItemOption[]} Options - An Array of type definitions for each allowed extended type
+ * @param {ExtendedItemOption[]} Options - An Array of type definitions for each allowed extended type. The first item in the array should
+ *     be the default option.
  * @param {string} DialogPrefix - The prefix to the dialog keys for the display strings describing each extended type.
  *     The full dialog key will be <Prefix><Option.Name>
  * @param {boolean} IsSelfBondage - Whether or not the player is applying the item to themselves
@@ -204,7 +213,8 @@ function ExtendedItemDrawGrid(Options, DialogPrefix, IsSelfBondage) {
 
 /**
  * Handles clicks on the extended item type selection screen when there are only two options
- * @param {ExtendedItemOption[]} Options - An Array of type definitions for each allowed extended type
+ * @param {ExtendedItemOption[]} Options - An Array of type definitions for each allowed extended type. The first item in the array should
+ *     be the default option.
  * @param {boolean} IsSelfBondage - Whether or not the player is applying the item to themselves
  * @returns {void} Nothing
  */
@@ -213,7 +223,7 @@ function ExtendedItemClickTwo(Options, IsSelfBondage) {
 		var X = 1175 + I * 425;
 		var Y = 550;
 		var Option = Options[I];
-		if (MouseX >= X && MouseX <= X + 225 && MouseY >= Y && MouseY <= Y + 225 && DialogFocusItem.Property.Type !== Option.Property.Type) {
+		if (CommonIsClickAt(X, Y, 225, 225) && DialogFocusItem.Property.Type !== Option.Property.Type) {
 			ExtendedItemHandleOptionClick(Options, Option, IsSelfBondage);
 		}
 	}
@@ -221,13 +231,14 @@ function ExtendedItemClickTwo(Options, IsSelfBondage) {
 
 /**
  * Handles clicks on the extended item type selection screen when there are more than two options
- * @param {ExtendedItemOption[]} Options - An Array of type definitions for each allowed extended type
+ * @param {ExtendedItemOption[]} Options - An Array of type definitions for each allowed extended type. The first item in the array should
+ *     be the default option.
  * @param {boolean} IsSelfBondage - Whether or not the player is applying the item to themselves
  * @returns {void} Nothing
  */
 function ExtendedItemClickGrid(Options, IsSelfBondage) {
 	// Pagination button
-	if (Options.length > 4 && MouseX >= 1775 && MouseX <= 1865 && MouseY >= 25 && MouseY <= 110) {
+	if (Options.length > 4 && CommonIsClickAt(1775, 25, 90, 85)) {
 		ExtendedItemNextPage(InventoryItemArmsWebOptions);
 	}
 
@@ -238,7 +249,7 @@ function ExtendedItemClickGrid(Options, IsSelfBondage) {
 		var X = 1200 + (offset % 2 * 387);
 		var Y = 450 + (Math.floor(offset / 2) * 300);
 		var Option = Options[I];
-		if (MouseX >= X && MouseX <= X + 225 && MouseY >= Y && MouseY <= Y + 225 && DialogFocusItem.Property.Type !== Option.Property.Type) {
+		if (CommonIsClickAt(X, Y, 225, 225) && DialogFocusItem.Property.Type !== Option.Property.Type) {
 			ExtendedItemHandleOptionClick(Options, Option, IsSelfBondage);
 		}
 	}
@@ -246,7 +257,8 @@ function ExtendedItemClickGrid(Options, IsSelfBondage) {
 
 /**
  * Handler function called when an option on the type selection screen is clicked
- * @param {ExtendedItemOption[]} Options - An Array of type definitions for each allowed extended type
+ * @param {ExtendedItemOption[]} Options - An Array of type definitions for each allowed extended type. The first item in the array should
+ *     be the default option.
  * @param {ExtendedItemOption} Option - The selected type definition
  * @param {boolean} IsSelfBondage - Whether or not the player is applying the item to themselves
  * @returns {void} Nothing
@@ -317,7 +329,8 @@ function ExtendedItemSetOffset(Offset) {
 /**
  * Switches the pagination offset to the next page for the currently focused extended item. If the new offset is greater
  * than the number of available options, the offset will be reset to zero, wrapping back to the first page.
- * @param {ExtendedItemOption[]} Options - An Array of type definitions for each allowed extended type
+ * @param {ExtendedItemOption[]} Options - An Array of type definitions for each allowed extended type. The first item in the array should
+ *     be the default option.
  * @returns {void} Nothing
  */
 function ExtendedItemNextPage(Options) {


### PR DESCRIPTION
# Summary

This PR makes a few small improvements to the extended item script:
* Adds handling for when an extended item has a `Property` but not `Property.Type` - this fixes a bug with the dildo plug gag (reproduction steps below)
* Replaces usages of `MouseX`/`MouseY` bounds checking with the `CommonIsClickAt` function
* Updates some of the JSDoc to clarify the script's behaviour

# Steps to reproduce

1. Add a dildo plug gag to a character (can be yourself or another character)
2. Exit the extended item menu (do not select an option)
3. Lock the dildo plug gag
4. Enter the extended item menu and attempt to select an option
5. Note that selecting the option doesn't work

The following error is shown in the console:
```
ExtendedItem.js:126 Uncaught TypeError: Cannot read property 'Property' of undefined
    at ExtendedItemSetType (ExtendedItem.js:126)
    at ExtendedItemHandleOptionClick (ExtendedItem.js:259)
    at ExtendedItemClickTwo (ExtendedItem.js:217)
    at ExtendedItemClick (ExtendedItem.js:93)
    at InventoryItemMouthDildoPlugGagClick (DildoPlugGag.js:32)
    at CommonDynamicFunction (Common.js:237)
    at DialogClick (Dialog.js:1143)
    at CommonClick (Common.js:202)
    at Click ((index):303)
    at HTMLCanvasElement.onclick ((index):345)
```
