### PR TITLE
Fix: Respect for lover lover locks

### DIFF
--- a/BondageClub/Screens/Room/KidnapLeague/KidnapLeague.js
+++ b/BondageClub/Screens/Room/KidnapLeague/KidnapLeague.js
@@ -275,7 +275,7 @@ function KidnapLeagueRandomActivityLaunch() {
 			if (KidnapPlayerClothAccessory != null) InventoryWear(Player, KidnapPlayerClothAccessory.Asset.Name, "ClothAccessory", KidnapPlayerClothAccessory.Color);
 			if (KidnapPlayerClothLower != null) InventoryWear(Player, KidnapPlayerClothLower.Asset.Name, "ClothLower", KidnapPlayerClothLower.Color);
 		}
-		if (!InventoryCharacterHasOwnerOnlyRestraint(Player)) {
+		if ((!InventoryCharacterHasOwnerOnlyRestraint(Player)) && (!InventoryCharacterHasLoverOnlyRestraint(Player))){
 			CharacterRelease(Player);		
 			KidnapLeagueRandomActivityStart("End");
 			KidnapLeagueVisitRoom = ((Math.random() >= 0.5) && KidnapLeagueCanTransferToRoom());

--- a/BondageClub/Screens/Room/MainHall/Dialog_NPC_MainHall_Maid.csv
+++ b/BondageClub/Screens/Room/MainHall/Dialog_NPC_MainHall_Maid.csv
@@ -30,9 +30,10 @@ ItemPelvisLeatherCrop,,,(She grumbles as you strike her butt with the crop.)  A 
 0,,,"(A maid walks by and greets you.)  Hi Sister, are you in trouble?  Do you need help?",,IsMaid
 0,,,(A maid walks by and greets you.)  Are you in trouble?  Do you need help?,,!IsMaid
 0,,Who are you?,"I'm DialogCharacterName, I work here as a maid to help submissives in trouble.  Do you need help?",DialogRemove(),!IsMaid
-0,,(Nod yes.),(She releases you and smiles.)  Here you go!  Everything is ok now?,MaidReleasePlayer(),!HasOwnerLock
-0,,"Yes, can you release me?",(She releases you and smiles.)  Here you go!  Everything is ok now?,MaidReleasePlayer(),!HasOwnerLock
+0,,(Nod yes.),(She releases you and smiles.)  Here you go!  Everything is ok now?,MaidReleasePlayer(),!HasOwnerOrLoverItem()
+0,,"Yes, can you release me?",(She releases you and smiles.)  Here you go!  Everything is ok now?,MaidReleasePlayer(),!HasOwnerOrLoverItem()
 0,40,(Nod yes.),(She checks your locks and frowns.)  Is that an owner lock?  Your Mistress might not be pleased if I release you.,,HasOwnerLock
+0,45,(Nod yes.),(She checks your locks and frowns.)  Is that a lover lock?  Your Lover might not be pleased if I release you.,,HasLoverLock
 0,70,(Nod yes and point to your slave collar.),(She checks the lock and frowns.) That is a slave collar. Your Mistress might not be pleased if I change it.,,HasSlaveCollar
 0,40,"Yes, can you release me?",(She checks your locks and frowns.)  Is that an owner lock?  Your Mistress might not be pleased if I release you.,,HasOwnerLock
 0,70,"Yes, can you change my collar?",(She checks the lock and frowns.) That is a slave collar. Your Mistress might not be pleased if I change it.,,HasSlaveCollar
@@ -64,6 +65,7 @@ ItemPelvisLeatherCrop,,,(She grumbles as you strike her butt with the crop.)  A 
 43,,"Fine, I'm going then.  (Leave her.)",,DialogLeave(),
 43,,(Grumble and leave.),,DialogLeave(),
 43,1010,I have some questions on the club.,Sure.  What would you like to know?,,
+45,43,Please release me anyways.,  "Well, that's something you should discuss with your Lover  (She releases you)",MaidReleasePlayer(),
 50,51,Why do you care?,"I'm doing my job.  Club slaves must stay naked, let me help you to strip.","DialogChangeReputation(""Dominant"", 2)",Player.CanTalk()
 50,51,Oops!  I forgot the rule.,"Rules are important.  Club slaves must stay naked, let me help you to strip.",,Player.CanTalk()
 50,51,Sorry.  I was tricked by someone.,"Make sure to remember the rules.  Club slaves must stay naked, let me help you to strip.","DialogChangeReputation(""Dominant"", -2)",Player.CanTalk()

--- a/BondageClub/Screens/Room/MainHall/MainHall.js
+++ b/BondageClub/Screens/Room/MainHall/MainHall.js
@@ -7,6 +7,7 @@ var MainHallMaid = null;
 var MainHallIsMaid = false;
 var MainHallIsHeadMaid = false;
 var MainHallHasOwnerLock = false;
+var MainHallHasLoverLock = false;
 var MainHallHasSlaveCollar = false;
 var MainHallTip = 0;
 
@@ -15,6 +16,12 @@ var MainHallTip = 0;
  * @returns {boolean} - Returns TRUE if the maid can be tricked
  */
 function MainHallCanTrickMaid() { return (ManagementIsClubSlave() && SarahUnlockQuest) }
+
+/**
+ * Checks, if the player has an owner or lover lock on her
+ * @returns {boolean} - Returns true, if the player has either a lover or owner item on herself, false otherwise
+ */
+function MainHallHasOwnerOrLoverItem() { return MainHallHasLoverLock || MainHallHasOwnerLock }
 
 /**
  * Loads the main hall by setting up the NPCs, CSVs and global variables required.
@@ -32,6 +39,7 @@ function MainHallLoad() {
 	MainHallIsMaid = LogQuery("JoinedSorority", "Maid");
 	MainHallIsHeadMaid = LogQuery("LeadSorority", "Maid");
 	MainHallHasOwnerLock = InventoryCharacterHasOwnerOnlyRestraint(Player);
+	MainHallHasLoverLock = InventoryCharacterHasLoverOnlyRestraint(Player);
 	for (var A = 0; A < Player.Appearance.length; A++)
 		if (Player.Appearance[A].Asset.Name == "SlaveCollar")
 			if (Player.Appearance[A].Property)

--- a/BondageClub/Screens/Room/Management/Dialog_NPC_Management_Mistress.csv
+++ b/BondageClub/Screens/Room/Management/Dialog_NPC_Management_Mistress.csv
@@ -255,6 +255,7 @@ MistressExpulsion,,,We Mistresses have been speaking.  It seems you're not fit t
 300,,What if the sub is already owned?,"As long as the owner doesn't disapprove, a regular slave can take a club slave contract for one hour.  We will swap collars and lock the slave collar again in the end.",,,
 300,,Can I become a club slave?,"No, you're not submissive enough.",,CannotBeClubSlaveDominant(),
 300,,Can I become a club slave?,"(She checks your locks.)  No, your Mistress has put an owner lock on you, get released first.",,CannotBeClubSlaveOwnerLock(),
+300,,Can I become a club slave?,"(She checks your locks.)  No, your Lover has put a lover lock on you, get released first.",,CannotBeClubSlaveLoverLock(),
 300,310,Can I become a club slave?,"You could, are you sure you understand the terms and commitments?  Do you accept the contract?",,CanBeClubSlave(),
 300,0,Let's talk about something else.,"Alright girl, but don't waste my time.",,,
 310,320,I accept the terms.  I want to be a club slave.,"Very good, it's time to strip girl.",,!Player.IsNaked(),

--- a/BondageClub/Screens/Room/Management/Management.js
+++ b/BondageClub/Screens/Room/Management/Management.js
@@ -66,9 +66,14 @@ function ManagementCannotBeClubMistressLaugh() { return ((ReputationGet("Dominan
 function ManagementCannotBeClubMistressTime() { return (((Math.floor((CurrentTime - Player.Creation) / 86400000)) < 30) && !LogQuery("ClubMistress", "Management") && !Player.IsRestrained() && !Player.IsKneeling() && Player.CanChange()) }
 function ManagementMistressCanBePaid() { return (LogQuery("ClubMistress", "Management") && !LogQuery("MistressWasPaid", "Management")) }
 function ManagementMistressCannotBePaid() { return (LogQuery("ClubMistress", "Management") && LogQuery("MistressWasPaid", "Management")) }
-function ManagementCanBeClubSlave() { return (!InventoryCharacterHasOwnerOnlyRestraint(Player) && DialogReputationLess("Dominant", -50)) }
-function ManagementCannotBeClubSlaveDominant() { return (!InventoryCharacterHasOwnerOnlyRestraint(Player) && DialogReputationGreater("Dominant", -49)) }
+function ManagementCanBeClubSlave() { return (!InventoryCharacterHasOwnerOnlyRestraint(Player) && !InventoryCharacterHasLoverOnlyRestraint(Player) && DialogReputationLess("Dominant", -50)) }
+function ManagementCannotBeClubSlaveDominant() { return (!InventoryCharacterHasOwnerOnlyRestraint(Player) && !InventoryCharacterHasLoverOnlyRestraint(Player) && DialogReputationGreater("Dominant", -49)) }
 function ManagementCannotBeClubSlaveOwnerLock() { return InventoryCharacterHasOwnerOnlyRestraint(Player) }
+/**
+ * Checks, if the player is wearing a lover locked restraint
+ * @returns {boolean} - Returns true, if the player wears a lover locked item, false otherwise
+ */
+function ManagementCannotBeClubSlaveLoverLock() { return InventoryCharacterHasLoverOnlyRestraint(Player) }
 function ManagementCanKiss() { return (Player.CanTalk() && CurrentCharacter.CanTalk()) }
 function ManagementCanMasturbate() { return (Player.CanInteract() && !CurrentCharacter.IsVulvaChaste()) }
 function ManagementCanPlayWithSub() { return (DialogReputationLess("Dominant", 24) && !InventoryCharacterHasLockedRestraint(Player)) }

--- a/BondageClub/Scripts/Inventory.js
+++ b/BondageClub/Scripts/Inventory.js
@@ -482,6 +482,21 @@ function InventoryCharacterHasOwnerOnlyRestraint(C) {
 }
 
 /**
+* Returns TRUE if the character is wearing at least one item that's a restraint with a LoverOnly flag, such as the lover padlock
+* @param {Character} C - The character to scan
+* @returns {Boolean} - TRUE if one lover only restraint is found
+*/
+function InventoryCharacterHasLoverOnlyRestraint(C) {
+	if (C.GetLoversNumbers().length == 0) return false;
+	if (C.Appearance != null)
+		for (var A = 0; A < C.Appearance.length; A++) {
+			if (C.Appearance[A].Asset.IsRestraint && InventoryLoverOnlyItem(C.Appearance[A]))
+				return true;
+		}
+	return false;
+}
+
+/**
 * Returns TRUE if at least one item on the character can be locked
 * @param {Character} C - The character to scan
 * @returns {Boolean} - TRUE if at least one item can be locked


### PR DESCRIPTION
# Summary
Up to now, most NPCs pay no real respect for lover locked items and mostly ignore them. This fix tries to change that.
This has been reported as [#877698](http://www.hostedredmine.com/issues/877698).
# Details
Six files were changed to achieve that. The changes are as follows
## What it does
### `Inventory.js`
* Added a new function `InventoryCharacterHasLoverOnlyRestraint` that checks for lover restrained items, similar to `InventoryCharacterHasOwnerOnlyRestraint`
### `KidnapLeague.js`
* At the end of a battle, the lover locked items are not removed, likewise to the owner locked ones
### `MainHall.js` and corresponding dialog
* Added a new function to check, if the player wears either lover or owner locked items
* The rescue maid now asks the player, if she really wants to get rid of her lover locked items, but if the player agrees, she will not get punished
### `Management.js` and corresponding dialog
* Added a new function to check for lover locked items
* If the player wears any lover locked items, she cannot become a club slave
## Testing
As the changes only touch the NPC part of the game, I tested them locally with one player, by clicking through the various dialog options