### PR TITLE
Bugfix: Ensures spanking toys are always drawn on initial equip

### DIFF
--- a/BondageClub/Screens/Inventory/ItemHands/SpankingToys/SpankingToy.js
+++ b/BondageClub/Screens/Inventory/ItemHands/SpankingToys/SpankingToy.js
@@ -90,7 +90,10 @@ var SpankingPlayerInventory;
 // Loads the item extension properties
 function InventoryItemHandsSpankingToysLoad() {
 	SpankingPlayerInventory = SpankingInventory.filter(x => Player.Inventory.map(i => i.Name).includes("SpankingToys" + x.Name));
-	if (DialogFocusItem.Property == null) DialogFocusItem.Property = { Type: "Crop" };
+	if (DialogFocusItem.Property == null) {
+		DialogFocusItem.Property = { Type: "Crop" };
+		CharacterRefresh(CharacterGetCurrent(), false);
+	}
 	if (SpankingPlayerInventory.length > 6) SpankingNextButton = true;
 }
 


### PR DESCRIPTION
## Summary

This fixes a bug where equipping a spanking toy on another player would not initially draw the toy (the crop in the case of initial equip).

## Steps to reproduce

1. Enter a chatroom with another character
2. Equip a spanking toy on the other character, but do not select another toy type
3. Note that the toy does not get drawn