### PR TITLE
Fix: winking matching eyes

### DIFF
--- a/BondageClub/Scripts/Dialog.js
+++ b/BondageClub/Scripts/Dialog.js
@@ -1230,10 +1230,10 @@ function DialogClick() {
 			});
 		} else if (MouseIn(120, 50, 90, 90)) { 
 			var EyesExpression = WardrobeGetExpression(Player);
-			CharacterSetFacialExpression(Player, "Eyes1", (EyesExpression.Eyes == "Closed") ? EyesExpression.Eyes2 : "Closed");
+			CharacterSetFacialExpression(Player, "Eyes1", (EyesExpression.Eyes !== "Closed") ? "Closed" : (EyesExpression.Eyes2 !== "Closed" ? EyesExpression.Eyes2 : null));
 		} else if (MouseIn(220, 50, 90, 90)) { 
 			var EyesExpression = WardrobeGetExpression(Player);
-			CharacterSetFacialExpression(Player, "Eyes2", (EyesExpression.Eyes2 == "Closed") ? EyesExpression.Eyes : "Closed");
+			CharacterSetFacialExpression(Player, "Eyes2", (EyesExpression.Eyes2 !== "Closed") ? "Closed" : (EyesExpression.Eyes !== "Closed" ? EyesExpression.Eyes : null));
 		} else for (var I = 0; I < DialogFacialExpressions.length; I++) {
 			var FE = DialogFacialExpressions[I];
 			if ((MouseY >= 160 + 120 * I) && (MouseY <= (160 + 120 * I) + 90)) {

--- a/BondageClub/Scripts/Dialog.js
+++ b/BondageClub/Scripts/Dialog.js
@@ -1229,11 +1229,11 @@ function DialogClick() {
 				FE.CurrentExpression = null;
 			});
 		} else if (MouseIn(120, 50, 90, 90)) { 
-			var EyeExpression = WardrobeGetExpression(Player).Eyes;
-			CharacterSetFacialExpression(Player, "Eyes1", (EyeExpression == "Closed") ? null : "Closed");
+			var EyesExpression = WardrobeGetExpression(Player);
+			CharacterSetFacialExpression(Player, "Eyes1", (EyesExpression.Eyes == "Closed") ? EyesExpression.Eyes2 : "Closed");
 		} else if (MouseIn(220, 50, 90, 90)) { 
-			var EyeExpression = WardrobeGetExpression(Player).Eyes2;
-			CharacterSetFacialExpression(Player, "Eyes2", (EyeExpression == "Closed") ? null : "Closed");
+			var EyesExpression = WardrobeGetExpression(Player);
+			CharacterSetFacialExpression(Player, "Eyes2", (EyesExpression.Eyes2 == "Closed") ? EyesExpression.Eyes : "Closed");
 		} else for (var I = 0; I < DialogFacialExpressions.length; I++) {
 			var FE = DialogFacialExpressions[I];
 			if ((MouseY >= 160 + 120 * I) && (MouseY <= (160 + 120 * I) + 90)) {


### PR DESCRIPTION
- made it so the eye toggle actually maintains the same eye expression

I purposefully made it so you can't mix and match expressions because they don't work well together in the first place, but forgot the toggle would re-open this possibility. This fix makes it so instead of opening the eye, it just sets it to the same expression.

If both eyes are closed, it will just open them as normal to be a lot more user friendly and keep the intended design. 