### PR TITLE
Difficulty Consistency Fix

### DIFF
--- a/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
+++ b/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
@@ -596,7 +596,7 @@ function ChatRoomCharacterItemUpdate(C, Group) {
 		P.Group = Group;
 		P.Name = (Item != null) ? Item.Asset.Name : undefined;
 		P.Color = ((Item != null) && (Item.Color != null)) ? Item.Color : "Default";
-		P.Difficulty = SkillGetWithRatio("Bondage");
+		P.Difficulty = Item != null ? (Item.Difficulty - Item.Asset.Difficulty) : SkillGetWithRatio("Bondage");
 		P.Property = ((Item != null) && (Item.Property != null)) ? Item.Property : undefined;
 		ServerSend("ChatRoomCharacterItemUpdate", P);
 	}


### PR DESCRIPTION
When an applied item is updated through ChatRoomCharacterItemUpdate, the difficulty is refreshed using the player's bondage skill. However this player may not have applied the item originally and will often be just adding a lock or changing the colour, making the base escape difficulty quietly increase or decrease when we'd expect it to stay the same. (Note: difficulty increases from locks are not stored in this number).

You can recreate this easily by having A tie B, then having C with a different bondage skill to A make any trivial change to the item. The escape difficulty changes.

I couldn't see any cases where we actually want this difficulty change to happen. I've changed the formula to be the difference between the asset difficulty and applied difficulty (original skill + asset difficulty) to ensure the skill-based difficulty is not changed by item updates. I've tested cases such as the Bondage bench which calls the function directly and the resulting numbers all looked consistent.