### PR TITLE
Fix: afk timer

### DIFF
--- a/BondageClub/Scripts/AfkTimer.js
+++ b/BondageClub/Scripts/AfkTimer.js
@@ -75,7 +75,7 @@ function AfkTimerSetEnabled(Enabled) {
 function AfkTimerSetIsAfk() {
     if (CurrentScreen != "ChatRoom") return;
     // save the current Emoticon, if there is any
-    if (InventoryGet(Player, "Emoticon") && InventoryGet(Player, "Emoticon").Property &&AfkTimerOldEmoticon == null) {
+    if (InventoryGet(Player, "Emoticon") && InventoryGet(Player, "Emoticon").Property && AfkTimerOldEmoticon == null) {
         AfkTimerOldEmoticon = InventoryGet(Player, "Emoticon").Property.Expression;
     }
     CharacterSetFacialExpression(Player, "Emoticon", "Afk");

--- a/BondageClub/Scripts/AfkTimer.js
+++ b/BondageClub/Scripts/AfkTimer.js
@@ -75,8 +75,8 @@ function AfkTimerSetEnabled(Enabled) {
 function AfkTimerSetIsAfk() {
     if (CurrentScreen != "ChatRoom") return;
     // save the current Emoticon, if there is any
-    if (Player.Appearance.filter(A => A.Asset.Name === "Emoticon").length > 0 && AfkTimerOldEmoticon == null) {
-        AfkTimerOldEmoticon = Player.Appearance.filter(A => A.Asset.Name === "Emoticon")[0].Property.Expression;
+    if (InventoryGet(Player, "Emoticon") && InventoryGet(Player, "Emoticon").Property &&AfkTimerOldEmoticon == null) {
+        AfkTimerOldEmoticon = InventoryGet(Player, "Emoticon").Property.Expression;
     }
     CharacterSetFacialExpression(Player, "Emoticon", "Afk");
     AfkTimerIsSet = true;


### PR DESCRIPTION
fixed the exception when the emoticon asset was in its initial state (often when loading from wardrobe or randomized character)

I also simplified the check to use InventoryGet