### PR TITLE
Improvement: Prevents null fields from being sent in chatroom item updates

### DIFF
--- a/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
+++ b/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
@@ -589,10 +589,10 @@ function ChatRoomCharacterItemUpdate(C, Group) {
 		var P = {};
 		P.Target = C.MemberNumber;
 		P.Group = Group;
-		P.Name = (Item != null) ? Item.Asset.Name : null;
+		P.Name = (Item != null) ? Item.Asset.Name : undefined;
 		P.Color = ((Item != null) && (Item.Color != null)) ? Item.Color : "Default";
 		P.Difficulty = SkillGetWithRatio("Bondage");
-		P.Property = ((Item != null) && (Item.Property != null)) ? Item.Property : null;
+		P.Property = ((Item != null) && (Item.Property != null)) ? Item.Property : undefined;
 		ServerSend("ChatRoomCharacterItemUpdate", P);
 	}
 }


### PR DESCRIPTION
# Summary

This change was mostly prompted by the comments on #1115.

This makes some minor optimisations to the `ChatRoomCharacterItemUpdate` function by setting fields to `undefined` rather than `null` if they should not be set. This will prevent the field from being sent in the websocket message. I've tested this in as many ways as I can think of and not seen any unexpected behaviour. I've included before/after examples of the websocket message changes below - these are all recorded from the actual websocket messages being sent by my browser. As you can see, this reduces the message size on item additions, removals and updates, and as far as I've seen, doesn't cause any issues with gameplay.

Note that the changes in #1115 will only send the `Property` field when the `CharacterRestricted` is present on an added asset - `Property` will not be sent (even as `null`) for other items.

## Item addition

### Before

```json
[
    "ChatRoomCharacterItemUpdate",
    {
        "Target": 1,
        "Group": "ItemArms",
        "Name": "LeatherArmbinder",
        "Color": "#404040",
        "Difficulty": 10,
        "Property": null
    }
]
```

### After

```json
[
    "ChatRoomCharacterItemUpdate",
    {
        "Target": 1,
        "Group": "ItemArms",
        "Name": "LeatherArmbinder",
        "Color": "#404040",
        "Difficulty": 10
    }
]
```

## Item Removal

### Before

```json
[
    "ChatRoomCharacterItemUpdate",
    {
        "Target": 1,
        "Group": "ItemArms",
        "Name": null,
        "Color": "Default",
        "Difficulty": 10,
        "Property": null
    }
]
```

### After

```json
[
    "ChatRoomCharacterItemUpdate",
    {
        "Target": 1,
        "Group": "ItemArms",
        "Color": "Default",
        "Difficulty": 10
    }
]
```

## Item Change

### Before

```json
[
    "ChatRoomCharacterItemUpdate",
    {
        "Target": 1,
        "Group": "ItemArms",
        "Name": "LeatherArmbinder",
        "Color": "#404040",
        "Difficulty": 10,
        "Property": null
    }
]
```

### After

```json
[
    "ChatRoomCharacterItemUpdate",
    {
        "Target": 1,
        "Group": "ItemArms",
        "Name": "LeatherArmbinder",
        "Color": "#404040",
        "Difficulty": 10
    }
]
```