### PR TITLE
Beta Fix: extended leave

### DIFF
--- a/BondageClub/Screens/Character/Appearance/Appearance.js
+++ b/BondageClub/Screens/Character/Appearance/Appearance.js
@@ -434,6 +434,12 @@ function CharacterAppearanceGetCurrentValue(C, Group, Type) {
  * @returns {void} - Nothing
  */
 function AppearanceLoad() {
+	// We quit the extended item menu if it was not properly closed previously.
+	if (DialogFocusItem) {
+		DialogLeaveFocusItem();
+		DialogFocusItem = null;
+	}
+	
 	if (!CharacterAppearanceSelection) CharacterAppearanceSelection = Player;
 	var C = CharacterAppearanceSelection;
 	CharacterAppearanceBuildAssets(Player);

--- a/BondageClub/Screens/Character/Appearance/Appearance.js
+++ b/BondageClub/Screens/Character/Appearance/Appearance.js
@@ -434,12 +434,8 @@ function CharacterAppearanceGetCurrentValue(C, Group, Type) {
  * @returns {void} - Nothing
  */
 function AppearanceLoad() {
-	// We quit the extended item menu if it was not properly closed previously.
-	if (DialogFocusItem) {
-		DialogLeaveFocusItem();
-		DialogFocusItem = null;
-	}
-	
+	// We make sure no extended item was left active by mistake.
+	DialogFocusItem = null;
 	if (!CharacterAppearanceSelection) CharacterAppearanceSelection = Player;
 	var C = CharacterAppearanceSelection;
 	CharacterAppearanceBuildAssets(Player);


### PR DESCRIPTION
- fixed a case where going in the wardrobe revealed restraints extended menus

some items do not reset DialogFocusItem under certain circumstances, this makes sure to reset any of them if they were still active.