### PR TITLE
Fix: InventoryLock verification

### DIFF
--- a/BondageClub/Scripts/Inventory.js
+++ b/BondageClub/Scripts/Inventory.js
@@ -562,7 +562,7 @@ function InventoryHasLockableItems(C) {
 function InventoryLock(C, Item, Lock, MemberNumber) {
 	if (typeof Item === 'string') Item = InventoryGet(C, Item);
 	if (typeof Lock === 'string') Lock = { Asset: AssetGet(C.AssetFamily, "ItemMisc", Lock) };
-	if (Item && Lock && Item.Asset.AllowLock) {
+	if (Item && Lock && Item.Asset.AllowLock && Lock.Asset.IsLock) {
 		if (Item.Property == null) Item.Property = {};
 		if (Item.Property.Effect == null) Item.Property.Effect = [];
 		if (Item.Property.Effect.indexOf("Lock") < 0) Item.Property.Effect.push("Lock");


### PR DESCRIPTION
- added a check to make sure InventoryLock is called with a lock

There was a report of a NPC locked by an item which is not a lock. I could not reproduce it or find any obvious reason why it happened. However, I checked and it is easily possible to call InventoryLock with an asset object which is not a lock.. this causes soft locks, especially in the case of NPCs who have no validation.

This makes the InventoryLock function safer to use, and will likely lead us to find the cause of the problem if we ever get reports of people not being able to lock a NPC under certain circumstances.