### PR TITLE
Fix: Reset to old emoticon after afk

### DIFF
--- a/BondageClub/Scripts/AfkTimer.js
+++ b/BondageClub/Scripts/AfkTimer.js
@@ -7,6 +7,7 @@ var AfkTimerIsSet = false;
 var AfkTimerIsEnabled = null;
 var AfkTimerEventsList = ['mousedown', 'mousemove', 'keypress', 'scroll', 'touchstart'];
 var AfkTimerID = null;
+var AfkTimerOldEmoticon = null;
 
 /**
  * Resets the timer for AFK count
@@ -16,7 +17,8 @@ function AfkTimerReset() {
     AfkTimerIdle = 0;
     if (AfkTimerIsSet) {
         AfkTimerIsSet = false;
-        CharacterSetFacialExpression(Player, "Emoticon", null);
+        CharacterSetFacialExpression(Player, "Emoticon", AfkTimerOldEmoticon);
+        AfkTimerOldEmoticon = null;
     }
 }
 
@@ -67,11 +69,15 @@ function AfkTimerSetEnabled(Enabled) {
 }
 
 /**
- * Sets the players's emote to the Afk symbol, when the timer runs out
+ * Sets the players's emote to the Afk symbol, when the timer runs out and saves the current Emoticon, if there is any
  * @returns {void} - Nothing
  */
 function AfkTimerSetIsAfk() {
     if (CurrentScreen != "ChatRoom") return;
+    // save the current Emoticon, if there is any
+    if (Player.Appearance.filter(A => A.Asset.Name === "Emoticon").length > 0 && AfkTimerOldEmoticon == null) {
+        AfkTimerOldEmoticon = Player.Appearance.filter(A => A.Asset.Name === "Emoticon")[0].Property.Expression;
+    }
     CharacterSetFacialExpression(Player, "Emoticon", "Afk");
     AfkTimerIsSet = true;
 }


### PR DESCRIPTION
# Summary
If a user has the "Auto AFK Setting" enabled and does nothing for 5 minutes, the "AFK" emoticon is shown over her head. As soon as she returns to the game, the Emoticon disappears, instead of resetting to the Emoticon, she had defined before.
This fix saves the old emoticon, before the "AFK" is displayed and reverts back to the old emoticon, when the player returns to the game.
# Details
## Step to reproduce
* Select an emoticon, e.g. "Read"
* Wait until the "AFK" emoticon is shown
* Click with your mouse in the game screen ==> The emoticon disappears
## What it does
* Added lines to save the old emoticon to a global variable in `AFKTimer.js`
## Testing
Did the above described steps on my local instance of the game and the behavior is as expected.