### PR TITLE
Improvement: Reduced inventory sync calls

### DIFF
--- a/BondageClub/Screens/Character/Login/Login.js
+++ b/BondageClub/Screens/Character/Login/Login.js
@@ -360,6 +360,7 @@ function LoginResponse(C) {
 			SarahSetStatus();
 
 			// Fixes a few items
+			var InventoryBeforeFixes = JSON.stringify(Player.Inventory);
 			InventoryRemove(Player, "ItemMisc");
 			if (LogQuery("JoinedSorority", "Maid") && !InventoryAvailable(Player, "MaidOutfit2", "Cloth")) InventoryAdd(Player, "MaidOutfit2", "Cloth", false);
 			if ((InventoryGet(Player, "ItemArms") != null) && (InventoryGet(Player, "ItemArms").Asset.Name == "FourLimbsShackles")) InventoryRemove(Player, "ItemArms");
@@ -369,7 +370,7 @@ function LoginResponse(C) {
 			LoginLoversItems();
 			LoginValideBuyGroups();
 			LoginValidateArrays();
-			ServerPlayerInventorySync();
+			if (InventoryBeforeFixes != JSON.stringify(Player.Inventory)) ServerPlayerInventorySync();
 			CharacterAppearanceValidate(Player);
 
 			// If the player must log back in the cell

--- a/BondageClub/Screens/Character/Login/Login.js
+++ b/BondageClub/Screens/Character/Login/Login.js
@@ -168,7 +168,6 @@ function LoginMistressItems() {
 		InventoryDelete(Player, "MistressTop", "Cloth", false);
 		InventoryDelete(Player, "MistressBottom", "ClothLower", false);
 	}
-	ServerPlayerInventorySync();
 }
 
 /**
@@ -194,7 +193,6 @@ function LoginStableItems() {
 		InventoryDelete(Player, "PonyHood", "ItemHood",false)
 		InventoryDelete(Player,"HoofMittens", "ItemHands", false);
 	}
-	ServerPlayerInventorySync();
 }
 
 /**
@@ -233,7 +231,7 @@ function LoginValideBuyGroups() {
 		if ((Asset[A].BuyGroup != null) && InventoryAvailable(Player, Asset[A].Name, Asset[A].Group.Name))
 			for (var B = 0; B < Asset.length; B++)
 				if ((Asset[B] != null) && (Asset[B].BuyGroup != null) && (Asset[B].BuyGroup == Asset[A].BuyGroup) && !InventoryAvailable(Player, Asset[B].Name, Asset[B].Group.Name))
-					InventoryAdd(Player, Asset[B].Name, Asset[B].Group.Name);
+					InventoryAdd(Player, Asset[B].Name, Asset[B].Group.Name, false);
 }
 
 /**
@@ -363,7 +361,7 @@ function LoginResponse(C) {
 
 			// Fixes a few items
 			InventoryRemove(Player, "ItemMisc");
-			if (LogQuery("JoinedSorority", "Maid") && !InventoryAvailable(Player, "MaidOutfit2", "Cloth")) InventoryAdd(Player, "MaidOutfit2", "Cloth");
+			if (LogQuery("JoinedSorority", "Maid") && !InventoryAvailable(Player, "MaidOutfit2", "Cloth")) InventoryAdd(Player, "MaidOutfit2", "Cloth", false);
 			if ((InventoryGet(Player, "ItemArms") != null) && (InventoryGet(Player, "ItemArms").Asset.Name == "FourLimbsShackles")) InventoryRemove(Player, "ItemArms");
 			LoginValidCollar();
 			LoginMistressItems();
@@ -371,6 +369,7 @@ function LoginResponse(C) {
 			LoginLoversItems();
 			LoginValideBuyGroups();
 			LoginValidateArrays();
+			ServerPlayerInventorySync();
 			CharacterAppearanceValidate(Player);
 
 			// If the player must log back in the cell


### PR DESCRIPTION
- reduced the amount of inventory sync calls on login to 1 max.

Currently, every login triggers 2 inventory sync, and has the odds of triggering even more, This removes all of them in favor of only one sync. This singular sync only occurs if the player actually had something changed in their inventory.

I also have two questions:
1- The following line seems useless to me, but I saw you added it so I thought I would ask. I understand this was added when a new maid outfit was available, but with the buy group validation, this item will be earned automatically for anyone with the base maid outfit since they share the same buygroup. I tested and had no problem without this line.
 `if (LogQuery("JoinedSorority", "Maid") && !InventoryAvailable(Player, "MaidOutfit2", "Cloth")) InventoryAdd(Player, "MaidOutfit2", "Cloth");`

2- The other topic is, any groups of InventoryAdd can trigger several sync calls when it happens for the first time. I was thinking of refactoring those into a InventoryAddItems or something like that to add several at once which would trigger less server calls overall. Let me know what you think. If you say you'll accept it, I'll do that optimization.

For example, this would trigger 6 calls when earned for the first time:
```
InventoryAdd(Player, "NylonRope", "ItemFeet");
InventoryAdd(Player, "NylonRope", "ItemLegs");
InventoryAdd(Player, "NylonRope", "ItemArms");
InventoryAdd(Player, "ClothGag", "ItemMouth");
InventoryAdd(Player, "ClothGag", "ItemMouth2");
InventoryAdd(Player, "ClothGag", "ItemMouth3");
```