### PR TITLE
Beta Bugfix: Minor issue with layer sorting for layers belonging to the same asset

### DIFF
--- a/BondageClub/Screens/Character/Appearance/Appearance.js
+++ b/BondageClub/Screens/Character/Appearance/Appearance.js
@@ -308,10 +308,10 @@ function CharacterAppearanceSortLayers(C) {
 		return layersAcc;
 	}, []);
 	return layers.sort((l1, l2) => {
-		// If the layers belong to the same Asset, ensure layer order is preserved
-		if (l1.Asset === l2.Asset) return l1.Asset.Layer.indexOf(l1) - l1.Asset.Layer.indexOf(l2);
 		// If priorities are different, sort by priority
 		if (l1.Priority !== l2.Priority) return l1.Priority - l2.Priority;
+		// If the priorities are identical and the layers belong to the same Asset, ensure layer order is preserved
+		if (l1.Asset === l2.Asset) return l1.Asset.Layer.indexOf(l1) - l1.Asset.Layer.indexOf(l2);
 		// If priorities are identical, sort alphabetically to maintain consistency
 		return (l1.Asset.Group.Name + l1.Asset.Name).localeCompare(l2.Asset.Group.Name + l2.Asset.Name);
 	});


### PR DESCRIPTION
## Summary

This PR fixes a small issue with layer sorting between layers that belong to the same asset. If two layers belonged to the same asset with different priorities, the layer sorting algorithm would respect the position of the layers inside their parent asset's `Layer` array, rather than respecting their priorities. This meant that the sort order could become inconsistent, causing the layers to be rendered incorrectly (see image below).

This PR changes the sorting algorithm so that priority is most important, and position within the asset is used as a fallback in the case of equal priorities.

![Incorrect layer order](https://cdn.discordapp.com/attachments/743491048352907355/744581538859057252/Screenshot_68.png)