### PR TITLE
Improvement: Extended script support for clothes

### DIFF
--- a/BondageClub/Screens/Character/Appearance/Appearance.js
+++ b/BondageClub/Screens/Character/Appearance/Appearance.js
@@ -884,6 +884,10 @@ function AppearanceClick() {
 		// Cancels the selected cloth and reverts it back
 		if (!DialogItemPermissionMode && (MouseX >= 1768) && (MouseX < 1858) && (MouseY >= 25) && (MouseY < 115)) {
 			CharacterAppearanceSetItem(C, C.FocusGroup.Name, ((CharacterAppearanceCloth != null) && (CharacterAppearanceCloth.Asset != null)) ? CharacterAppearanceCloth.Asset : null);
+			if (CharacterAppearanceCloth != null && CharacterAppearanceCloth.Property != null) {
+				InventoryGet(C, C.FocusGroup.Name).Property = CharacterAppearanceCloth.Property;
+				CharacterRefresh(C, false);
+			}
 			C.FocusGroup = null;
 			AppearanceExit();
 		}

--- a/BondageClub/Screens/Character/Appearance/Appearance.js
+++ b/BondageClub/Screens/Character/Appearance/Appearance.js
@@ -884,10 +884,6 @@ function AppearanceClick() {
 		// Cancels the selected cloth and reverts it back
 		if (!DialogItemPermissionMode && (MouseX >= 1768) && (MouseX < 1858) && (MouseY >= 25) && (MouseY < 115)) {
 			CharacterAppearanceSetItem(C, C.FocusGroup.Name, ((CharacterAppearanceCloth != null) && (CharacterAppearanceCloth.Asset != null)) ? CharacterAppearanceCloth.Asset : null);
-			if (CharacterAppearanceCloth != null && CharacterAppearanceCloth.Property != null) {
-				InventoryGet(C, C.FocusGroup.Name).Property = CharacterAppearanceCloth.Property;
-				CharacterRefresh(C, false);
-			}
 			C.FocusGroup = null;
 			AppearanceExit();
 		}

--- a/BondageClub/Scripts/ExtendedItem.js
+++ b/BondageClub/Scripts/ExtendedItem.js
@@ -103,10 +103,10 @@ function ExtendedItemDraw(Options, DialogPrefix) {
  * Handles clicks on the extended item type selection screen
  * @param {ExtendedItemOption[]} Options - An Array of type definitions for each allowed extended type. The first item in the array should
  *     be the default option.
- * @param {boolean} Clothes - TRUE if the click is performed on a clothing item.
+ * @param {boolean} IsClothes - Whether or not the click is performed on a clothing item.
  * @returns {void} Nothing
  */
-function ExtendedItemClick(Options, Clothes) {
+function ExtendedItemClick(Options, IsClothes) {
 
 	// Exit button
 	if (MouseIn(1885, 25, 90, 85)) {
@@ -116,9 +116,9 @@ function ExtendedItemClick(Options, Clothes) {
 
 	var IsSelfBondage = CharacterGetCurrent().ID === 0;
 	if (Options.length === 2) {
-		ExtendedItemClickTwo(Options, IsSelfBondage, Clothes);
+		ExtendedItemClickTwo(Options, IsSelfBondage, IsClothes);
 	} else {
-		ExtendedItemClickGrid(Options, IsSelfBondage, Clothes);
+		ExtendedItemClickGrid(Options, IsSelfBondage, IsClothes);
 	}
 }
 
@@ -127,10 +127,10 @@ function ExtendedItemClick(Options, Clothes) {
  * @param {ExtendedItemOption[]} Options - An Array of type definitions for each allowed extended type. The first item in the array should
  *     be the default option.
  * @param {ExtendedItemOption} Option - The selected type definition
- * @param {boolean} Clothes - TRUE if the click is performed on a clothing item.
+ * @param {boolean} IsClothes - Whether or not the click is performed on a clothing item.
  * @returns {void} Nothing
  */
-function ExtendedItemSetType(Options, Option, Clothes) {
+function ExtendedItemSetType(Options, Option, IsClothes) {
 	var C = CharacterGetCurrent();
 	var FunctionPrefix = ExtendedItemFunctionPrefix();
 
@@ -164,10 +164,10 @@ function ExtendedItemSetType(Options, Option, Clothes) {
 	}
 
 	DialogFocusItem.Property = NewProperty;
-	CharacterRefresh(C, !Clothes); // Does not sync appearance while in the wardrobe
+	CharacterRefresh(C, !IsClothes); // Does not sync appearance while in the wardrobe
 	
 	// For a restraint, we might publish an action or change the dialog of a NPC
-	if (!Clothes) {
+	if (!IsClothes) {
 		ChatRoomCharacterUpdate(C);
 		if (CurrentScreen === "ChatRoom") {
 			// If we're in a chatroom, call the item's publish function to publish a message to the chatroom
@@ -242,16 +242,16 @@ function ExtendedItemDrawGrid(Options, DialogPrefix, IsSelfBondage) {
  * @param {ExtendedItemOption[]} Options - An Array of type definitions for each allowed extended type. The first item in the array should
  *     be the default option.
  * @param {boolean} IsSelfBondage - Whether or not the player is applying the item to themselves
- * @param {boolean} Clothes - TRUE if the click is performed on a clothing item.
+ * @param {boolean} IsClothes - Whether or not the click is performed on a clothing item.
  * @returns {void} Nothing
  */
-function ExtendedItemClickTwo(Options, IsSelfBondage, Clothes) {
+function ExtendedItemClickTwo(Options, IsSelfBondage, IsClothes) {
 	for (let I = 0; I < Options.length; I++) {
 		var X = 1175 + I * 425;
 		var Y = 550;
 		var Option = Options[I];
 		if (MouseIn(X, Y, 225, 225) && DialogFocusItem.Property.Type !== Option.Property.Type) {
-			ExtendedItemHandleOptionClick(Options, Option, IsSelfBondage, Clothes);
+			ExtendedItemHandleOptionClick(Options, Option, IsSelfBondage, IsClothes);
 		}
 	}
 }
@@ -261,10 +261,10 @@ function ExtendedItemClickTwo(Options, IsSelfBondage, Clothes) {
  * @param {ExtendedItemOption[]} Options - An Array of type definitions for each allowed extended type. The first item in the array should
  *     be the default option.
  * @param {boolean} IsSelfBondage - Whether or not the player is applying the item to themselves
- * @param {boolean} Clothes - TRUE if the click is performed on a clothing item.
+ * @param {boolean} IsClothes - Whether or not the click is performed on a clothing item.
  * @returns {void} Nothing
  */
-function ExtendedItemClickGrid(Options, IsSelfBondage, Clothes) {
+function ExtendedItemClickGrid(Options, IsSelfBondage, IsClothes) {
 
 	// Pagination button
 	if ((Options.length > 4) && MouseIn(1775, 25, 90, 85))
@@ -278,7 +278,7 @@ function ExtendedItemClickGrid(Options, IsSelfBondage, Clothes) {
 		var Y = 450 + (Math.floor(offset / 2) * 300);
 		var Option = Options[I];
 		if (MouseIn(X, Y, 225, 225) && DialogFocusItem.Property.Type !== Option.Property.Type) {
-			ExtendedItemHandleOptionClick(Options, Option, IsSelfBondage, Clothes);
+			ExtendedItemHandleOptionClick(Options, Option, IsSelfBondage, IsClothes);
 		}
 	}
 }
@@ -289,15 +289,15 @@ function ExtendedItemClickGrid(Options, IsSelfBondage, Clothes) {
  *     be the default option.
  * @param {ExtendedItemOption} Option - The selected type definition
  * @param {boolean} IsSelfBondage - Whether or not the player is applying the item to themselves
- * @param {boolean} Clothes - TRUE if the click is performed on a clothing item.
+ * @param {boolean} IsClothes - Whether or not the click is performed on a clothing item.
  * @returns {void} Nothing
  */
-function ExtendedItemHandleOptionClick(Options, Option, IsSelfBondage, Clothes) {
+function ExtendedItemHandleOptionClick(Options, Option, IsSelfBondage, IsClothes) {
 	var requirementMessage = ExtendedItemRequirementCheckMessage(Option, IsSelfBondage);
 	if (requirementMessage) {
 		DialogExtendedMessage = requirementMessage;
 	} else {
-		ExtendedItemSetType(Options, Option, Clothes);
+		ExtendedItemSetType(Options, Option, IsClothes);
 	}
 }
 

--- a/BondageClub/Scripts/ExtendedItem.js
+++ b/BondageClub/Scripts/ExtendedItem.js
@@ -103,10 +103,10 @@ function ExtendedItemDraw(Options, DialogPrefix) {
  * Handles clicks on the extended item type selection screen
  * @param {ExtendedItemOption[]} Options - An Array of type definitions for each allowed extended type. The first item in the array should
  *     be the default option.
- * @param {boolean} IsClothes - Whether or not the click is performed on a clothing item.
+ * @param {boolean} IsCloth - Whether or not the click is performed on a clothing item.
  * @returns {void} Nothing
  */
-function ExtendedItemClick(Options, IsClothes) {
+function ExtendedItemClick(Options, IsCloth) {
 
 	// Exit button
 	if (MouseIn(1885, 25, 90, 85)) {
@@ -116,9 +116,9 @@ function ExtendedItemClick(Options, IsClothes) {
 
 	var IsSelfBondage = CharacterGetCurrent().ID === 0;
 	if (Options.length === 2) {
-		ExtendedItemClickTwo(Options, IsSelfBondage, IsClothes);
+		ExtendedItemClickTwo(Options, IsSelfBondage, IsCloth);
 	} else {
-		ExtendedItemClickGrid(Options, IsSelfBondage, IsClothes);
+		ExtendedItemClickGrid(Options, IsSelfBondage, IsCloth);
 	}
 }
 
@@ -127,10 +127,10 @@ function ExtendedItemClick(Options, IsClothes) {
  * @param {ExtendedItemOption[]} Options - An Array of type definitions for each allowed extended type. The first item in the array should
  *     be the default option.
  * @param {ExtendedItemOption} Option - The selected type definition
- * @param {boolean} IsClothes - Whether or not the click is performed on a clothing item.
+ * @param {boolean} IsCloth - Whether or not the click is performed on a clothing item.
  * @returns {void} Nothing
  */
-function ExtendedItemSetType(Options, Option, IsClothes) {
+function ExtendedItemSetType(Options, Option, IsCloth) {
 	var C = CharacterGetCurrent();
 	var FunctionPrefix = ExtendedItemFunctionPrefix();
 
@@ -164,10 +164,10 @@ function ExtendedItemSetType(Options, Option, IsClothes) {
 	}
 
 	DialogFocusItem.Property = NewProperty;
-	CharacterRefresh(C, !IsClothes); // Does not sync appearance while in the wardrobe
+	CharacterRefresh(C, !IsCloth); // Does not sync appearance while in the wardrobe
 	
 	// For a restraint, we might publish an action or change the dialog of a NPC
-	if (!IsClothes) {
+	if (!IsCloth) {
 		ChatRoomCharacterUpdate(C);
 		if (CurrentScreen === "ChatRoom") {
 			// If we're in a chatroom, call the item's publish function to publish a message to the chatroom
@@ -242,16 +242,16 @@ function ExtendedItemDrawGrid(Options, DialogPrefix, IsSelfBondage) {
  * @param {ExtendedItemOption[]} Options - An Array of type definitions for each allowed extended type. The first item in the array should
  *     be the default option.
  * @param {boolean} IsSelfBondage - Whether or not the player is applying the item to themselves
- * @param {boolean} IsClothes - Whether or not the click is performed on a clothing item.
+ * @param {boolean} IsCloth - Whether or not the click is performed on a clothing item.
  * @returns {void} Nothing
  */
-function ExtendedItemClickTwo(Options, IsSelfBondage, IsClothes) {
+function ExtendedItemClickTwo(Options, IsSelfBondage, IsCloth) {
 	for (let I = 0; I < Options.length; I++) {
 		var X = 1175 + I * 425;
 		var Y = 550;
 		var Option = Options[I];
 		if (MouseIn(X, Y, 225, 225) && DialogFocusItem.Property.Type !== Option.Property.Type) {
-			ExtendedItemHandleOptionClick(Options, Option, IsSelfBondage, IsClothes);
+			ExtendedItemHandleOptionClick(Options, Option, IsSelfBondage, IsCloth);
 		}
 	}
 }
@@ -261,10 +261,10 @@ function ExtendedItemClickTwo(Options, IsSelfBondage, IsClothes) {
  * @param {ExtendedItemOption[]} Options - An Array of type definitions for each allowed extended type. The first item in the array should
  *     be the default option.
  * @param {boolean} IsSelfBondage - Whether or not the player is applying the item to themselves
- * @param {boolean} IsClothes - Whether or not the click is performed on a clothing item.
+ * @param {boolean} IsCloth - Whether or not the click is performed on a clothing item.
  * @returns {void} Nothing
  */
-function ExtendedItemClickGrid(Options, IsSelfBondage, IsClothes) {
+function ExtendedItemClickGrid(Options, IsSelfBondage, IsCloth) {
 
 	// Pagination button
 	if ((Options.length > 4) && MouseIn(1775, 25, 90, 85))
@@ -278,7 +278,7 @@ function ExtendedItemClickGrid(Options, IsSelfBondage, IsClothes) {
 		var Y = 450 + (Math.floor(offset / 2) * 300);
 		var Option = Options[I];
 		if (MouseIn(X, Y, 225, 225) && DialogFocusItem.Property.Type !== Option.Property.Type) {
-			ExtendedItemHandleOptionClick(Options, Option, IsSelfBondage, IsClothes);
+			ExtendedItemHandleOptionClick(Options, Option, IsSelfBondage, IsCloth);
 		}
 	}
 }
@@ -289,15 +289,15 @@ function ExtendedItemClickGrid(Options, IsSelfBondage, IsClothes) {
  *     be the default option.
  * @param {ExtendedItemOption} Option - The selected type definition
  * @param {boolean} IsSelfBondage - Whether or not the player is applying the item to themselves
- * @param {boolean} IsClothes - Whether or not the click is performed on a clothing item.
+ * @param {boolean} IsCloth - Whether or not the click is performed on a clothing item.
  * @returns {void} Nothing
  */
-function ExtendedItemHandleOptionClick(Options, Option, IsSelfBondage, IsClothes) {
+function ExtendedItemHandleOptionClick(Options, Option, IsSelfBondage, IsCloth) {
 	var requirementMessage = ExtendedItemRequirementCheckMessage(Option, IsSelfBondage);
 	if (requirementMessage) {
 		DialogExtendedMessage = requirementMessage;
 	} else {
-		ExtendedItemSetType(Options, Option, IsClothes);
+		ExtendedItemSetType(Options, Option, IsCloth);
 	}
 }
 

--- a/BondageClub/Scripts/ExtendedItem.js
+++ b/BondageClub/Scripts/ExtendedItem.js
@@ -103,9 +103,10 @@ function ExtendedItemDraw(Options, DialogPrefix) {
  * Handles clicks on the extended item type selection screen
  * @param {ExtendedItemOption[]} Options - An Array of type definitions for each allowed extended type. The first item in the array should
  *     be the default option.
+ * @param {boolean} Clothes - TRUE if the click is performed on a clothing item.
  * @returns {void} Nothing
  */
-function ExtendedItemClick(Options) {
+function ExtendedItemClick(Options, Clothes) {
 
 	// Exit button
 	if (MouseIn(1885, 25, 90, 85)) {
@@ -115,9 +116,9 @@ function ExtendedItemClick(Options) {
 
 	var IsSelfBondage = CharacterGetCurrent().ID === 0;
 	if (Options.length === 2) {
-		ExtendedItemClickTwo(Options, IsSelfBondage);
+		ExtendedItemClickTwo(Options, IsSelfBondage, Clothes);
 	} else {
-		ExtendedItemClickGrid(Options, IsSelfBondage);
+		ExtendedItemClickGrid(Options, IsSelfBondage, Clothes);
 	}
 }
 
@@ -126,9 +127,10 @@ function ExtendedItemClick(Options) {
  * @param {ExtendedItemOption[]} Options - An Array of type definitions for each allowed extended type. The first item in the array should
  *     be the default option.
  * @param {ExtendedItemOption} Option - The selected type definition
+ * @param {boolean} Clothes - TRUE if the click is performed on a clothing item.
  * @returns {void} Nothing
  */
-function ExtendedItemSetType(Options, Option) {
+function ExtendedItemSetType(Options, Option, Clothes) {
 	var C = CharacterGetCurrent();
 	var FunctionPrefix = ExtendedItemFunctionPrefix();
 
@@ -162,21 +164,24 @@ function ExtendedItemSetType(Options, Option) {
 	}
 
 	DialogFocusItem.Property = NewProperty;
-	CharacterRefresh(C);
-	ChatRoomCharacterUpdate(C);
-
-	if (CurrentScreen === "ChatRoom") {
-		// If we're in a chatroom, call the item's publish function to publish a message to the chatroom
-		CommonCallFunctionByName(FunctionPrefix + "PublishAction", C, Option, PreviousOption);
-	} else {
-		DialogFocusItem = null;
-		if (C.ID === 0) {
-			// Player is using the item on herself
-			DialogMenuButtonBuild(C);
+	CharacterRefresh(C, !Clothes); // Does not sync appearance while in the wardrobe
+	
+	// For a restraint, we might publish an action or change the dialog of a NPC
+	if (!Clothes) {
+		ChatRoomCharacterUpdate(C);
+		if (CurrentScreen === "ChatRoom") {
+			// If we're in a chatroom, call the item's publish function to publish a message to the chatroom
+			CommonCallFunctionByName(FunctionPrefix + "PublishAction", C, Option, PreviousOption);
 		} else {
-			// Otherwise, call the item's NPC dialog function, if one exists
-			CommonCallFunctionByName(FunctionPrefix + "NpcDialog", C, Option, PreviousOption);
-			C.FocusGroup = null;
+			DialogFocusItem = null;
+			if (C.ID === 0) {
+				// Player is using the item on herself
+				DialogMenuButtonBuild(C);
+			} else {
+				// Otherwise, call the item's NPC dialog function, if one exists
+				CommonCallFunctionByName(FunctionPrefix + "NpcDialog", C, Option, PreviousOption);
+				C.FocusGroup = null;
+			}
 		}
 	}
 }
@@ -237,15 +242,16 @@ function ExtendedItemDrawGrid(Options, DialogPrefix, IsSelfBondage) {
  * @param {ExtendedItemOption[]} Options - An Array of type definitions for each allowed extended type. The first item in the array should
  *     be the default option.
  * @param {boolean} IsSelfBondage - Whether or not the player is applying the item to themselves
+ * @param {boolean} Clothes - TRUE if the click is performed on a clothing item.
  * @returns {void} Nothing
  */
-function ExtendedItemClickTwo(Options, IsSelfBondage) {
+function ExtendedItemClickTwo(Options, IsSelfBondage, Clothes) {
 	for (let I = 0; I < Options.length; I++) {
 		var X = 1175 + I * 425;
 		var Y = 550;
 		var Option = Options[I];
 		if (MouseIn(X, Y, 225, 225) && DialogFocusItem.Property.Type !== Option.Property.Type) {
-			ExtendedItemHandleOptionClick(Options, Option, IsSelfBondage);
+			ExtendedItemHandleOptionClick(Options, Option, IsSelfBondage, Clothes);
 		}
 	}
 }
@@ -255,9 +261,10 @@ function ExtendedItemClickTwo(Options, IsSelfBondage) {
  * @param {ExtendedItemOption[]} Options - An Array of type definitions for each allowed extended type. The first item in the array should
  *     be the default option.
  * @param {boolean} IsSelfBondage - Whether or not the player is applying the item to themselves
+ * @param {boolean} Clothes - TRUE if the click is performed on a clothing item.
  * @returns {void} Nothing
  */
-function ExtendedItemClickGrid(Options, IsSelfBondage) {
+function ExtendedItemClickGrid(Options, IsSelfBondage, Clothes) {
 
 	// Pagination button
 	if ((Options.length > 4) && MouseIn(1775, 25, 90, 85))
@@ -271,7 +278,7 @@ function ExtendedItemClickGrid(Options, IsSelfBondage) {
 		var Y = 450 + (Math.floor(offset / 2) * 300);
 		var Option = Options[I];
 		if (MouseIn(X, Y, 225, 225) && DialogFocusItem.Property.Type !== Option.Property.Type) {
-			ExtendedItemHandleOptionClick(Options, Option, IsSelfBondage);
+			ExtendedItemHandleOptionClick(Options, Option, IsSelfBondage, Clothes);
 		}
 	}
 }
@@ -282,14 +289,15 @@ function ExtendedItemClickGrid(Options, IsSelfBondage) {
  *     be the default option.
  * @param {ExtendedItemOption} Option - The selected type definition
  * @param {boolean} IsSelfBondage - Whether or not the player is applying the item to themselves
+ * @param {boolean} Clothes - TRUE if the click is performed on a clothing item.
  * @returns {void} Nothing
  */
-function ExtendedItemHandleOptionClick(Options, Option, IsSelfBondage) {
+function ExtendedItemHandleOptionClick(Options, Option, IsSelfBondage, Clothes) {
 	var requirementMessage = ExtendedItemRequirementCheckMessage(Option, IsSelfBondage);
 	if (requirementMessage) {
 		DialogExtendedMessage = requirementMessage;
 	} else {
-		ExtendedItemSetType(Options, Option);
+		ExtendedItemSetType(Options, Option, Clothes);
 	}
 }
 


### PR DESCRIPTION
- added explicit support for clothes in the extended script

This will allow an extended item to prevent being refreshed/sending messages so that changing an item will not change the appearance for others in the room. This will also allow us to tweak things based on restraints vs clothes in the future

Talked with Ellie to make this change as best as it could be.