### PR TITLE
Improvement: Relog screen

### DIFF
--- a/BondageClub/Screens/Character/Relog/Relog.js
+++ b/BondageClub/Screens/Character/Relog/Relog.js
@@ -45,7 +45,7 @@ function RelogRun() {
 	
 	// Draw the relog controls
 	if (!LoginMessage) LoginUpdateMessage();
-	DrawText(LoginMessage, 1000, 150, "White", "Black");
+	if (LoginMessage != TextGet("EnterPassword")) DrawText(LoginMessage, 1000, 150, "White", "Black");
 	DrawText(TextGet("EnterPassword"), 1000, 230, "White", "Black");
 	DrawText(TextGet("Account") + "  " + Player.AccountName, 1000, 400, "White", "Black");
 	DrawText(TextGet("Password"), 1000, 500, "White", "Black");
@@ -60,8 +60,8 @@ function RelogRun() {
  * @returns {void} Nothing
  */
 function RelogClick() {
-	if ((MouseX >= 675) && (MouseX <= 975) && (MouseY >= 750) && (MouseY <= 810)) RelogSend(); // Log Back button
-	if ((MouseX >= 1025) && (MouseX <= 1325) && (MouseY >= 750) && (MouseY <= 810)) RelogExit(); // Give Up button
+	if (MouseIn(675, 750, 300, 60)) RelogSend(); // Log Back button
+	if (MouseIn(1025, 750, 300, 60)) RelogExit(); // Give Up button
 }
 
 /**

--- a/BondageClub/Screens/Room/MainHall/MainHall.js
+++ b/BondageClub/Screens/Room/MainHall/MainHall.js
@@ -43,6 +43,7 @@ function MainHallLoad() {
 	CommonReadCSV("NoArravVar", "Room", "AsylumEntrance", "Dialog_NPC_AsylumEntrance_KidnapNurse");
 	CommonReadCSV("NoArravVar", "Room", "AsylumEntrance", "Dialog_NPC_AsylumEntrance_EscapedPatient");
 	CommonReadCSV("NoArravVar", "Room", "Prison", "Dialog_NPC_Prison_Police");
+	CommonReadCSV("NoArravVar", "Character", "Relog", "Text_Relog");
 
 }
 


### PR DESCRIPTION
- preloaded the CSV for the reconnection screen in the main hall
- removed the possibility to show duplicate messages
- replaced click conditions to use MouseIn

Currently, the "Enter your password..." message displays twice if this is what the server sent back, so I added a check to avoid this from happening. 

Also, if you actually disconnect, the screen is just 3 white boxes because you fail to fetch the CSV, this fix makes it so when you run the main hall, it will fetch the CSV and cache it so you will have the text available if you DC later which will make sure the page displays properly in all cases of disconnections.