### PR TITLE
Handheld Item Free Fix

### DIFF
--- a/BondageClub/Scripts/Dialog.js
+++ b/BondageClub/Scripts/Dialog.js
@@ -619,7 +619,7 @@ function DialogInventoryBuild(C, Offset) {
 
 			// Fourth, we add all free items (especially useful for clothes)
 			for (var A = 0; A < Asset.length; A++)
-				if ((Asset[A].Group.Name == C.FocusGroup.Name) && (Asset[A].Value == 0)) {
+				if ((Asset[A].Group.Name == C.FocusGroup.Name) && (Asset[A].Value == 0) && Asset[A].DynamicAllowInventoryAdd(C)) {
 					var DialogSortOrder = Asset[A].DialogSortOverride != null ? Asset[A].DialogSortOverride : (InventoryAllow(C, Asset[A].Prerequisite, false)) ? DialogSortOrderUsable : DialogSortOrderUnusable;
 					DialogInventoryAdd(C, { Asset: Asset[A] }, false, DialogSortOrder);
 				}


### PR DESCRIPTION
The new free-item source for the item inventory didn't have the DynamicAllowInventoryAdd check that the other ones do, meaning the handheld toy would appear as an option everywhere even if the player wasn't holding one.