### PR TITLE
Bugfix: Gag level tweak for the dildo plug gag

### DIFF
--- a/BondageClub/Assets/Female3DCG/Female3DCG.js
+++ b/BondageClub/Assets/Female3DCG/Female3DCG.js
@@ -1961,7 +1961,7 @@ var AssetFemale3DCG = [
 				]
 			},
 			{
-				Name: "DildoPlugGag", Fetish: ["Leather"], Value: 100, Time: 20, Random: false, AllowLock: true, BuyGroup: "DildoPlugGag", Prerequisite: "GagUnique", Hide: ["Mouth"], SetPose: ["GagUnique"], Effect: ["GagMedium"], AllowEffect: ["BlockMouth", "GagMedium", "GagTotal2"], AllowType: ["Open", "Plug"], ExpressionTrigger: [{ Name: "Soft", Group: "Eyebrows", Timer: 10 }], Extended: true,
+				Name: "DildoPlugGag", Fetish: ["Leather"], Value: 100, Time: 20, Random: false, AllowLock: true, BuyGroup: "DildoPlugGag", Prerequisite: "GagUnique", Hide: ["Mouth"], SetPose: ["GagUnique"], Effect: ["GagEasy"], AllowEffect: ["BlockMouth", "GagMedium", "GagTotal2"], AllowType: ["Open", "Plug"], ExpressionTrigger: [{ Name: "Soft", Group: "Eyebrows", Timer: 10 }], Extended: true,
 				Layer: [
 					{ Name: "Strap", AllowColorize: true },
 					{ Name: "Tongue", AllowColorize: false },

--- a/BondageClub/Screens/Inventory/ItemMouth/DildoPlugGag/DildoPlugGag.js
+++ b/BondageClub/Screens/Inventory/ItemMouth/DildoPlugGag/DildoPlugGag.js
@@ -5,7 +5,7 @@ var InventoryItemMouthDildoPlugGagOptions = [
 		Name: "Open",
 		Property: {
 			Type: null,
-			Effect: ["GagMedium"],
+			Effect: ["GagEasy"],
 		},
 	},
 	{


### PR DESCRIPTION
## Summary

This PR is just a small modification to the gag level of the dildo plug gag following #1123 (the gag level consistency fix). Upon examining the previous code, I realised that the intention was actually probably to make the open version of the gag have the `GagEasy` effect for a gag level of 3 (rather than 6 which is how it behaved before that fix), which would line up with the gag level on the ring gag. This PR makes that change, bringing the open version of the dildo gag in line with the ring gag.