### PR TITLE
Bugfix: Fix for timer locks removing gag effects upon expiry

### DIFF
--- a/BondageClub/Scripts/Timer.js
+++ b/BondageClub/Scripts/Timer.js
@@ -57,10 +57,13 @@ function TimerInventoryRemove() {
 						delete Character[C].Appearance[A].Property.ShowTimer;
 						delete Character[C].Appearance[A].Property.EnableRandomInput;
 						delete Character[C].Appearance[A].Property.MemberNumberList;
-						if (Character[C].Appearance[A].Property.Effect != null)
+						if (Character[C].Appearance[A].Property.Effect != null) {
 							for (let E = 0; E < Character[C].Appearance[A].Property.Effect.length; E++)
 								if (Character[C].Appearance[A].Property.Effect[E] == "Lock")
 									Character[C].Appearance[A].Property.Effect.splice(E, 1);
+							if (!Character[C].Appearance[A].Property.Effect.length) Character[C].Appearance[A].Property.Effect = undefined;
+						}
+
 
 						// If we're removing a lock and we're in a chatroom, send a chatroom message
 						if (LockName && CurrentScreen === "ChatRoom") {


### PR DESCRIPTION
## Summary

There was a small bug with the way timer locks interact with the new gag level calculation code which meant that when the timer expired, it would leave the gag's `Property` with an empty `Effect` array, causing the calculated gag level to be 0.

## Steps to reproduce

1. Equip a (non-extended) gag
2. Attach a timer padlock (any kind) - don't set the padlock to remove the item upon expiry
3. Wait for the timer padlock to expire
4. Note that when the padlock expires, the player can talk normally (no speech garbling)