### PR TITLE
Fix: InventoryRemove crash

### DIFF
--- a/BondageClub/Scripts/Inventory.js
+++ b/BondageClub/Scripts/Inventory.js
@@ -356,11 +356,13 @@ function InventoryWearRandom(C, GroupName, Difficulty) {
 function InventoryRemove(C, AssetGroup) {
 
 	// First loop to find the item and any sub item to remove with it
-	for (let E = 0; E < C.Appearance.length; E++)
-		if (C.Appearance[E].Asset.Group.Name == AssetGroup)
-			for (let R = 0; R < C.Appearance[E].Asset.RemoveItemOnRemove.length; R++)
-				if ((C.Appearance[E].Asset.RemoveItemOnRemove[R].Name == "") || ((C.Appearance[E].Asset.RemoveItemOnRemove[R].Name != "") && (InventoryGet(C, C.Appearance[E].Asset.RemoveItemOnRemove[R].Group) != null) && (InventoryGet(C, C.Appearance[E].Asset.RemoveItemOnRemove[R].Group).Asset.Name == C.Appearance[E].Asset.RemoveItemOnRemove[R].Name)))
-					InventoryRemove(C, C.Appearance[E].Asset.RemoveItemOnRemove[R].Group);
+	for (var E = 0; E < C.Appearance.length; E++)
+		if (C.Appearance[E].Asset.Group.Name == AssetGroup) {
+			let AssetToRemove = C.Appearance[E].Asset
+			for (let R = 0; R < AssetToRemove.RemoveItemOnRemove.length; R++)
+				if ((AssetToRemove.RemoveItemOnRemove[R].Name == "") || ((AssetToRemove.RemoveItemOnRemove[R].Name != "") && (InventoryGet(C, AssetToRemove.RemoveItemOnRemove[R].Group) != null) && (InventoryGet(C, AssetToRemove.RemoveItemOnRemove[R].Group).Asset.Name == AssetToRemove.RemoveItemOnRemove[R].Name)))
+					InventoryRemove(C, AssetToRemove.RemoveItemOnRemove[R].Group);
+		}
 
 	// Second loop to find the item again, and remove it from the character appearance
 	for (let E = 0; E < C.Appearance.length; E++)

--- a/BondageClub/Scripts/Inventory.js
+++ b/BondageClub/Scripts/Inventory.js
@@ -356,13 +356,11 @@ function InventoryWearRandom(C, GroupName, Difficulty) {
 function InventoryRemove(C, AssetGroup) {
 
 	// First loop to find the item and any sub item to remove with it
-	for (var E = 0; E < C.Appearance.length; E++)
-		if (C.Appearance[E].Asset.Group.Name == AssetGroup) {
-			let AssetToRemove = C.Appearance[E].Asset
-			for (let R = 0; R < AssetToRemove.RemoveItemOnRemove.length; R++)
-				if ((AssetToRemove.RemoveItemOnRemove[R].Name == "") || ((AssetToRemove.RemoveItemOnRemove[R].Name != "") && (InventoryGet(C, AssetToRemove.RemoveItemOnRemove[R].Group) != null) && (InventoryGet(C, AssetToRemove.RemoveItemOnRemove[R].Group).Asset.Name == AssetToRemove.RemoveItemOnRemove[R].Name)))
-					InventoryRemove(C, AssetToRemove.RemoveItemOnRemove[R].Group);
-		}
+	for (let E = 0; E < C.Appearance.length; E++)
+		if (C.Appearance[E].Asset.Group.Name == AssetGroup)
+			for (let R = 0; R < C.Appearance[E].Asset.RemoveItemOnRemove.length; R++)
+				if ((C.Appearance[E].Asset.RemoveItemOnRemove[R].Name == "") || ((C.Appearance[E].Asset.RemoveItemOnRemove[R].Name != "") && (InventoryGet(C, C.Appearance[E].Asset.RemoveItemOnRemove[R].Group) != null) && (InventoryGet(C, C.Appearance[E].Asset.RemoveItemOnRemove[R].Group).Asset.Name == C.Appearance[E].Asset.RemoveItemOnRemove[R].Name)))
+					InventoryRemove(C, C.Appearance[E].Asset.RemoveItemOnRemove[R].Group);
 
 	// Second loop to find the item again, and remove it from the character appearance
 	for (let E = 0; E < C.Appearance.length; E++)


### PR DESCRIPTION
- fixed a crash with items containing a RemoveItemOnRemove item.

ways to reproduce -> Char1 and Char2 are in the same room, Char2 uses a leather armbinder with straps or a suspension hogtie , Char2 changes the color of it, Char2 tries to remove it -> Char1 has an error and the item stays

https://discord.com/channels/554377975714414605/554378725916147722/742716102185844796