### PR TITLE
Fix: online dialog building

### DIFF
--- a/BondageClub/Scripts/Character.js
+++ b/BondageClub/Scripts/Character.js
@@ -343,11 +343,8 @@ function CharacterLoadOnline(data, SourceMemberNumber) {
 		Char.AccountName = "Online-" + data.ID.toString();
 		Char.MemberNumber = data.MemberNumber;
 		Char.AllowItem = false;
-		var BackupCurrentScreen = CurrentScreen;
-		CurrentScreen = "ChatRoom";
 		CharacterLoadCSVDialog(Char, "Screens/Online/ChatRoom/Dialog_Online");
 		CharacterOnlineRefresh(Char, data, SourceMemberNumber);
-		CurrentScreen = BackupCurrentScreen;
 
 	} else {
 

--- a/BondageClub/Scripts/Translation.js
+++ b/BondageClub/Scripts/Translation.js
@@ -375,9 +375,10 @@ function TranslationDialog(C) {
 	// If we play in a foreign language
 	if ((TranslationLanguage != null) && (TranslationLanguage.trim() != "") && (TranslationLanguage.trim().toUpperCase() != "EN")) {
 
+		var OnlinePlayer = C.AccountName.indexOf("Online-") >= 0;
 		// Finds the full path of the translation file to use
-		var FullPath = ((C.ID == 0) ? "Screens/Character/Player/Dialog_Player" : "Screens/" + CurrentModule + "/" + CurrentScreen + "/Dialog_" + C.AccountName) + "_" + TranslationLanguage + ".txt";
-
+		var FullPath = (OnlinePlayer ? "Screens/Online/ChatRoom/Dialog_Online" :  (C.ID == 0) ? "Screens/Character/Player/Dialog_Player" : "Screens/" + CurrentModule + "/" + CurrentScreen + "/Dialog_" + C.AccountName) + "_" + TranslationLanguage + ".txt";
+			
 		// If the translation file is already loaded, we translate from it
 		if (TranslationCache[FullPath]) {
 			TranslationDialogArray(C, TranslationCache[FullPath]);


### PR DESCRIPTION
This attempts to fix a commonly reported bug where the text for chatroom is not loaded properly (https://discord.com/channels/554377975714414605/554378725916147722/748049560705695754)

The only area this can come from is `TextLoad `which listens to `CurrentScreen`. The lines I've removed are an old trick to get around the parsing restrictions which is the only area in the code where `CurrentScreen `can be altered. (Besides relog which is unrelated). Since the online load is a callback on the socket, if you leave a screen and return to the chatroom while a chatroom sync is triggered... There is a slim change `TextLoad` will be called while the `CurrentScreen `is not `ChatRoom`. The reason for the lack of 404s would be that the Module/Screen combo loaded is still valid which would also make sense due to the fact that we get a "Missing value tag for X". If there would be a 404, `Text` would be null and "Missing tag" would not appear, we would just get blank spots instead.

I'm going to keep an eye out to be 100% sure its this and to find the actual cause if it is not. CurrentScreen is not overwritten anywhere else so I fail to see how else it could happen. 

Regardless, this PR fixes an old bug I fixed for the english format (#978 ), but it wasn't in the `TranslationDialog` function so it still caused issue in other languages. With that change, overwritting `CurrentScreen` in `CharacterLoadOnline `is no longer needed so it's safer to remove it even if it doesn't fix the reported bug above directly.

I tested and loading NPC dialog, your own dialog, online character dialog (in and out of chatroom screen) in english and in another language and all loaded as expected.
