### PR TITLE
Hidden Items - Block Option

### DIFF
--- a/BondageClub/Screens/Character/Preference/Text_Preference.csv
+++ b/BondageClub/Screens/Character/Preference/Text_Preference.csv
@@ -3,7 +3,7 @@ ChatPreferences,- Chat Preferences -
 AudioPreferences,- Audio Preferences -
 ArousalPreferences,- Arousal Meter & Sexual Activities Preferences -
 SecurityPreferences,- Security Preferences -
-VisibilityPreferences,- Item Visibility Preferences -
+VisibilityPreferences,- Item Preferences -
 CharacterLabelColor,Character label color:
 ItemPermission,Item permission:
 PermissionLevel0,"Everyone, no exceptions"
@@ -128,8 +128,10 @@ ArousalStutterVibration,When you're vibrated
 ArousalStutterAll,Aroused & vibrated
 VisibilityGroup,Group:
 VisibilityAsset,Asset:
-VisibilityCheckbox,Hide
+VisibilityCheckboxHide,Hide
+VisibilityCheckboxBlock,Block
 VisibilityWarning,This icon will appear beside a character that's wearing a hidden item
-VisibilityReset,This will reset all items to be visible. Click again to confirm and exit.
+VisibilityReset,Reset All
+VisibilityResetDescription,This will reset all items to be visible. Click again to confirm and exit.
 LeaveSave,Accept changes
 LeaveNoSave,Cancel changes


### PR DESCRIPTION
This is the change that was discussed in PR #1277.
The item visibility preference screen now includes a Block checkbox under the Hide one, which allows the player to set whether they want the item blocked. This will not appear as an option if the item is currently being worn or is already set to Limited.