### PR TITLE
Improvement: Thoughtful NPCs

### DIFF
--- a/BondageClub/Scripts/Inventory.js
+++ b/BondageClub/Scripts/Inventory.js
@@ -291,13 +291,16 @@ function InventoryWearRandom(C, GroupName, Difficulty) {
 				break;
 			}
 
-		// Builds a list of all possible items and use one
+		// Builds a list of all possible items and uses one of them, prevents the user from blocking everything to cheat
 		var List = [];
-		for (var A = 0; A < Asset.length; A++)
-			if ((Asset[A].Group.Name == GroupName) && Asset[A].Wear && Asset[A].Enable && Asset[A].Random && InventoryAllow(C, Asset[A].Prerequisite, false))
+		var ListWithPermission = [];
+		for (var A = 0; A < Asset.length; A++) 
+			if ((Asset[A].Group.Name == GroupName) && Asset[A].Wear && Asset[A].Enable && Asset[A].Random && InventoryAllow(C, Asset[A].Prerequisite, false)) {
 				List.push(Asset[A]);
+				if (C.ID == 0 && !InventoryIsPermissionBlocked(C, Asset[A].Name, Asset[A].Group.Name)) ListWithPermission.push(Asset[A]);
+			}
 		if (List.length == 0) return;
-		var RandomAsset = List[Math.floor(Math.random() * List.length)];
+		var RandomAsset = ListWithPermission.length > 0 ? ListWithPermission[Math.floor(Math.random() * ListWithPermission.length)] : List[Math.floor(Math.random() * List.length)];
 		CharacterAppearanceSetItem(C, GroupName, RandomAsset, RandomAsset.DefaultColor, Difficulty);
 		CharacterRefresh(C);
 


### PR DESCRIPTION
- made NPCs listen to the player's permissions

Currently, NPCs bypass blocked items which some players have complained about in the past. Any specific case can't necessarily be fixed, but at least all calls to the randomwear function will properly check and remove blocked items from the random pool which solves nearly all cases. 

Due to how the limited system works, I can't factor in limited items for NPCs.

This makes it so any blocked item will not be used UNLESS, there is nothing BUT a blocked item that can be used. This is not necessary, but I made it this way to prevent someone from cheating by blocking all restraints. If you think it is not needed, I can remove that concept and always remove blocked items from the pool. The odds that someone blocked all the basic items that could be used instead of blocked items is almost null, so I don't expect this to cause issue, it will only block cheating.

Let me know what you think