### PR TITLE
Inherit Colours - Hands Fix

### DIFF
--- a/BondageClub/Assets/Female3DCG/Female3DCG.csv
+++ b/BondageClub/Assets/Female3DCG/Female3DCG.csv
@@ -378,8 +378,6 @@ BodyLower,Small,Small
 BodyLower,Normal,Normal
 BodyLower,Large,Large
 BodyLower,XLarge,Xlarge
-Hands,,Hands
-Hands,Default,Default
 HairBack,,Back Hair
 HairBack,HairNone,None
 HairBack,HairBack1,Style 1

--- a/BondageClub/Assets/Female3DCG/Female3DCG.js
+++ b/BondageClub/Assets/Female3DCG/Female3DCG.js
@@ -865,6 +865,7 @@ var AssetFemale3DCG = [
 		ParentColor: "BodyUpper",
 		Priority: 27,
 		AllowNone: false,
+		AllowColorize: false,
 		AllowCustomize: false,
 		AllowPose: ["TapedHands", "BackBoxTie", "BackCuffs", "BackElbowTouch", "AllFours"],
 		Asset: ["Default"],

--- a/BondageClub/Assets/Female3DCG/Female3DCG.js
+++ b/BondageClub/Assets/Female3DCG/Female3DCG.js
@@ -765,17 +765,6 @@ var AssetFemale3DCG = [
 	},
 
 	{
-		Group: "Hands",
-		ParentColor: "BodyUpper",
-		Priority: 27,
-		AllowNone: false,
-		AllowCustomize: false,
-		AllowPose: ["TapedHands", "BackBoxTie", "BackCuffs", "BackElbowTouch", "AllFours"],
-		Asset: ["Default"],
-		InheritColor: "BodyUpper"
-	},
-
-	{
 		Group: "HairBack",
 		Priority: 5,
 		Left: 50,
@@ -869,6 +858,17 @@ var AssetFemale3DCG = [
 		AllowNone: false,
 		Asset: ["PussyLight1", "PussyLight2", "PussyLight3", "PussyDark1", "PussyDark2", "PussyDark3"],
 		Color: ["Default", "#6a3628", "#443330", "#222222"]
+	},
+
+	{
+		Group: "Hands",
+		ParentColor: "BodyUpper",
+		Priority: 27,
+		AllowNone: false,
+		AllowCustomize: false,
+		AllowPose: ["TapedHands", "BackBoxTie", "BackCuffs", "BackElbowTouch", "AllFours"],
+		Asset: ["Default"],
+		InheritColor: "BodyUpper"
 	},
 
 	// Facial Expression specific


### PR DESCRIPTION
Moving the Hands group down below the customizable groups so that it doesn't leave a gap and disabling AllowColorize again.