### PR TITLE
Fix: Extended Items Next Page

### DIFF
--- a/BondageClub/Scripts/ExtendedItem.js
+++ b/BondageClub/Scripts/ExtendedItem.js
@@ -268,7 +268,7 @@ function ExtendedItemClickGrid(Options, IsSelfBondage, IsCloth) {
 
 	// Pagination button
 	if ((Options.length > 4) && MouseIn(1775, 25, 90, 85))
-		ExtendedItemNextPage(InventoryItemArmsWebOptions);
+		ExtendedItemNextPage(Options);
 
 	var ItemOptionsOffset = ExtendedItemGetOffset();
 


### PR DESCRIPTION
The extended item script's click function had a reference to InventoryItemArmsWebOptions instead of the options passed in. This hasn't matter so far since the Web is the only item currently using the extended scripts with enough options to use a second page.