### PR TITLE
Fix: Lock verification

### DIFF
--- a/BondageClub/Scripts/Server.js
+++ b/BondageClub/Scripts/Server.js
@@ -259,8 +259,8 @@ function ServerValidateProperties(C, Item) {
 				// Make sure the combination number on the lock is valid, 4 digits only
 				var Lock = InventoryGetLock(Item);
 				if ((Item.Property.CombinationNumber != null) && (typeof Item.Property.CombinationNumber == "string")) {
-					var E = /^[0-9]+$/;
-					if (!Item.Property.CombinationNumber.match(E) || (Item.Property.CombinationNumber.length != 4)) {
+					var Regex = /^[0-9]+$/;
+					if (!Item.Property.CombinationNumber.match(Regex) || (Item.Property.CombinationNumber.length != 4)) {
 						Item.Property.CombinationNumber = "0000";
 					}
 				} else delete Item.Property.CombinationNumber;


### PR DESCRIPTION
- fixed a scope issue when validating combo locks

We were testing the for let change and we already identified several code issues where it was already not working or broke because the code relied on bad practices. After fixing 2-3 of them, all the code runs fine after switching the 900 for-var loops as far as I can see for now, and each frame is drastically faster. I can publish my test branch if you want to see.

This bug was found while doing tests, the regex used the same var as the loop which caused scoping issues. After verifying the combination, it breaks out of the loop because `regex++ = NaN` and `NaN < anything = false`. This causes combo locked items to be "unsafe" and is a clear reason why `let` and `const` should  be used over var in 99% of cases.