### PR TITLE
Improvement: wardrobe restore properties

### DIFF
--- a/BondageClub/Screens/Character/Appearance/Appearance.js
+++ b/BondageClub/Screens/Character/Appearance/Appearance.js
@@ -884,6 +884,10 @@ function AppearanceClick() {
 		// Cancels the selected cloth and reverts it back
 		if (!DialogItemPermissionMode && (MouseX >= 1768) && (MouseX < 1858) && (MouseY >= 25) && (MouseY < 115)) {
 			CharacterAppearanceSetItem(C, C.FocusGroup.Name, ((CharacterAppearanceCloth != null) && (CharacterAppearanceCloth.Asset != null)) ? CharacterAppearanceCloth.Asset : null);
+			if (CharacterAppearanceCloth != null && CharacterAppearanceCloth.Property != null) {
+				InventoryGet(C, C.FocusGroup.Name).Property = CharacterAppearanceCloth.Property;
+				CharacterRefresh(C, false);
+			}
 			C.FocusGroup = null;
 			AppearanceExit();
 		}


### PR DESCRIPTION
- made it so canceling out reverts the extended properties 

Cancelling out a change did not save extended properties, this applies them properly when applicable. 