### PR TITLE
Improvement: Clean up permissions

### DIFF
--- a/BondageClub/Screens/Character/Login/Login.js
+++ b/BondageClub/Screens/Character/Login/Login.js
@@ -237,6 +237,22 @@ function LoginValideBuyGroups() {
 }
 
 /**
+ * Checks if the player arrays contains any item that does not exists and saves them.
+ * @returns {void} Nothing
+ */
+function LoginValidateArrays() { 
+	var Result = AssetCleanArray([Player.BlockItems, Player.LimitedItems]);
+	if (Result[0].length != Player.BlockItems.length) { 
+		Player.BlockItems = Result[0];
+		ServerSend("AccountUpdate", { BlockItems: Player.BlockItems });
+	}
+	if (Result[1].length != Player.LimitedItems.length) { 
+		Player.LimitedItems = Result[1];
+		ServerSend("AccountUpdate", { LimitedItems: Player.LimitedItems });
+	}
+}
+
+/**
  * Handles player login response data
  * @param {Character | string} C - The Login response data - this will either be the player's character data if the
  * login was successful, or a string error message if the login failed.
@@ -352,6 +368,7 @@ function LoginResponse(C) {
 			LoginStableItems();
 			LoginLoversItems();
 			LoginValideBuyGroups();
+			LoginValidateArrays();
 			CharacterAppearanceValidate(Player);
 
 			// If the player must log back in the cell

--- a/BondageClub/Screens/Character/Login/Login.js
+++ b/BondageClub/Screens/Character/Login/Login.js
@@ -237,27 +237,6 @@ function LoginValideBuyGroups() {
 }
 
 /**
- * Checks if the player arrays contains any item that does not exists and saves them.
- * @returns {void} Nothing
- */
-function LoginValidateArrays() { 
-	var Result = AssetCleanArray([Player.BlockItems, Player.OptedItems, Player.LimitedItems]);
-	if (Result[0].length != Player.BlockItems) { 
-		Player.BlockItems = Result[0];
-		ServerSend("AccountUpdate", { BlockItems: Player.BlockItems });
-	}
-	if (Result[1].length != Player.OptedItems) { 
-		Player.OptedItems = Result[1];
-		ServerSend("AccountUpdate", { OptedItems: Player.OptedItems });
-	}
-	if (Result[2].length != Player.LimitedItems) { 
-		Player.LimitedItems = Result[2];
-		ServerSend("AccountUpdate", { LimitedItems: Player.LimitedItems });
-	}
-	
-}
-
-/**
  * Handles player login response data
  * @param {Character | string} C - The Login response data - this will either be the player's character data if the
  * login was successful, or a string error message if the login failed.
@@ -306,9 +285,8 @@ function LoginResponse(C) {
 			WardrobeFixLength();
 			Player.OnlineID = C.ID.toString();
 			Player.MemberNumber = C.MemberNumber;
-			Player.BlockItems = ((C.BlockItems == null) || !Array.isArray(C.BlockItems)) ? [] : C.BlockItems;
+			Player.BlockItems = ((C.BlockItems == null) || !Array.isArray(C.BlockItems)) ? [] : C.BlockItems;;
 			Player.LimitedItems = ((C.LimitedItems == null) || !Array.isArray(C.LimitedItems)) ? [] : C.LimitedItems;
-			Player.OptedItems = ((C.OptedItems == null) || !Array.isArray(C.OptedItems)) ? [] : C.OptedItems;
 			Player.WardrobeCharacterNames = C.WardrobeCharacterNames;
 			WardrobeCharacter = [];
 
@@ -324,16 +302,6 @@ function LoginResponse(C) {
 				ServerPlayerSync();
 			}
 
-			// Assures all blocked-by-default items are blocked
-			var MustRefresh = false
-			for (var A = 0; A < Asset.length; A++) { 
-				if (Asset[A].BlackList && !Player.OptedItems.find(OI => OI.Name == Asset[A].Name && OI.Group == Asset[A].Group.Name) && !Player.BlockItems.find(BI => BI.Name == Asset[A].Name && BI.Group == Asset[A].Group.Name)  && !Player.LimitedItems.find(LI => LI.Name == Asset[A].Name && LI.Group == Asset[A].Group.Name)) { 
-					Player.BlockItems.push({ Name: Asset[A].Name, Group: Asset[A].Group.Name });
-					MustRefresh = true;
-				}
-			}
-			if (MustRefresh) ServerSend("AccountUpdate", { BlockItems: Player.BlockItems });
-			
 			// Gets the online preferences
 			Player.LabelColor = C.LabelColor;
 			Player.ItemPermission = C.ItemPermission;
@@ -385,8 +353,7 @@ function LoginResponse(C) {
 			LoginLoversItems();
 			LoginValideBuyGroups();
 			CharacterAppearanceValidate(Player);
-			LoginValidateArrays();
-			
+
 			// If the player must log back in the cell
 			if (LogQuery("Locked", "Cell")) {
 				CommonSetScreen("Room", "Cell");

--- a/BondageClub/Screens/Character/Login/Login.js
+++ b/BondageClub/Screens/Character/Login/Login.js
@@ -241,13 +241,15 @@ function LoginValideBuyGroups() {
  * @returns {void} Nothing
  */
 function LoginValidateArrays() { 
-	var Result = AssetCleanArray([Player.BlockItems, Player.LimitedItems]);
-	if (Result[0].length != Player.BlockItems.length) { 
-		Player.BlockItems = Result[0];
+	var CleanBlockItems = AssetCleanArray(Player.BlockItems);
+	if (CleanBlockItems.length != Player.BlockItems.length) { 
+		Player.BlockItems = CleanBlockItems;
 		ServerSend("AccountUpdate", { BlockItems: Player.BlockItems });
 	}
-	if (Result[1].length != Player.LimitedItems.length) { 
-		Player.LimitedItems = Result[1];
+	
+	var CleanLimitedItems = AssetCleanArray(Player.LimitedItems);
+	if (CleanLimitedItems.length != Player.LimitedItems.length) { 
+		Player.LimitedItems = CleanLimitedItems;
 		ServerSend("AccountUpdate", { LimitedItems: Player.LimitedItems });
 	}
 }

--- a/BondageClub/Scripts/Asset.js
+++ b/BondageClub/Scripts/Asset.js
@@ -101,6 +101,7 @@ function AssetAdd(NewAsset) {
 		Audio: NewAsset.Audio,
 		ArousalZone: (NewAsset.ArousalZone == null) ? AssetCurrentGroup.Name : NewAsset.ArousalZone,
 		IgnoreParentGroup: (NewAsset.IgnoreParentGroup == null) ? false : NewAsset.IgnoreParentGroup,
+		BlackList: (NewAsset.BlackList == null) ? false : NewAsset.BlackList,
 		IsRestraint: (NewAsset.IsRestraint == null) ? ((AssetCurrentGroup.IsRestraint == null) ? false : AssetCurrentGroup.IsRestraint) : NewAsset.IsRestraint,
 		BodyCosplay: (NewAsset.BodyCosplay == null) ? ((AssetCurrentGroup.BodyCosplay == null) ? false : AssetCurrentGroup.BodyCosplay) : NewAsset.BodyCosplay,
 		OverrideBlinking: (NewAsset.OverrideBlinking == null) ? false : NewAsset.OverrideBlinking,
@@ -239,4 +240,25 @@ function AssetGetActivity(Family, Name) {
 			if (ActivityFemale3DCG[A].Name == Name)
 				return ActivityFemale3DCG[A];
 	return null;
+}
+
+/**
+ * Cleans one to many given arrays of assets of any items that no longer exists
+ * @param {Array.<Array.<{Name: string, Group: string}>>} AssetArray - The arrays of items to clean
+ * @returns {Array.<{Name: string, Group: string}>} - The cleaned up array
+ */
+function AssetCleanArray(Arrays) { 
+	var CleanArrays = [];
+	for (var ARR = 0; ARR < Arrays.length; ARR++)
+		CleanArrays.push([]);
+	
+	// Only save the existing items
+	for (var A = 0; A < Asset.length; A++)
+		for (var ARR = 0; ARR < Arrays.length; ARR++) { 
+			var FoundItem = Arrays[ARR].find(Item => Item.Name == Asset[A].Name && Item.Group == Asset[A].Group.Name)
+			if (Arrays[ARR].find(Item => Item.Name == Asset[A].Name && Item.Group == Asset[A].Group.Name))
+				CleanArrays[ARR].push(FoundItem);
+		}
+	
+	return CleanArrays;
 }

--- a/BondageClub/Scripts/Asset.js
+++ b/BondageClub/Scripts/Asset.js
@@ -240,3 +240,24 @@ function AssetGetActivity(Family, Name) {
 				return ActivityFemale3DCG[A];
 	return null;
 }
+
+/**
+ * Cleans one to many given arrays of assets of any items that no longer exists
+ * @param {Array.<Array.<{Name: string, Group: string}>>} AssetArray - The arrays of items to clean
+ * @returns {Array.<Array.<{Name: string, Group: string}>>} - The cleaned up array(s)
+ */
+function AssetCleanArray(Arrays) { 
+	var CleanArrays = [];
+	for (var ARR = 0; ARR < Arrays.length; ARR++)
+		CleanArrays.push([]);
+	
+	// Only save the existing items
+	for (var A = 0; A < Asset.length; A++)
+		for (var ARR = 0; ARR < Arrays.length; ARR++) { 
+			var FoundItem = Arrays[ARR].find(Item => Item.Name == Asset[A].Name && Item.Group == Asset[A].Group.Name)
+			if (Arrays[ARR].find(Item => Item.Name == Asset[A].Name && Item.Group == Asset[A].Group.Name))
+				CleanArrays[ARR].push(FoundItem);
+		}
+	
+	return CleanArrays;
+}

--- a/BondageClub/Scripts/Asset.js
+++ b/BondageClub/Scripts/Asset.js
@@ -255,8 +255,7 @@ function AssetCleanArray(Arrays) {
 	for (var A = 0; A < Asset.length; A++)
 		for (var ARR = 0; ARR < Arrays.length; ARR++) { 
 			var FoundItem = Arrays[ARR].find(Item => Item.Name == Asset[A].Name && Item.Group == Asset[A].Group.Name)
-			if (Arrays[ARR].find(Item => Item.Name == Asset[A].Name && Item.Group == Asset[A].Group.Name))
-				CleanArrays[ARR].push(FoundItem);
+			if (FoundItem) CleanArrays[ARR].push(FoundItem);
 		}
 	
 	return CleanArrays;

--- a/BondageClub/Scripts/Asset.js
+++ b/BondageClub/Scripts/Asset.js
@@ -249,9 +249,11 @@ function AssetGetActivity(Family, Name) {
 function AssetCleanArray(AssetArray) { 
 	var CleanArray = [];
 	// Only save the existing items
-	for (var A = 0; A < Asset.length; A++) {
-		var FoundItem = AssetArray.find(Item => Item.Name == Asset[A].Name && Item.Group == Asset[A].Group.Name)
-		if (FoundItem) CleanArray.push(FoundItem);
-	}
+	for (var A = 0; A < Asset.length; A++)
+		for (var AA = 0; AA < AssetArray.length; AA++)
+			if (AssetArray[AA].Name == Asset[A].Name && AssetArray[AA].Group == Asset[A].Group.Name) {
+				CleanArray.push(AssetArray[AA]);
+				break;
+			}
 	return CleanArray;
 }

--- a/BondageClub/Scripts/Asset.js
+++ b/BondageClub/Scripts/Asset.js
@@ -242,21 +242,16 @@ function AssetGetActivity(Family, Name) {
 }
 
 /**
- * Cleans one to many given arrays of assets of any items that no longer exists
- * @param {Array.<Array.<{Name: string, Group: string}>>} AssetArray - The arrays of items to clean
- * @returns {Array.<Array.<{Name: string, Group: string}>>} - The cleaned up array(s)
+ * Cleans the given array of assets of any items that no longer exists
+ * @param {Array.<{Name: string, Group: string}>} AssetArray - The arrays of items to clean
+ * @returns {Array.<{Name: string, Group: string}>} - The cleaned up array
  */
-function AssetCleanArray(Arrays) { 
-	var CleanArrays = [];
-	for (var ARR = 0; ARR < Arrays.length; ARR++)
-		CleanArrays.push([]);
-	
+function AssetCleanArray(AssetArray) { 
+	var CleanArray = [];
 	// Only save the existing items
-	for (var A = 0; A < Asset.length; A++)
-		for (var ARR = 0; ARR < Arrays.length; ARR++) { 
-			var FoundItem = Arrays[ARR].find(Item => Item.Name == Asset[A].Name && Item.Group == Asset[A].Group.Name)
-			if (FoundItem) CleanArrays[ARR].push(FoundItem);
-		}
-	
-	return CleanArrays;
+	for (var A = 0; A < Asset.length; A++) {
+		var FoundItem = AssetArray.find(Item => Item.Name == Asset[A].Name && Item.Group == Asset[A].Group.Name)
+		if (FoundItem) CleanArray.push(FoundItem);
+	}
+	return CleanArray;
 }

--- a/BondageClub/Scripts/Asset.js
+++ b/BondageClub/Scripts/Asset.js
@@ -101,7 +101,6 @@ function AssetAdd(NewAsset) {
 		Audio: NewAsset.Audio,
 		ArousalZone: (NewAsset.ArousalZone == null) ? AssetCurrentGroup.Name : NewAsset.ArousalZone,
 		IgnoreParentGroup: (NewAsset.IgnoreParentGroup == null) ? false : NewAsset.IgnoreParentGroup,
-		BlackList: (NewAsset.BlackList == null) ? false : NewAsset.BlackList,
 		IsRestraint: (NewAsset.IsRestraint == null) ? ((AssetCurrentGroup.IsRestraint == null) ? false : AssetCurrentGroup.IsRestraint) : NewAsset.IsRestraint,
 		BodyCosplay: (NewAsset.BodyCosplay == null) ? ((AssetCurrentGroup.BodyCosplay == null) ? false : AssetCurrentGroup.BodyCosplay) : NewAsset.BodyCosplay,
 		OverrideBlinking: (NewAsset.OverrideBlinking == null) ? false : NewAsset.OverrideBlinking,
@@ -240,25 +239,4 @@ function AssetGetActivity(Family, Name) {
 			if (ActivityFemale3DCG[A].Name == Name)
 				return ActivityFemale3DCG[A];
 	return null;
-}
-
-/**
- * Cleans one to many given arrays of assets of any items that no longer exists
- * @param {Array.<Array.<{Name: string, Group: string}>>} AssetArray - The arrays of items to clean
- * @returns {Array.<{Name: string, Group: string}>} - The cleaned up array
- */
-function AssetCleanArray(Arrays) { 
-	var CleanArrays = [];
-	for (var ARR = 0; ARR < Arrays.length; ARR++)
-		CleanArrays.push([]);
-	
-	// Only save the existing items
-	for (var A = 0; A < Asset.length; A++)
-		for (var ARR = 0; ARR < Arrays.length; ARR++) { 
-			var FoundItem = Arrays[ARR].find(Item => Item.Name == Asset[A].Name && Item.Group == Asset[A].Group.Name)
-			if (Arrays[ARR].find(Item => Item.Name == Asset[A].Name && Item.Group == Asset[A].Group.Name))
-				CleanArrays[ARR].push(FoundItem);
-		}
-	
-	return CleanArrays;
 }

--- a/BondageClub/Scripts/Dialog.js
+++ b/BondageClub/Scripts/Dialog.js
@@ -1020,15 +1020,21 @@ function DialogItemClick(ClickItem) {
 	// In permission mode, the player can allow or block items for herself
 	if ((C.ID == 0) && DialogItemPermissionMode) {
 		if (CurrentItem && (CurrentItem.Asset.Name == ClickItem.Asset.Name)) return;
+		
+		var ListItem = { Name: ClickItem.Asset.Name, Group: ClickItem.Asset.Group.Name };
 		if (InventoryIsPermissionBlocked(Player, ClickItem.Asset.Name, ClickItem.Asset.Group.Name)) {
 			Player.BlockItems = Player.BlockItems.filter(B => B.Name != ClickItem.Asset.Name || B.Group != ClickItem.Asset.Group.Name);
-			Player.LimitedItems.push({ Name: ClickItem.Asset.Name, Group: ClickItem.Asset.Group.Name });
+			Player.LimitedItems.push(ListItem);
 		}
-		else if (InventoryIsPermissionLimited(Player, ClickItem.Asset.Name, ClickItem.Asset.Group.Name))
+		else if (InventoryIsPermissionLimited(Player, ClickItem.Asset.Name, ClickItem.Asset.Group.Name)) {
 			Player.LimitedItems = C.LimitedItems.filter(B => B.Name != ClickItem.Asset.Name || B.Group != ClickItem.Asset.Group.Name);
-		else
-			Player.BlockItems.push({ Name: ClickItem.Asset.Name, Group: ClickItem.Asset.Group.Name });
-		ServerSend("AccountUpdate", { BlockItems: Player.BlockItems, LimitedItems: Player.LimitedItems });
+			Player.OptedItems.push(ListItem);
+		} else {
+			Player.BlockItems.push(ListItem);
+			Player.OptedItems = C.OptedItems.filter(OI => OI.Name != ClickItem.Asset.Name || OI.Group != ClickItem.Asset.Group.Name);
+		}
+		
+		ServerSend("AccountUpdate", { BlockItems: Player.BlockItems, LimitedItems: Player.LimitedItems, OptedItems: Player.OptedItems });
 		return;
 	}
 

--- a/BondageClub/Scripts/Dialog.js
+++ b/BondageClub/Scripts/Dialog.js
@@ -1020,21 +1020,15 @@ function DialogItemClick(ClickItem) {
 	// In permission mode, the player can allow or block items for herself
 	if ((C.ID == 0) && DialogItemPermissionMode) {
 		if (CurrentItem && (CurrentItem.Asset.Name == ClickItem.Asset.Name)) return;
-		
-		var ListItem = { Name: ClickItem.Asset.Name, Group: ClickItem.Asset.Group.Name };
 		if (InventoryIsPermissionBlocked(Player, ClickItem.Asset.Name, ClickItem.Asset.Group.Name)) {
 			Player.BlockItems = Player.BlockItems.filter(B => B.Name != ClickItem.Asset.Name || B.Group != ClickItem.Asset.Group.Name);
-			Player.LimitedItems.push(ListItem);
+			Player.LimitedItems.push({ Name: ClickItem.Asset.Name, Group: ClickItem.Asset.Group.Name });
 		}
-		else if (InventoryIsPermissionLimited(Player, ClickItem.Asset.Name, ClickItem.Asset.Group.Name)) {
+		else if (InventoryIsPermissionLimited(Player, ClickItem.Asset.Name, ClickItem.Asset.Group.Name))
 			Player.LimitedItems = C.LimitedItems.filter(B => B.Name != ClickItem.Asset.Name || B.Group != ClickItem.Asset.Group.Name);
-			Player.OptedItems.push(ListItem);
-		} else {
-			Player.BlockItems.push(ListItem);
-			Player.OptedItems = C.OptedItems.filter(OI => OI.Name != ClickItem.Asset.Name || OI.Group != ClickItem.Asset.Group.Name);
-		}
-		
-		ServerSend("AccountUpdate", { BlockItems: Player.BlockItems, LimitedItems: Player.LimitedItems, OptedItems: Player.OptedItems });
+		else
+			Player.BlockItems.push({ Name: ClickItem.Asset.Name, Group: ClickItem.Asset.Group.Name });
+		ServerSend("AccountUpdate", { BlockItems: Player.BlockItems, LimitedItems: Player.LimitedItems });
 		return;
 	}
 


### PR DESCRIPTION
- added login validation to remove non-valid data from the permission arrays to maintain data integrity

currently you can push anything to those arrays and it will be saved permanently, moreover, with items changing slots and the likes, it's important to make sure we don't keep a lot of data we do not need in the db. 

For example, all the hoods being moved will require people to re-blacklist them, but the old entries would stay in their array forever unless this change is approved. The server sync will only be triggered to remove bad data someone may have pushed through console, or when changing club version to clean up from changes.

I extracted it into a separate function in case we ever have more things we wish to cleanup that follow the same pattern