### PR TITLE
Improvement: Inventory screen refresh

### DIFF
--- a/BondageClub/Scripts/Dialog.js
+++ b/BondageClub/Scripts/Dialog.js
@@ -5,7 +5,7 @@ var DialogTextDefaultTimer = -1;
 var DialogProgress = -1;
 var DialogColor = null;
 var DialogColorSelect = null;
-var DialogPreviousCharacterAppearance = null;
+var DialogPreviousCharacterData = {};
 var DialogProgressStruggleCount = 0;
 var DialogProgressAuto = 0;
 var DialogProgressOperation = "...";
@@ -401,7 +401,7 @@ function DialogLeaveItemMenu() {
 	DialogActivityMode = false;
 	DialogTextDefault = "";
 	DialogTextDefaultTimer = 0;
-	DialogPreviousCharacterAppearance = null;
+	DialogPreviousCharacterData = {};
 	ElementRemove("InputColor");
 	AudioDialogStop();
 	ColorPickerEndPick();
@@ -566,12 +566,14 @@ function DialogInventorySort() {
  * Build the inventory listing for the dialog which is what's equipped, 
  * the player's inventory and the character's inventory for that group
  * @param {Character} C - The character whose inventory must be built
+ * @param {number} [Offset] - The offset to be at, if specified.
  * @returns {void} - Nothing
  */
-function DialogInventoryBuild(C) {
+function DialogInventoryBuild(C, Offset) {
 
 	// Make sure there's a focused group
-	DialogInventoryOffset = 0;
+	DialogInventoryOffset = Offset;
+	if (DialogInventoryOffset == null) DialogInventoryOffset = 0;
 	DialogInventory = [];
 	if (C.FocusGroup != null) {
 
@@ -1359,7 +1361,6 @@ function DialogChangeItemColor(C, Color) {
 
 }
 
-// 
 /**
  * Draw the activity selection dialog
  * @param {Character} C - The character for whom the activity selection dialog is drawn. That can be the player or another character.
@@ -1606,10 +1607,13 @@ function DialogDraw() {
 
 		// We rebuild the menu if things changed
 		var C = CharacterGetCurrent();
-		if (DialogPreviousCharacterAppearance !== JSON.stringify(ServerAppearanceBundle(C.Appearance))) {
-			DialogInventoryBuild(C);
+		if (DialogPreviousCharacterData.Appearance !== JSON.stringify(ServerAppearanceBundle(C.Appearance)) || JSON.stringify(DialogPreviousCharacterData.Limited) !== JSON.stringify(C.LimitedItems) || JSON.stringify(DialogPreviousCharacterData.Blocked) !== JSON.stringify(C.BlockItems) || DialogPreviousCharacterData.ActivePose !== C.ActivePose) {
+			DialogInventoryBuild(C, DialogInventoryOffset);
 			ActivityDialogBuild(C);
-			DialogPreviousCharacterAppearance = JSON.stringify(ServerAppearanceBundle(C.Appearance));
+			DialogPreviousCharacterData.Appearance = JSON.stringify(ServerAppearanceBundle(C.Appearance));
+			DialogPreviousCharacterData.Limited = C.LimitedItems;
+			DialogPreviousCharacterData.Blocked = C.BlockItems;
+			DialogPreviousCharacterData.ActivePose = C.ActivePose;
 		}
 
 		// The view can show one specific extended item or the list of all items for a group

--- a/BondageClub/Scripts/Dialog.js
+++ b/BondageClub/Scripts/Dialog.js
@@ -1468,7 +1468,10 @@ function DialogDrawItemMenu(C) {
 		
 		// We cancel out if at least one of the following cases apply: a new item conflicts with this, the player can no longer interact, something else was added first, the item was already removed
 		if (InventoryGroupIsBlocked(C) || (C != Player && !Player.CanInteract()) || (DialogProgressNextItem == null && !InventoryGet(C, DialogProgressPrevItem.Asset.Group.Name)) || (DialogProgressNextItem != null && !InventoryAllow(C, DialogProgressNextItem.Asset.Prerequisite)) || (DialogProgressNextItem != null && DialogProgressPrevItem != null && ((InventoryGet(C, DialogProgressPrevItem.Asset.Group.Name) && InventoryGet(C, DialogProgressPrevItem.Asset.Group.Name).Asset.Name != DialogProgressPrevItem.Asset.Name) || !InventoryGet(C, DialogProgressPrevItem.Asset.Group.Name))) || (DialogProgressNextItem != null && DialogProgressPrevItem == null && InventoryGet(C, DialogProgressNextItem.Asset.Group.Name))) {
-			ChatRoomPublishAction(C, DialogProgressPrevItem, DialogProgressNextItem, true, "interrupted");
+			if (DialogProgress > 0)
+				ChatRoomPublishAction(C, DialogProgressPrevItem, DialogProgressNextItem, true, "interrupted");
+			else
+				DialogLeave();
 			DialogProgress = -1;
 			return;
 		}


### PR DESCRIPTION
- optimized the interruption message to not send any if the player never progressed through the action (this prevents a message from being sent if a character was sitting on it.)
- improved how changes are handled while refreshing the screen to retain the current page and to take every possible changes into consideration.

With the new inventory colors change, I wanted to improve the new refresh system ahead of the beta so that is is more consistant. This means that it takes into account changes in the blocklist, limited list and active pose to always reflect the correct status.

This prompted me to change the inventory build function to take a possible offset. This means you will stay on the given page when rebuilding the screen to avoid having to scroll back constantly. This greatly improves the experience since it won't kick you back to the first page, it's especially good when nothing changed for the zone you are focused on.

With the amount of things in the next beta, I have a feeling some will complain about items moving or just changes in general... This should help alleviate those complaints, Regardless, this only happens if the player's appearance change in a way that affects the current zone, paired with interruptions, this assures we do not allow conflicting items and get characters soft locked. 