### PR TITLE
Improvement: More Inventory Sync Optimisation

### DIFF
--- a/BondageClub/Screens/Room/AsylumEntrance/AsylumEntrance.js
+++ b/BondageClub/Screens/Room/AsylumEntrance/AsylumEntrance.js
@@ -472,6 +472,8 @@ function AsylumEntranceEscapedPatientLeave() {
  * @returns {void} - Nothing
  */
 function AsylumEntranceGiveNurseUniform() {
-	InventoryAdd(Player, "NurseUniform", "Cloth");
-	InventoryAdd(Player, "NurseCap", "Hat");
+	var ItemsToEarn = [];
+	ItemsToEarn.push({Name: "NurseUniform", Group: "Cloth"});
+	ItemsToEarn.push({Name: "NurseCap", Group: "Hat"});
+	InventoryAddMany(Player, ItemsToEarn);
 }

--- a/BondageClub/Screens/Room/CollegeDetention/CollegeDetention.js
+++ b/BondageClub/Screens/Room/CollegeDetention/CollegeDetention.js
@@ -193,9 +193,13 @@ function CollegeDetentionRestrainPlayer(Type) {
  */
 function CollegeDetentionInviteToPrivateRoom() {
 	CollegeDetentionDressBack();
-	InventoryAdd(Player, "Ribbons2", "HairAccessory1");
-	InventoryAdd(Player, "Ribbons2", "HairAccessory2");
-	InventoryAdd(Player, "RegularSleepingPill", "ItemMouth");
+	
+	var ItemsToEarn = [];
+	ItemsToEarn.push({Name: "Ribbons2", Group: "HairAccessory1"});
+	ItemsToEarn.push({Name: "Ribbons2", Group: "HairAccessory2"});
+	ItemsToEarn.push({Name: "RegularSleepingPill", Group: "ItemMouth"});
+	InventoryAddMany(Player, ItemsToEarn);
+	
 	CommonSetScreen("Room", "Private");
 	PrivateAddCharacter(CollegeDetentionYuki, null, true);
 	var C = PrivateCharacter[PrivateCharacter.length - 1];

--- a/BondageClub/Screens/Room/CollegeTheater/CollegeTheater.js
+++ b/BondageClub/Screens/Room/CollegeTheater/CollegeTheater.js
@@ -193,10 +193,18 @@ function CollegeTheaterDressBack() {
  */
 function CollegeTheaterInviteToPrivateRoom(Role) {
 	CollegeTheaterDressBack();
-	if (Role == "Witch") InventoryAdd(Player, "WitchHat1", "Hat");
-	if (Role == "Witch") InventoryAdd(Player, "BondageDress2", "Cloth");
-	if (Role == "Maiden") InventoryAdd(Player, "Dress2", "Cloth");
-	if (Role == "Maiden") InventoryAdd(Player, "BatWings", "Wings");
+	if (Role == "Witch") { 
+		var ItemsToEarn = [];
+		ItemsToEarn.push({Name: "WitchHat1", Group: "Hat"});
+		ItemsToEarn.push({Name: "BondageDress2", Group: "Cloth"});
+		InventoryAddMany(Player, ItemsToEarn);
+	}
+	if (Role == "Maiden") { 
+		var ItemsToEarn = [];
+		ItemsToEarn.push({Name: "BatWings", Group: "Wings"});
+		ItemsToEarn.push({Name: "Dress2", Group: "Cloth"});
+		InventoryAddMany(Player, ItemsToEarn);
+	}
 	CommonSetScreen("Room", "Private");
 	PrivateAddCharacter(CollegeTheaterJulia, null, true);
 	var C = PrivateCharacter[PrivateCharacter.length - 1];

--- a/BondageClub/Screens/Room/Introduction/Introduction.js
+++ b/BondageClub/Screens/Room/Introduction/Introduction.js
@@ -162,12 +162,14 @@ function IntroductionClearZone() {
  * @returns {void} - Nothing
  */
 function IntroductionGetBasicItems() {
-	InventoryAdd(Player, "NylonRope", "ItemFeet");
-	InventoryAdd(Player, "NylonRope", "ItemLegs");
-	InventoryAdd(Player, "NylonRope", "ItemArms");
-	InventoryAdd(Player, "ClothGag", "ItemMouth");
-	InventoryAdd(Player, "ClothGag", "ItemMouth2");
-	InventoryAdd(Player, "ClothGag", "ItemMouth3");
+	var ItemsToEarn = [];
+	ItemsToEarn.push({Name: "NylonRope", Group: "ItemFeet"});
+	ItemsToEarn.push({Name: "NylonRope", Group: "ItemLegs"});
+	ItemsToEarn.push({Name: "NylonRope", Group: "ItemArms"});
+	ItemsToEarn.push({Name: "ClothGag", Group: "ItemMouth"});
+	ItemsToEarn.push({Name: "ClothGag", Group: "ItemMouth2"});
+	ItemsToEarn.push({Name: "ClothGag", Group: "ItemMouth3"});
+	InventoryAddMany(Player, ItemsToEarn);
 	IntroductionHasBasicItems = true;
 }
 

--- a/BondageClub/Screens/Room/MaidQuarters/MaidQuarters.js
+++ b/BondageClub/Screens/Room/MaidQuarters/MaidQuarters.js
@@ -307,11 +307,14 @@ function MaidQuartersChangeInitiationMaid() {
  * @returns {void} - Nothing
  */
 function MaidQuartersBecomMaid() {
-	InventoryAdd(Player, "MaidOutfit1", "Cloth");
-	InventoryAdd(Player, "MaidOutfit2", "Cloth");
-	InventoryAdd(Player, "MaidApron1", "Cloth");
-	InventoryAdd(Player, "MaidApron2", "Cloth");
-	InventoryAdd(Player, "MaidHairband1", "Hat");
+	var ItemsToEarn = [];
+	ItemsToEarn.push({Name: "MaidOutfit1", Group: "Cloth"});
+	ItemsToEarn.push({Name: "MaidOutfit2", Group: "Cloth"});
+	ItemsToEarn.push({Name: "MaidHairband1", Group: "Cloth"});
+	ItemsToEarn.push({Name: "MaidApron1", Group: "Cloth"});
+	ItemsToEarn.push({Name: "MaidHairband1", Group: "Hat"});
+	InventoryAddMany(Player, ItemsToEarn);
+	
 	InventoryWear(Player, "MaidOutfit1", "Cloth", "Default");
 	InventoryWear(Player, "MaidHairband1", "Hat", "Default");
 	LogAdd("JoinedSorority", "Maid");
@@ -374,9 +377,11 @@ function MaidQuartersFreeSarah() {
  * @returns {void} - Nothing
  */
 function MaidQuartersGetDusterGag() {
-	InventoryAdd(Player, "DusterGag", "ItemMouth");
-	InventoryAdd(Player, "DusterGag", "ItemMouth2");
-	InventoryAdd(Player, "DusterGag", "ItemMouth3");
+	var ItemsToEarn = [];
+	ItemsToEarn.push({Name: "DusterGag", Group: "ItemMouth"});
+	ItemsToEarn.push({Name: "DusterGag", Group: "ItemMouth2"});
+	ItemsToEarn.push({Name: "DusterGag", Group: "ItemMouth3"});
+	InventoryAddMany(Player, ItemsToEarn);
 }
 
 /**

--- a/BondageClub/Screens/Room/Nursery/Nursery.js
+++ b/BondageClub/Screens/Room/Nursery/Nursery.js
@@ -382,9 +382,11 @@ function NurseryBadBabies() {
 // Player will loose skill progress or level from drinking special milk
 function NurseryPlayerSkillsAmnesia() {
 	SkillModifierChange(-1);
-	InventoryAdd(Player, "RegressedMilk", "ItemMouth");
-	InventoryAdd(Player, "RegressedMilk", "ItemMouth2");
-	InventoryAdd(Player, "RegressedMilk", "ItemMouth3");
+	var ItemsToEarn = [];
+	ItemsToEarn.push({Name: "RegressedMilk", Group: "ItemMouth"});
+	ItemsToEarn.push({Name: "RegressedMilk", Group: "ItemMouth2"});
+	ItemsToEarn.push({Name: "RegressedMilk", Group: "ItemMouth3"});
+	InventoryAddMany(Player, ItemsToEarn);
 	InventoryWear(Player, "RegressedMilk", "ItemMouth3");
 }
 

--- a/BondageClub/Screens/Room/Sarah/Sarah.js
+++ b/BondageClub/Screens/Room/Sarah/Sarah.js
@@ -504,8 +504,10 @@ function SarahKickPlayerOut() {
 function SarahTransferSophieToRoom(Love) {
 	if (SarahShackled()) SarahUnlock();
 	SarahSophieLeaveRoom();
-	InventoryAdd(Player, "LeatherCuffs", "ItemArms");
-	InventoryAdd(Player, "LeatherCuffsKey", "ItemArms");
+	var ItemsToEarn = [];
+	ItemsToEarn.push({Name: "LeatherCuffs", Group: "ItemArms"});
+	ItemsToEarn.push({Name: "LeatherCuffsKey", Group: "ItemArms"});
+	InventoryAddMany(Player, ItemsToEarn);
 	CharacterRelease(Sophie);
 	CharacterArchetypeClothes(Sophie, "Mistress", "#333333");
 	CommonSetScreen("Room", "Private");

--- a/BondageClub/Screens/Room/Shop/Shop.js
+++ b/BondageClub/Screens/Room/Shop/Shop.js
@@ -176,21 +176,21 @@ function ShopClick() {
 
 							// Add the item and removes the money
 							CharacterChangeMoney(Player, Asset[A].Value * -1);
-							InventoryAdd(Player, Asset[A].Name, Asset[A].Group.Name);
+							InventoryAdd(Player, Asset[A].Name, Asset[A].Group.Name, false);
 							ShopText = TextGet("ThankYou");
 
 							// Add any item that belongs in the same buy group
 							if (Asset[A].BuyGroup != null)
 								for (var B = 0; B < Asset.length; B++)
 									if ((Asset[B] != null) && (Asset[B].BuyGroup != null) && (Asset[B].BuyGroup == Asset[A].BuyGroup))
-										InventoryAdd(Player, Asset[B].Name, Asset[B].Group.Name);
+										InventoryAdd(Player, Asset[B].Name, Asset[B].Group.Name, false);
 
 							if (Asset[A].PrerequisiteBuyGroups)
 								for (var B = 0; B < Asset.length; B++)
 									for (var C = 0; C < Asset[A].PrerequisiteBuyGroups.length; C++)
 										if ((Asset[B]) && (Asset[B].BuyGroup != null) && (Asset[B].BuyGroup == Asset[A].PrerequisiteBuyGroups[C]))
-											InventoryAdd(Player, Asset[B].Name, Asset[B].Group.Name);
-
+											InventoryAdd(Player, Asset[B].Name, Asset[B].Group.Name, false);
+							ServerPlayerInventorySync();
 						}
 
 					}

--- a/BondageClub/Screens/Room/Stable/Stable.js
+++ b/BondageClub/Screens/Room/Stable/Stable.js
@@ -49,8 +49,10 @@ function StableLoad() {
 
 	// Give items to the player in case they completed the exam before they were added
 	if (StablePlayerIsExamTrainer || StablePlayerIsExamPony) {
-		InventoryAdd(Player, "HarnessPonyBits", "ItemMouth");
-		InventoryAdd(Player, "PonyBoots", "Shoes");
+		var ItemsToEarn = [];
+		ItemsToEarn.push({Name: "PonyBoots", Group: "Shoes"});
+		ItemsToEarn.push({Name: "HarnessPonyBits", Group: "ItemMouth"});
+		InventoryAddMany(Player, ItemsToEarn);
 	}
 	
 	// Default load

--- a/BondageClub/Scripts/Inventory.js
+++ b/BondageClub/Scripts/Inventory.js
@@ -29,6 +29,46 @@ function InventoryAdd(C, NewItemName, NewItemGroup, Push) {
 }
 
 /**
+* Adds multiple new items by group & name to the character inventory
+* @param {Character} C - The character that gets the new items added to her inventory
+* @param {Array.<{ Name: string, Group: string }>} NewItems - The new items to add
+* @param {Boolean} Push - Set to TRUE to push to the server, pushed by default
+*/
+function InventoryAddMany(C, NewItems, Push) {
+
+	// Return if data is invalid
+	if (C == null || !Array.isArray(NewItems)) return;
+	
+	var ShouldSync = false;
+	
+	// Add each items
+	for (var NI = 0; NI < NewItems.length; NI++) { 
+		// First, we check if the item already exists in the inventory, continue if it's the case
+		var ItemExists = false;
+		for (var I = 0; I < C.Inventory.length; I++)
+			if ((C.Inventory[I].Name == NewItems[NI].Name) && (C.Inventory[I].Group == NewItems[NI].Group)) {
+				ItemExists = true;
+				break;
+			}
+		
+		if (!ItemExists) { 
+			// Create the new item for current character's asset family, group name and item name
+			var NewItem = InventoryItemCreate(C, NewItems[NI].Group, NewItems[NI].Name);
+
+			// Only add the item if we found the asset
+			if (NewItem) {
+				// Pushes the new item to the inventory and flag the refresh
+				C.Inventory.push(NewItem);
+				ShouldSync = true;
+			}
+		}
+	}
+	
+	// Sends the new item(s) to the server if it's for the current player and an item was added
+	if ((C.ID == 0) && ((Push == null) || Push) && ShouldSync) ServerPlayerInventorySync();
+}
+
+/**
  * Creates a new item for a character based on asset group and name
  * @param {Character} C - The character to create the item for
  * @param {string} Group - The name of the asset group the item belongs to


### PR DESCRIPTION
- added a new `InventoryAddMany` function to add several items at once
- refactored existing calls to `InventoryAdd` to use the new `InventoryAddMany`. 
- reduced the amount of inventory syncs in the shop

This new function allows to add many items at once without spamming the server with the inventory array which is a large one. This function replicates the existing behavior of `InventoryAdd`. Meaning singleplayer areas that had the potential of triggering 0-6 syncs now only sync up to 1 time. 

Also, the shop spammed inventory syncs when an item has a buy group, this makes it so the inventory is synced after everything was added. Reducing any item bought from 1+ syncs to a singular one.

There is also a huge drop in performance in shopping mode, I'll have a look at that eventually.