### PR TITLE
Fix: Framerate in the tennis mini game

### DIFF
--- a/BondageClub/Screens/MiniGame/Tennis/Tennis.js
+++ b/BondageClub/Screens/MiniGame/Tennis/Tennis.js
@@ -87,7 +87,7 @@ function TennisRun() {
 			DrawText(TextGet("StartsIn") + " " + (5 - Math.floor(MiniGameTimer / 1000)).toString(), 1000, 600, "black");
 		} else {
 						
-			// Moves the ball the way a 60FPS monitor would if we are above 60FPS
+			// Checks for the frame ratio to keep the ball from moving too fast if the game is running above 60 FPS
 			var TennisCurrentFrame = performance.now();
 			var FrameRatio = 1;
 			if (TennisLastFrame != null && TennisCurrentFrame - TennisLastFrame <= 16.666667) {

--- a/BondageClub/Screens/MiniGame/Tennis/Tennis.js
+++ b/BondageClub/Screens/MiniGame/Tennis/Tennis.js
@@ -11,7 +11,6 @@ var TennisBallY = 500;
 var TennisBallSpeed = 100;
 /** Angle of the ball.  Angle is in radians (0 is right, PI / 2 is up, PI is left, 3 PI / 2 is down)*/
 var TennisBallAngle = 0;
-var TennisLastFrame = null;
 
 /**
  * Called when a player servers, the angle can vary by 45 degrees up or down
@@ -86,20 +85,11 @@ function TennisRun() {
 			DrawText(TextGet("Intro2"), 1000, 500, "black");
 			DrawText(TextGet("StartsIn") + " " + (5 - Math.floor(MiniGameTimer / 1000)).toString(), 1000, 600, "black");
 		} else {
-						
-			// Checks for the frame ratio to keep the ball from moving too fast if the game is running above 60 FPS
-			var TennisCurrentFrame = performance.now();
-			var FrameRatio = 1;
-			if (TennisLastFrame != null && TennisCurrentFrame - TennisLastFrame <= 16.666667) {
-				// Determine the speed ratio based on the framerate (Delta/ 1/60fps)
-				FrameRatio = (TennisCurrentFrame - TennisLastFrame) / 16.666667;
-			}
-			TennisLastFrame = TennisCurrentFrame;
 			
 			// Moves the ball
-			TennisBallX = TennisBallX + ((Math.cos(TennisBallAngle) * TennisBallSpeed / TimerRunInterval) * FrameRatio);
-			TennisBallY = TennisBallY - ((Math.sin(TennisBallAngle) * TennisBallSpeed / TimerRunInterval) * FrameRatio);
-
+			TennisBallX += Math.cos(TennisBallAngle) * (TennisBallSpeed / 20) * (TimerRunInterval / 16.6667);
+			TennisBallY -= Math.sin(TennisBallAngle) * (TennisBallSpeed / 20) * (TimerRunInterval / 16.6667);
+			
 			// Moves the player and opponent racket, the opponent speeds up with difficulty, tracks the ball in defense, go back toward the middle in offense
 			if ((MouseY >= 0) && (MouseY <= 999)) TennisCharacterLeftRacket = MouseY;
 			if ((Math.cos(TennisBallAngle) > 0) && (TennisBallY > TennisCharacterRightRacket + 55)) TennisCharacterRightRacket = TennisCharacterRightRacket + (MiniGameDifficultyRatio / TimerRunInterval);
@@ -159,8 +149,6 @@ function TennisRun() {
 		}
 
 	} else {
-		
-		TennisLastFrame = null;
 		
 		// Draw the end message
 		if (MiniGameVictory && (TennisCharacterRightPoint == 0)) DrawText(TextGet("Perfect"), 1000, 400, "black");

--- a/BondageClub/Screens/MiniGame/Tennis/Tennis.js
+++ b/BondageClub/Screens/MiniGame/Tennis/Tennis.js
@@ -98,7 +98,7 @@ function TennisRun() {
 			
 			// Moves the ball
 			TennisBallX = TennisBallX + ((Math.cos(TennisBallAngle) * TennisBallSpeed / TimerRunInterval) * FrameRatio);
-			TennisBallY = TennisBallY - ((Math.cos(TennisBallAngle) * TennisBallSpeed / TimerRunInterval) * FrameRatio);
+			TennisBallY = TennisBallY - ((Math.sin(TennisBallAngle) * TennisBallSpeed / TimerRunInterval) * FrameRatio);
 
 			// Moves the player and opponent racket, the opponent speeds up with difficulty, tracks the ball in defense, go back toward the middle in offense
 			if ((MouseY >= 0) && (MouseY <= 999)) TennisCharacterLeftRacket = MouseY;

--- a/BondageClub/Screens/MiniGame/Tennis/Tennis.js
+++ b/BondageClub/Screens/MiniGame/Tennis/Tennis.js
@@ -120,11 +120,11 @@ function TennisRun() {
 			// If the racket hits the ball, we bounce it at an angle linked to the racket vs ball Y position
 			if ((Math.cos(TennisBallAngle) < 0) && (TennisBallX >= 500) && (TennisBallX <= 550) && (TennisBallY >= TennisCharacterLeftRacket - 110) && (TennisBallY <= TennisCharacterLeftRacket + 110)) {
 				TennisBallAngle = (Math.PI * 0.4 * ((TennisCharacterLeftRacket - TennisBallY) / 110));
-				TennisBallSpeed = TennisBallSpeed + 20;
+				TennisBallSpeed = TennisBallSpeed + (20 * FrameRatio);
 			}
 			if ((Math.cos(TennisBallAngle) > 0) && (TennisBallX >= 1450) && (TennisBallX <= 1500) && (TennisBallY >= TennisCharacterRightRacket - 110) && (TennisBallY <= TennisCharacterRightRacket + 110)) {
 				TennisBallAngle = Math.PI + (Math.PI * 0.4 * ((TennisBallY - TennisCharacterRightRacket) / 110));
-				TennisBallSpeed = TennisBallSpeed + 20;
+				TennisBallSpeed = TennisBallSpeed + (20 * FrameRatio);
 			}
 			
 			// Shows the rackets and ball

--- a/BondageClub/Screens/MiniGame/Tennis/Tennis.js
+++ b/BondageClub/Screens/MiniGame/Tennis/Tennis.js
@@ -11,6 +11,7 @@ var TennisBallY = 500;
 var TennisBallSpeed = 100;
 /** Angle of the ball.  Angle is in radians (0 is right, PI / 2 is up, PI is left, 3 PI / 2 is down)*/
 var TennisBallAngle = 0;
+var TennisLastFrame = null;
 
 /**
  * Called when a player servers, the angle can vary by 45 degrees up or down
@@ -86,6 +87,17 @@ function TennisRun() {
 			DrawText(TextGet("StartsIn") + " " + (5 - Math.floor(MiniGameTimer / 1000)).toString(), 1000, 600, "black");
 		} else {
 						
+			// Skip a frame if we are going higher than 60FPS to avoid issues on 144hz monitors, we skip a frame if the game is going too fast
+			var TennisCurrentFrame = performance.now();
+			if (TennisLastFrame != null && TennisCurrentFrame - TennisLastFrame <= 16.6) {
+				// Shows the rackets and ball again, they wont have moved
+				DrawImage("Screens/" + CurrentModule + "/" + CurrentScreen + "/RacketLeft.png", 500, TennisCharacterLeftRacket - 75);
+				DrawImage("Screens/" + CurrentModule + "/" + CurrentScreen + "/RacketRight.png", 1450, TennisCharacterRightRacket - 75);
+				DrawImage("Screens/" + CurrentModule + "/" + CurrentScreen + "/TennisBall.png", TennisBallX - 20, TennisBallY - 20);
+				return;
+			}
+			TennisLastFrame = TennisCurrentFrame;
+			
 			// Moves the ball
 			TennisBallX = TennisBallX + Math.cos(TennisBallAngle) * TennisBallSpeed / TimerRunInterval;
 			TennisBallY = TennisBallY - Math.sin(TennisBallAngle) * TennisBallSpeed / TimerRunInterval;

--- a/BondageClub/Screens/MiniGame/Tennis/Tennis.js
+++ b/BondageClub/Screens/MiniGame/Tennis/Tennis.js
@@ -159,7 +159,9 @@ function TennisRun() {
 		}
 
 	} else {
-
+		
+		TennisLastFrame = null;
+		
 		// Draw the end message
 		if (MiniGameVictory && (TennisCharacterRightPoint == 0)) DrawText(TextGet("Perfect"), 1000, 400, "black");
 		else if (MiniGameVictory) DrawText(TextGet("Victory"), 1000, 400, "black");

--- a/BondageClub/Screens/MiniGame/Tennis/Tennis.js
+++ b/BondageClub/Screens/MiniGame/Tennis/Tennis.js
@@ -87,20 +87,18 @@ function TennisRun() {
 			DrawText(TextGet("StartsIn") + " " + (5 - Math.floor(MiniGameTimer / 1000)).toString(), 1000, 600, "black");
 		} else {
 						
-			// Skip a frame if we are going higher than 60FPS to avoid issues on 144hz monitors, we skip a frame if the game is going too fast
+			// Moves the ball the way a 60FPS monitor would if we are above 60FPS
 			var TennisCurrentFrame = performance.now();
-			if (TennisLastFrame != null && TennisCurrentFrame - TennisLastFrame <= 16.6) {
-				// Shows the rackets and ball again, they wont have moved
-				DrawImage("Screens/" + CurrentModule + "/" + CurrentScreen + "/RacketLeft.png", 500, TennisCharacterLeftRacket - 75);
-				DrawImage("Screens/" + CurrentModule + "/" + CurrentScreen + "/RacketRight.png", 1450, TennisCharacterRightRacket - 75);
-				DrawImage("Screens/" + CurrentModule + "/" + CurrentScreen + "/TennisBall.png", TennisBallX - 20, TennisBallY - 20);
-				return;
+			var FrameRatio = 1;
+			if (TennisLastFrame != null && TennisCurrentFrame - TennisLastFrame <= 16.666667) {
+				// Determine the speed ratio based on the framerate (Delta/ 1/60fps)
+				FrameRatio = (TennisCurrentFrame - TennisLastFrame) / 16.666667;
 			}
 			TennisLastFrame = TennisCurrentFrame;
 			
 			// Moves the ball
-			TennisBallX = TennisBallX + Math.cos(TennisBallAngle) * TennisBallSpeed / TimerRunInterval;
-			TennisBallY = TennisBallY - Math.sin(TennisBallAngle) * TennisBallSpeed / TimerRunInterval;
+			TennisBallX = TennisBallX + (Math.cos(TennisBallAngle) * TennisBallSpeed * FrameRatio) / TimerRunInterval;
+			TennisBallY = TennisBallY - (Math.sin(TennisBallAngle) * TennisBallSpeed * FrameRatio) / TimerRunInterval;
 
 			// Moves the player and opponent racket, the opponent speeds up with difficulty, tracks the ball in defense, go back toward the middle in offense
 			if ((MouseY >= 0) && (MouseY <= 999)) TennisCharacterLeftRacket = MouseY;

--- a/BondageClub/Screens/MiniGame/Tennis/Tennis.js
+++ b/BondageClub/Screens/MiniGame/Tennis/Tennis.js
@@ -97,8 +97,8 @@ function TennisRun() {
 			TennisLastFrame = TennisCurrentFrame;
 			
 			// Moves the ball
-			TennisBallX = TennisBallX + (Math.cos(TennisBallAngle) * TennisBallSpeed * FrameRatio) / TimerRunInterval;
-			TennisBallY = TennisBallY - (Math.sin(TennisBallAngle) * TennisBallSpeed * FrameRatio) / TimerRunInterval;
+			TennisBallX = TennisBallX + ((Math.cos(TennisBallAngle) * TennisBallSpeed / TimerRunInterval) * FrameRatio);
+			TennisBallY = TennisBallY - ((Math.cos(TennisBallAngle) * TennisBallSpeed / TimerRunInterval) * FrameRatio);
 
 			// Moves the player and opponent racket, the opponent speeds up with difficulty, tracks the ball in defense, go back toward the middle in offense
 			if ((MouseY >= 0) && (MouseY <= 999)) TennisCharacterLeftRacket = MouseY;
@@ -120,11 +120,11 @@ function TennisRun() {
 			// If the racket hits the ball, we bounce it at an angle linked to the racket vs ball Y position
 			if ((Math.cos(TennisBallAngle) < 0) && (TennisBallX >= 500) && (TennisBallX <= 550) && (TennisBallY >= TennisCharacterLeftRacket - 110) && (TennisBallY <= TennisCharacterLeftRacket + 110)) {
 				TennisBallAngle = (Math.PI * 0.4 * ((TennisCharacterLeftRacket - TennisBallY) / 110));
-				TennisBallSpeed = TennisBallSpeed + (20 * FrameRatio);
+				TennisBallSpeed = TennisBallSpeed + 20;
 			}
 			if ((Math.cos(TennisBallAngle) > 0) && (TennisBallX >= 1450) && (TennisBallX <= 1500) && (TennisBallY >= TennisCharacterRightRacket - 110) && (TennisBallY <= TennisCharacterRightRacket + 110)) {
 				TennisBallAngle = Math.PI + (Math.PI * 0.4 * ((TennisBallY - TennisCharacterRightRacket) / 110));
-				TennisBallSpeed = TennisBallSpeed + (20 * FrameRatio);
+				TennisBallSpeed = TennisBallSpeed + 20;
 			}
 			
 			// Shows the rackets and ball

--- a/BondageClub/Scripts/Timer.js
+++ b/BondageClub/Scripts/Timer.js
@@ -1,8 +1,8 @@
 "use strict";
 var CurrentTime = 0;
 var TimerRunInterval = 20;
-var TimerCycle = 0;
 var TimerLastTime = CommonTime();
+var TimerLastCycleCall = 0;
 var TimerLastArousalProgress = 0;
 var TimerLastArousalProgressCount = 0;
 var TimerLastArousalDecay = 0;
@@ -136,11 +136,11 @@ function TimerProcess(Timestamp) {
 	TimerLastTime = Timestamp;
 	CurrentTime = CurrentTime + TimerRunInterval;
 
-	// At each 100 cycles, we check for timed events
-	TimerCycle++;
-	if (TimerCycle % 100 == 0) {
+	// At each 1700 ms, we check for timed events (equivalent of 100 cycles at 60FPS)
+	if (TimerLastCycleCall + 1700 <= CurrentTime) {
 		TimerInventoryRemove();
 		TimerPrivateOwnerBeep();
+		TimerLastCycleCall = CurrentTime;
 	}
 
 	// Arousal/Activity events only occur in allowed rooms


### PR DESCRIPTION
- fixed an issue with 144hz monitor and the tennis minigame

The current tennis minigame moves the ball forward with every frame, causing it to move WAY too fast on 144hz monitors. I dont have one myself but I've tested with a 30FPS  cap on 60FPS, and the ratio method makes it so the ball moves smoothly. This makes the minigame playable when the current  FPS is higher than ~60.

At first I wanted to skip a frame, but that actually didn't look smooth. Capping the club to 60FPS would have been an option, but I don't think it would have been needed.

If there are other games affected by this, a similar fix should work. I'm not knowledgeable in singleplayer stuff, so if anyone mentions them, I can have a look.