### PR TITLE
Beta Bugfix: Fix for gag level returning 0 on locked items

### DIFF
--- a/BondageClub/Scripts/Speech.js
+++ b/BondageClub/Scripts/Speech.js
@@ -53,7 +53,10 @@ function SpeechGetGagLevel(C, AssetGroup) {
 		var item = C.Appearance[i];
 		if (item.Asset.Group.Name === AssetGroup) {
 			var EffectArray = [];
-			if (item.Property && Array.isArray(item.Property.Effect)) EffectArray = item.Property.Effect;
+			if (item.Property &&
+			    Array.isArray(item.Property.Effect) &&
+			    !(typeof item.Property.Type === "undefined" && item.Property.Effect.length === 1 && item.Property.Effect[0] === "Lock")
+			) EffectArray = item.Property.Effect;
 			else if (Array.isArray(item.Asset.Effect)) EffectArray = item.Asset.Effect;
 			else if (Array.isArray(item.Asset.Group.Effect)) EffectArray = item.Asset.Group.Effect;
 			GagEffect += SpeechGetEffectGagLevel(EffectArray);


### PR DESCRIPTION
## Summary

This PR fixes an oversight in the new `SpeechGetGagLevel` function where the `Property.Effect` array would be used to calculate a non-extended item's gag level when it was locked (and hence it's `Effect` array would be `["Lock"]`, causing a gag level of 0 to be returned).

The function now checks for `Property.Effect` arrays containing only the `Lock` effect, and falls back to `Asset.Property` if the item isn't an extended item with allowed types.

## Steps to reproduce

* Equip any non-extended gag
* Talk - note that speech is garbled as expected
* Lock the gag (with any lock)
* Talk - note that speech is no longer garbled