### PR TITLE
Bugfix: Makes struggle progress per keypress independent of framerate

### DIFF
--- a/BondageClub/Scripts/Dialog.js
+++ b/BondageClub/Scripts/Dialog.js
@@ -693,7 +693,7 @@ function DialogProgressGetOperation(C, PrevItem, NextItem) {
 function DialogStruggle(Reverse) {
 
 	// Progress calculation
-	var P = TimerRunInterval * 2.5 / (DialogProgressSkill * CheatFactor("DoubleItemSpeed", 0.5)); // Regular progress, slowed by long timers, faster with cheats
+	var P = 42 / (DialogProgressSkill * CheatFactor("DoubleItemSpeed", 0.5)); // Regular progress, slowed by long timers, faster with cheats
 	P = P * (100 / (DialogProgress + 50));  // Faster when the dialog starts, longer when it ends	
 	if ((DialogProgressChallenge > 6) && (DialogProgress > 50) && (DialogProgressAuto < 0)) P = P * (1 - ((DialogProgress - 50) / 50)); // Beyond challenge 6, it becomes impossible after 50% progress
 	P = P * (Reverse ? -1 : 1); // Reverses the progress if the user pushed the same key twice


### PR DESCRIPTION
## Summary

This fixes a bug that would make it much harder to struggle out of items at higher framerates. `TimerRunInterval` was being used to calculate the amount of struggle progress on each keypress. This meant that at higher framerates it would take many more keypresses to struggle out of the same item. Note that the framerate is still used (correctly as far as I can see) to calculate the amount of progress decay/growth. Note that the 42 multiplier was calculated (and rounded up) using the expected value of `TimerRunInterval` at 60Hz, so this change should keep the struggling experience consistent with the current behaviour at 60Hz regardless of framerate.