### PR TITLE
Improvement: Remove loop variable modification

### DIFF
--- a/BondageClub/Screens/Character/Appearance/Appearance.js
+++ b/BondageClub/Screens/Character/Appearance/Appearance.js
@@ -47,20 +47,18 @@ function CharacterAppearanceValidate(C) {
 
 	// Remove any appearance item that's not in inventory
 	var Refresh = false;
-	for (let A = 0; A < C.Appearance.length; A++)
+	for (let A = C.Appearance.length - 1; A >= 0; A--)
 		if ((C.Appearance[A].Asset.Value != 0) && (C.Appearance[A].Asset.Group.Category == "Appearance") && !InventoryAvailable(C, C.Appearance[A].Asset.Name, C.Appearance[A].Asset.Group.Name)) {
 			C.Appearance.splice(A, 1);
 			Refresh = true;
-			A--;
 		}
 
 	// Remove items flagged as "Remove At Login"
 	if (!Player.GameplaySettings || !Player.GameplaySettings.DisableAutoRemoveLogin)
-		for (let A = 0; A < C.Appearance.length; A++)
+		for (let A = C.Appearance.length - 1; A >= 0; A--)
 			if (C.Appearance[A].Asset.RemoveAtLogin) {
 				C.Appearance.splice(A, 1);
 				Refresh = true;
-				A--;
 			}
 
 	// Dress back if there are missing appearance items
@@ -154,11 +152,10 @@ function CharacterAppearanceMustHide(C, GroupName) {
 function CharacterAppearanceFullRandom(C, ClothOnly) {
 
 	// Clear the current appearance
-	for (let A = 0; A < C.Appearance.length; A++)
+	for (let A = C.Appearance.length - 1; A >= 0; A--)
 		if (C.Appearance[A].Asset.Group.Category == "Appearance")
 			if ((ClothOnly == null) || (C.Appearance[A].Asset.Group.AllowNone)) {
 				C.Appearance.splice(A, 1);
-				A--;
 			}
 
 	// For each item group (non default items only show at a 20% rate, if it can occasionally happen)
@@ -219,10 +216,9 @@ function CharacterAppearanceFullRandom(C, ClothOnly) {
 function CharacterAppearanceNaked(C) {
 
 	// For each item group (non default items only show at a 20% rate)
-	for (let A = 0; A < C.Appearance.length; A++)
+	for (let A = C.Appearance.length-1; A >= 0; A--)
 		if (C.Appearance[A].Asset.Group.AllowNone && !C.Appearance[A].Asset.Group.KeepNaked && (C.Appearance[A].Asset.Group.Category == "Appearance")) {
 			C.Appearance.splice(A, 1);
-			A--;
 		}
 
 	// Loads the new character canvas
@@ -257,7 +253,7 @@ function CharacterAppearanceStripLayer(C) {
 
 	// Remove assets from the top layer only
 	var RemoveAsset = false;
-	for (let A = 0; A < C.Appearance.length; A++) {
+	for (let A = C.Appearance.length - 1; A >= 0; A--) {
 		RemoveAsset = false;
 
 		if (C.Appearance[A].Asset.Group.BodyCosplay || C.Appearance[A].Asset.BodyCosplay) {
@@ -272,7 +268,6 @@ function CharacterAppearanceStripLayer(C) {
 
 		if (RemoveAsset) {
 			C.Appearance.splice(A, 1);
-			A--;
 		}
 	}
 
@@ -1081,10 +1076,9 @@ function CharacterAppearanceReady(C) {
 function CharacterAppearanceCopy(FromC, ToC) {
 
 	// Removes any previous appearance asset
-	for (let A = 0; A < ToC.Appearance.length; A++)
+	for (let A = ToC.Appearance.length - 1; A >= 0; A--)
 		if ((ToC.Appearance[A].Asset != null) && (ToC.Appearance[A].Asset.Group.Category == "Appearance")) {
 			ToC.Appearance.splice(A, 1);
-			A--;
 		}
 
 	// Adds all appearance assets from the first character to the second

--- a/BondageClub/Screens/Room/Magic/Magic.js
+++ b/BondageClub/Screens/Room/Magic/Magic.js
@@ -309,20 +309,18 @@ function MagicTrickEndPerformance() {
 
 function MagicRestrainCopyTransfer(FromC, ToC) {
 	// Removes any previous appearance asset From second
-	for (let A = 0; A < ToC.Appearance.length; A++)
+	for (let A = ToC.Appearance.length - 1; A >= 0; A--)
 		if ((ToC.Appearance[A].Asset != null) && ((ToC.Appearance[A].Asset.Group.Name == "ItemMouth") || (ToC.Appearance[A].Asset.Group.Name == "ItemMouth2") || (ToC.Appearance[A].Asset.Group.Name == "ItemMouth3") || (ToC.Appearance[A].Asset.Group.Name == "ItemArms") || (ToC.Appearance[A].Asset.Group.Name == "ItemFeet") || (ToC.Appearance[A].Asset.Group.Name == "ItemLegs") || (ToC.Appearance[A].Asset.Group.Name == "ItemHood") || (ToC.Appearance[A].Asset.Group.Name == "ItemHead") || (ToC.Appearance[A].Asset.Group.Name == "ItemMisc") || (ToC.Appearance[A].Asset.Group.Name == "ItemDevices"))) {
 			ToC.Appearance.splice(A, 1);
-			A--;
 		}
 	// Adds all appearance assets from the first character to the second
 	for (let A = 0; A < FromC.Appearance.length; A++)
 		if ((FromC.Appearance[A].Asset != null) && ((FromC.Appearance[A].Asset.Group.Name == "ItemMouth") || (FromC.Appearance[A].Asset.Group.Name == "ItemMouth2") || (FromC.Appearance[A].Asset.Group.Name == "ItemMouth3") || (FromC.Appearance[A].Asset.Group.Name == "ItemArms") || (FromC.Appearance[A].Asset.Group.Name == "ItemFeet") || (FromC.Appearance[A].Asset.Group.Name == "ItemLegs") || (FromC.Appearance[A].Asset.Group.Name == "ItemHead") || (FromC.Appearance[A].Asset.Group.Name == "ItemHood") || (FromC.Appearance[A].Asset.Group.Name == "ItemMisc") || (FromC.Appearance[A].Asset.Group.Name == "ItemDevices")))
 			ToC.Appearance.push(FromC.Appearance[A]);
 	// Removes any previous appearance asset From first
-	for (let A = 0; A < FromC.Appearance.length; A++)
+	for (let A = FromC.Appearance.length-1; A >=0; A--)
 		if ((FromC.Appearance[A].Asset != null) && ((FromC.Appearance[A].Asset.Group.Name == "ItemMouth") || (FromC.Appearance[A].Asset.Group.Name == "ItemMouth2") || (FromC.Appearance[A].Asset.Group.Name == "ItemMouth3") || (FromC.Appearance[A].Asset.Group.Name == "ItemArms") || (FromC.Appearance[A].Asset.Group.Name == "ItemFeet") || (FromC.Appearance[A].Asset.Group.Name == "ItemLegs") || (FromC.Appearance[A].Asset.Group.Name == "ItemHead") || (FromC.Appearance[A].Asset.Group.Name == "ItemHood") || (FromC.Appearance[A].Asset.Group.Name == "ItemMisc") || (FromC.Appearance[A].Asset.Group.Name == "ItemDevices"))) {
 			FromC.Appearance.splice(A, 1);
-			A--;
 		}
 	// Refreshes the second character and saves it if it's the player
 	CharacterRefresh(ToC);

--- a/BondageClub/Screens/Room/Stable/Stable.js
+++ b/BondageClub/Screens/Room/Stable/Stable.js
@@ -577,10 +577,9 @@ function StableDressBackPlayer() {
 	CharacterRelease(Player);
 	CharacterNaked(Player);
 	//Release Harnes, Plug, Ears2
-	for (let E = 0; E < Player.Appearance.length; E++)
+	for (let E = Player.Appearance.length - 1; E >= 0; E--)
 	if ((Player.Appearance[E].Asset.Group.Name == "ItemTorso") || (Player.Appearance[E].Asset.Group.Name == "Hat") || (Player.Appearance[E].Asset.Group.Name == "ItemButt")) {
 		Player.Appearance.splice(E, 1);
-		E--;
 	}
 	CharacterDress(Player, StablePlayerAppearance);
 	StablePlayerDressOff = false;
@@ -682,10 +681,9 @@ function StablePlayerExamEnd() {
 	CharacterRelease(Player);
 	CharacterNaked(Player);
 	//Release Harnes, Plug, Ears2
-	for (let E = 0; E < Player.Appearance.length; E++)
+	for (let E = Player.Appearance.length - 1; E >= 0; E--);
 	if ((Player.Appearance[E].Asset.Group.Name == "ItemTorso") || (Player.Appearance[E].Asset.Group.Name == "Hat") || (Player.Appearance[E].Asset.Group.Name == "ItemButt")) {
 		Player.Appearance.splice(E, 1);
-		E--;
 	}
 	CharacterDress(Player, StablePlayerAppearance);
 	StablePlayerDressOff = false;

--- a/BondageClub/Scripts/Character.js
+++ b/BondageClub/Scripts/Character.js
@@ -708,10 +708,9 @@ function CharacterNaked(C) {
 function CharacterRandomUnderwear(C) {
 
 	// Clear the current clothes
-	for (let A = 0; A < C.Appearance.length; A++)
+	for (let A = C.Appearance.length - 1; A >= 0; A--)
 		if ((C.Appearance[A].Asset.Group.Category == "Appearance") && C.Appearance[A].Asset.Group.AllowNone) {
 			C.Appearance.splice(A, 1);
-			A--;
 		}
 
 	// Generate random undies at a random color
@@ -769,10 +768,9 @@ function CharacterDress(C, Appearance) {
  * @returns {void} - Nothing
  */
 function CharacterRelease(C, Refresh) {
-	for (let E = 0; E < C.Appearance.length; E++)
+	for (let E = C.Appearance.length - 1; E >= 0; E--)
 		if (C.Appearance[E].Asset.IsRestraint) {
 			C.Appearance.splice(E, 1);
-			E--;
 		}
 	if (Refresh || Refresh == null) CharacterRefresh(C);
 }
@@ -795,10 +793,9 @@ function CharacterReleaseFromLock(C, LockName) {
  * @returns {void} - Nothing
  */
 function CharacterReleaseNoLock(C) {
-	for (let E = 0; E < C.Appearance.length; E++)
+	for (let E = C.Appearance.length-1; E >=0 ; E--)
 		if (C.Appearance[E].Asset.IsRestraint && ((C.Appearance[E].Property == null) || (C.Appearance[E].Property.LockedBy == null))) {
 			C.Appearance.splice(E, 1);
-			E--;
 		}
 	CharacterRefresh(C);
 }
@@ -809,7 +806,7 @@ function CharacterReleaseNoLock(C) {
  * @returns {void} - Nothing
  */
 function CharacterReleaseTotal(C) {
-	for (let E = 0; E < C.Appearance.length; E++) {
+	for (let E = C.Appearance.length - 1; E >= 0; E--) {
 	    if (C.Appearance[E].Asset.Group.Category != "Appearance") {
 	    	if (C.IsOwned() && C.Appearance[E].Asset.Name == "SlaveCollar") {
 	    		// Reset slave collar to the default model if it has a gameplay effect (such as gagging the player)
@@ -818,7 +815,6 @@ function CharacterReleaseTotal(C) {
 	    	}
 	    	else {
 	    		C.Appearance.splice(E,1);
-	        	E--;
 	    	}
 	    }
 	}

--- a/BondageClub/Scripts/Dialog.js
+++ b/BondageClub/Scripts/Dialog.js
@@ -390,10 +390,9 @@ function DialogRemove() {
  */
 function DialogRemoveGroup(GroupName) {
 	GroupName = GroupName.trim().toUpperCase();
-	for (let D = 0; D < CurrentCharacter.Dialog.length; D++)
+	for (let D = CurrentCharacter.Dialog.length - 1; D >= 0; D--)
 		if ((CurrentCharacter.Dialog[D].Group != null) && (CurrentCharacter.Dialog[D].Group.trim().toUpperCase() == GroupName)) {
 			CurrentCharacter.Dialog.splice(D, 1);
-			D--;
 		}
 }
 

--- a/BondageClub/Scripts/NPC.js
+++ b/BondageClub/Scripts/NPC.js
@@ -243,7 +243,7 @@ function NPCEventAdd(C, EventName, EventValue) {
  */
 function NPCEventDelete(C, EventName) {
 	if (C.Event == null) C.Event = [];
-	for (let E = 0; E < C.Event.length; E++)
+	for (let E = C.Event.length - 1; E >= 0; E--)
 		if (C.Event[E].Name == EventName)
 			C.Event.splice(E, 1);
 }

--- a/BondageClub/Scripts/Server.js
+++ b/BondageClub/Scripts/Server.js
@@ -235,7 +235,7 @@ function ServerValidateProperties(C, Item) {
 
 	// For each effect on the item
 	if ((Item.Property != null) && (Item.Property.Effect != null)) {
-		for (let E = 0; E < Item.Property.Effect.length; E++) {
+		for (let E = Item.Property.Effect.length - 1; E >= 0; E--) {
 
 			// Make sure the item can be locked, remove any lock that's invalid
 			var Effect = Item.Property.Effect[E];
@@ -250,7 +250,6 @@ function ServerValidateProperties(C, Item) {
 				delete Item.Property.EnableRandomInput;
 				delete Item.Property.MemberNumberList;
 				Item.Property.Effect.splice(E, 1);
-				E--;
 			}
 
 			// If the item is locked by a lock
@@ -286,7 +285,6 @@ function ServerValidateProperties(C, Item) {
 					delete Item.Property.EnableRandomInput;
 					delete Item.Property.MemberNumberList;
 					Item.Property.Effect.splice(E, 1);
-					E--;
 				}
 
 				// Make sure the lover lock is valid
@@ -301,7 +299,6 @@ function ServerValidateProperties(C, Item) {
 					delete Item.Property.EnableRandomInput;
 					delete Item.Property.MemberNumberList;
 					Item.Property.Effect.splice(E, 1);
-					E--;
 				}
 
 			}
@@ -319,7 +316,6 @@ function ServerValidateProperties(C, Item) {
 				// Remove the effect if it's not allowed
 				if (MustRemove) {
 					Item.Property.Effect.splice(E, 1);
-					E--;
 				}
 
 			}
@@ -328,7 +324,7 @@ function ServerValidateProperties(C, Item) {
 
 	// For each block on the item
 	if ((Item.Property != null) && (Item.Property.Block != null)) {
-		for (let B = 0; B < Item.Property.Block.length; B++) {
+		for (let B = Item.Property.Block.length - 1; B >= 0; B--) {
 
 			// Check if the effect is allowed for the item
 			var MustRemove = true;
@@ -340,7 +336,6 @@ function ServerValidateProperties(C, Item) {
 			// Remove the effect if it's not allowed
 			if (MustRemove) {
 				Item.Property.Block.splice(B, 1);
-				B--;
 			}
 		}
 	}

--- a/BondageClub/Scripts/Translation.js
+++ b/BondageClub/Scripts/Translation.js
@@ -311,10 +311,9 @@ function TranslationParseTXT(str) {
     }
 
 	// Removes any comment rows (starts with ###)
-    for (let row = 0; row < arr.length; row++)
+	for (let row = arr.length - 1; row >= 0; row--)
 		if (arr[row].indexOf("###") == 0) {
 			arr.splice(row, 1);
-			row = row - 1;
 		}
 
 	// Trims the full translated array


### PR DESCRIPTION
# Summary
The code uses the following pattern at several places:
```JavaScript
for (A = 0; A < array.length; A++)
   if (something) {
      doSomething();
      array.splice(A,1);
      A--;
   }
```
As it is a bad idea in general to modify a loop variable within the loop, this PR changes this and transfers the above mentioned pattern to:
```JavaScript
for (A = array.length - 1; A >= 0; A--)
   if (something) {
      doSomething();
      array.splice(A,1);
   }
```
