### PR TITLE
Fix: Remove collar cuffs with the collar

### DIFF
--- a/BondageClub/Assets/Female3DCG/Female3DCG.js
+++ b/BondageClub/Assets/Female3DCG/Female3DCG.js
@@ -1743,7 +1743,9 @@ var AssetFemale3DCG = [
 		Left: 185,
 		Top: 160,
 		Zone: [[200, 200, 100, 70]],
-		RemoveItemOnRemove: [{ Group: "ItemNeckAccessories", Name: "" }, { Group: "ItemNeckRestraints", Name: "" }],
+		RemoveItemOnRemove: [{ Group: "ItemNeckAccessories", Name: "" },
+			{ Group: "ItemNeckRestraints", Name: "" },
+			{ Name: "CollarCuffs", Group: "ItemArms" }],
 		Activity: ["Bite", "Kiss", "Lick", "Nibble", "Caress", "MassageHands", "Choke", "TickleItem", "RubItem", "RollItem"],
 		Asset: [
 			{ Name: "LeatherCollar", Fetish: ["Leather"], Value: 20, Difficulty: 50, Time: 5, AllowLock: true },


### PR DESCRIPTION
# Summary
When a club slave has been fitted with collar cuffs and then goes to the club management to have her contract fulfilled, the management removes only the collar, leaving the player with the cuffs that cannot be removed.
This PR fixes that by adding the collar cuffs to the `RemoveItemOnRemoval` attribute of `ItemNeck` assets