### PR TITLE
Fix enclose in item properties

### DIFF
--- a/BondageClub/Scripts/Inventory.js
+++ b/BondageClub/Scripts/Inventory.js
@@ -455,7 +455,7 @@ function InventoryGroupIsBlocked(C, GroupName) {
 	// If another character is enclosed, items other than the enclosing one cannot be used
 	if ((C.ID != 0) && C.IsEnclose()) {
 		for (let E = 0; E < C.Appearance.length; E++)
-			if ((C.Appearance[E].Asset.Group.Name == GroupName) && InventoryItemHasEffect(C.Appearance[E], "Enclose"))
+			if ((C.Appearance[E].Asset.Group.Name == GroupName) && InventoryItemHasEffect(C.Appearance[E], "Enclose", true))
 				return false;
 		return true;
 	}


### PR DESCRIPTION
If enclose is stored in Property, it does not work (item blocks itself when others try to interact)

This problem was brought up by someone currently working on an item that toggles the enclose state and it might eventually be required by more items, like closing cages