### PR TITLE
Fix: timer lock

### DIFF
--- a/BondageClub/Scripts/Timer.js
+++ b/BondageClub/Scripts/Timer.js
@@ -140,10 +140,10 @@ function TimerProcess(Timestamp) {
 	CurrentTime = CurrentTime + TimerRunInterval;
 
 	// At each 1700 ms, we check for timed events (equivalent of 100 cycles at 60FPS)
-	if (TimerLastCycleCall + 1700 <= CurrentTime) {
+	if (TimerLastCycleCall + 1700 <= CommonTime()) {
 		TimerInventoryRemove();
 		TimerPrivateOwnerBeep();
-		TimerLastCycleCall = CurrentTime;
+		TimerLastCycleCall = CommonTime();
 	}
 
 	// Arousal/Activity events only occur in allowed rooms


### PR DESCRIPTION
- fixed a rare edge case where the CurrentTime is altered while wearing a timed lock which makes them think they should be unlocked in the future.

This uses commontime to make sure it is checked every 1.7seconds consistantly regardless of how we manipulate CurrentTime