### PR TITLE
Fixed stuff like  ̺̺ͩͩͩͩͩͩͩͩͩͩͩͩͩͩͩͩͩͩͩͩͩͩͩͩͩͩͩͩͩͩͩͩͩͩͩͩͩͩͩͩͩͩͩͩͩͩͩͩͩ…

### DIFF
--- a/BondageClub/CSS/Styles.css
+++ b/BondageClub/CSS/Styles.css
@@ -23,6 +23,7 @@ TextArea {
 .ChatMessage {
 	position: relative;
 	padding-left: 0.4em;
+	overflow: hidden;
 }
 .ChatMessage::before {
 	content: attr(data-time);


### PR DESCRIPTION
- fixed certain characters being able to overflow a person's message space

This will hide long characters when they clip out of bounds to prevent easy trolling.