### PR TITLE
Fix: safewording in spaces

### DIFF
--- a/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
+++ b/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
@@ -1403,7 +1403,7 @@ function ChatRoomSafewordRelease() {
 	ElementRemove("InputChat");
 	ElementRemove("TextAreaChatLog");
 	ServerSend("ChatRoomLeave", "");
-	CommonSetScreen("Room","MainHall");
+	CommonSetScreen("Online","ChatSearch");
 }
 
 /** 


### PR DESCRIPTION
- Fixed a problem where safeword in the asylum was enough to be freed

Instead of safewording into the main hall, I made it so it goes to chatsearch. This keeps the exact same behavior and ensures we do not skip the chatroom space. In the case of LARP, it does not matter, but for the asylum, it makes it so a patient does not have a free pass.