### PR TITLE
Fix: chatroom visual stutter

### DIFF
--- a/BondageClub/Screens/Online/ChatSearch/ChatSearch.js
+++ b/BondageClub/Screens/Online/ChatSearch/ChatSearch.js
@@ -5,6 +5,7 @@ var ChatSearchMessage = "";
 var ChatSearchLeaveRoom = "MainHall";
 var ChatSearchSafewordAppearance = null;
 var ChatSearchSafewordPose = null;
+var ChatRoomPreviousActivePose = null;
 
 /**
  * Loads the chat search screen properties, creates the inputs and loads up the first 24 rooms.
@@ -110,6 +111,7 @@ function ChatSearchKeyDown() {
  * @returns {void} - Nothing
  */
 function ChatSearchExit() {
+	ChatRoomPreviousActivePose = Player.ActivePose;
 	ElementRemove("InputSearch");
 	CommonSetScreen("Room", ChatSearchLeaveRoom);
 }

--- a/BondageClub/Screens/Online/ChatSearch/ChatSearch.js
+++ b/BondageClub/Screens/Online/ChatSearch/ChatSearch.js
@@ -5,7 +5,7 @@ var ChatSearchMessage = "";
 var ChatSearchLeaveRoom = "MainHall";
 var ChatSearchSafewordAppearance = null;
 var ChatSearchSafewordPose = null;
-var ChatRoomPreviousActivePose = null;
+var ChatSearchPreviousActivePose = null;
 
 /**
  * Loads the chat search screen properties, creates the inputs and loads up the first 24 rooms.
@@ -111,7 +111,7 @@ function ChatSearchKeyDown() {
  * @returns {void} - Nothing
  */
 function ChatSearchExit() {
-	ChatRoomPreviousActivePose = Player.ActivePose;
+	ChatSearchPreviousActivePose = Player.ActivePose;
 	ElementRemove("InputSearch");
 	CommonSetScreen("Room", ChatSearchLeaveRoom);
 }

--- a/BondageClub/Screens/Room/MainHall/MainHall.js
+++ b/BondageClub/Screens/Room/MainHall/MainHall.js
@@ -25,6 +25,10 @@ function MainHallLoad() {
 	// Loads the variables and dialog
 	ChatSearchSafewordAppearance = null;
 	CharacterSetActivePose(Player, null);
+	if (ChatRoomPreviousActivePose != null) {
+		ServerSend("ChatRoomCharacterPoseUpdate", { Pose: Player.ActivePose });
+		ChatRoomPreviousActivePose = null;
+	}
 	MainHallBackground = "MainHall";
 	MainHallStartEventTimer = null;
 	MainHallNextEventTimer = null;

--- a/BondageClub/Screens/Room/MainHall/MainHall.js
+++ b/BondageClub/Screens/Room/MainHall/MainHall.js
@@ -25,9 +25,9 @@ function MainHallLoad() {
 	// Loads the variables and dialog
 	ChatSearchSafewordAppearance = null;
 	CharacterSetActivePose(Player, null);
-	if (ChatRoomPreviousActivePose != null) {
+	if (ChatSearchPreviousActivePose != null) {
 		ServerSend("ChatRoomCharacterPoseUpdate", { Pose: Player.ActivePose });
-		ChatRoomPreviousActivePose = null;
+		ChatSearchPreviousActivePose = null;
 	}
 	MainHallBackground = "MainHall";
 	MainHallStartEventTimer = null;


### PR DESCRIPTION
- fixed a visual stutter when re-entering a chatroom caused by a desync in the activepose

It took me a while to pin point what was going on here, but here goes:

Currently, going back to the mainhall changes your active pose without syncing with the server, this means that if you were kneeling before going in the main hall from a chatroom, it was not saved on the server.

This caused a visual stutter when entering a room -> the character is refreshed with the old pose (kneeling) then refreshed again with the right pose (standing). causing unnecessary redraws.

 This fix makes sure to sync with the server only if necessary, so it will not trigger a bunch of active pose syncs for no reason.