### PR TITLE
Fix: new appearance mode

### DIFF
--- a/BondageClub/Screens/Character/Appearance/Appearance.js
+++ b/BondageClub/Screens/Character/Appearance/Appearance.js
@@ -927,6 +927,7 @@ function AppearanceClick() {
 		// Cancels the selected cloth and reverts it back
 		if ((MouseX >= 1768) && (MouseX < 1858) && (MouseY >= 25) && (MouseY < 115)) {
 			CharacterAppearanceSetItem(C, C.FocusGroup.Name, ((CharacterAppearanceCloth != null) && (CharacterAppearanceCloth.Asset != null)) ? CharacterAppearanceCloth.Asset : null);
+			C.FocusGroup = null;
 			AppearanceExit();
 		}
 
@@ -976,7 +977,6 @@ function AppearanceExit() {
 function CharacterAppearanceExit(C) {
 	ElementRemove("InputWardrobeName");
 	CharacterAppearanceMode = "";
-	C.FocusGroup = null;
 	C.Appearance = CharacterAppearanceBackup;
 	if (Player.GameplaySettings.EnableWardrobeIcon && CharacterAppearanceReturnRoom == "ChatRoom") {
 		CharacterSetFacialExpression(Player, "Emoticon", CharacterAppearancePreviousEmoticon);

--- a/BondageClub/Screens/Character/Appearance/Appearance.js
+++ b/BondageClub/Screens/Character/Appearance/Appearance.js
@@ -976,6 +976,7 @@ function AppearanceExit() {
 function CharacterAppearanceExit(C) {
 	ElementRemove("InputWardrobeName");
 	CharacterAppearanceMode = "";
+	C.FocusGroup = null;
 	C.Appearance = CharacterAppearanceBackup;
 	if (Player.GameplaySettings.EnableWardrobeIcon && CharacterAppearanceReturnRoom == "ChatRoom") {
 		CharacterSetFacialExpression(Player, "Emoticon", CharacterAppearancePreviousEmoticon);


### PR DESCRIPTION
- fixed a bug where leaving the new wardrobe mode caused the focus group to stick

Right now, if you go to the wardrobe mode and cancel the focus group is kept so the next character to inspect will be in the inventory with the cloth category selected. (Since that button leaves the dialog now, it needs FocusGroup = null like the save changes checkmark)