### PR TITLE
fix eslint so it is more simple to run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@
 .DS_Store
 
 /BondageClub/node_modules
+/BondageClub/Tools/ESLint/node_modules
 web.config

--- a/BondageClub/Tools/ESLint/package.json
+++ b/BondageClub/Tools/ESLint/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "description": "Welcome to the Bondage College!",
   "scripts": {
-    "lint": "eslint .",
-    "lint:fix": "eslint . --fix",
+    "lint": "eslint --config ./.eslintrc.js ../../Assets/Female3DCG/Female3DCG.js",
+    "lint:fix": "eslint --fix --config ./.eslintrc.js ../../Assets/Female3DCG/Female3DCG.js",
     "test": "echo \\\"Error: no test specified\\\" && exit 1"
   },
   "repository": {


### PR DESCRIPTION
npm scripts now can be run from `BondageClub/Tools/ESLint/` directly no need to copy or anything extra

.gitignore updated so npm modules can be installed to that path