### PR TITLE
Improvement: CommonWait

### DIFF
--- a/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
+++ b/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
@@ -1105,8 +1105,7 @@ function ChatRoomListManage(Operation, ListType) {
 		var data = {};
 		data[ListType] = Player[ListType];
 		ServerSend("AccountUpdate", data);
-		CommonWait(1000);
-		ChatRoomCharacterUpdate(Player);
+		setTimeout(() => ChatRoomCharacterUpdate(Player), 5000);
 	}
 	if (ListType == "GhostList") ChatRoomListManage(Operation, "BlackList");
 }
@@ -1118,8 +1117,7 @@ function ChatRoomListManipulation(Add, Remove, Message) {
 		if ((Add != null) && (Add.indexOf(C) < 0)) Add.push(C);
 		if ((Remove != null) && (Remove.indexOf(C) >= 0)) Remove.splice(Remove.indexOf(C), 1);
 		ServerSend("AccountUpdate", { FriendList: Player.FriendList, GhostList: Player.GhostList, WhiteList: Player.WhiteList, BlackList: Player.BlackList });
-		CommonWait(1000);
-		ChatRoomCharacterUpdate(Player);
+		setTimeout(() => ChatRoomCharacterUpdate(Player), 5000);
 	}
 }
 
@@ -1291,8 +1289,7 @@ function ChatRoomSafeword() {
 		if (Player.ItemPermission < 3) {
 			Player.ItemPermission = 3;
 			ServerSend("AccountUpdate", { ItemPermission: Player.ItemPermission });
-			CommonWait(1000);
-			ChatRoomCharacterUpdate(Player);
+			setTimeout(() => ChatRoomCharacterUpdate(Player), 5000);
 		}
 	}
 }


### PR DESCRIPTION
- changed how the wait time was handled to avoid the club from freezing

currently, changing your lists freezes your club for a second on purpose which was a quick fix for item permissions. This increases the time to avoid conflicts and will remove the freeze to make it a lot less annoying. I still believe we should have some kind of response sent back to the server to do a proper async callback, but this can do for now.