### PR TITLE
Bugfix: Resets character appearance text when accepting appearance changes

### DIFF
--- a/BondageClub/Screens/Character/Appearance/Appearance.js
+++ b/BondageClub/Screens/Character/Appearance/Appearance.js
@@ -908,6 +908,7 @@ function CharacterAppearanceReady(C) {
 	// Exits wardrobe mode
 	ElementRemove("InputWardrobeName");
 	CharacterAppearanceWardrobeMode = false;
+	CharacterAppearanceHeaderText = "";
 
 	// If there's no error, we continue to the login or main hall if already logged
 	if (C.AccountName != "") {


### PR DESCRIPTION
## Summary

This PR fixes a minor bug where the appearance screen text would not be reset after accepting changes to a character's appearance.

## Steps to reproduce

1. Change character A's appearance and accept the changes - note that while in the appearance screen the text should say "Select Character A's appearance"
2. Enter the appearance screen for character B - note that the text still says "Select Character A's appearance", rather than "Select Character B's appearance" (or "Select your appearance" if character B is yourself)