### PR TITLE
Refactor: Use IsNpc instead of string compares

### DIFF
--- a/BondageClub/Scripts/Activity.js
+++ b/BondageClub/Scripts/Activity.js
@@ -242,7 +242,7 @@ function ActivityOrgasmWillpowerProgress(C) {
  * @returns {void} - Nothing
  */
 function ActivityOrgasmStart(C) {
-	if ((C.ID == 0) || (C.AccountName.substring(0, 4) == "NPC_") || (C.AccountName.substring(0, 4) == "NPC-")) {
+	if ((C.ID == 0) || C.IsNpc()) {
 		if (C.ID == 0) ActivityOrgasmGameResistCount = 0;
 		ActivityOrgasmWillpowerProgress(C);
 		C.ArousalSettings.OrgasmTimer = CurrentTime + (Math.random() * 10000) + 5000;
@@ -265,7 +265,7 @@ function ActivityOrgasmStart(C) {
  * @returns {void} - Nothing
  */
 function ActivityOrgasmStop(C, Progress) {
-	if ((C.ID == 0) || (C.AccountName.substring(0, 4) == "NPC_") || (C.AccountName.substring(0, 4) == "NPC-")) {
+	if ((C.ID == 0) || C.IsNpc()) {
 		ActivityOrgasmWillpowerProgress(C);
 		C.ArousalSettings.OrgasmTimer = 0;
 		C.ArousalSettings.OrgasmStage = 0;
@@ -319,7 +319,7 @@ function ActivityOrgasmPrepare(C) {
 		return;
 	}
 
-	if ((C.ID == 0) || (C.AccountName.substring(0, 4) == "NPC_") || (C.AccountName.substring(0, 4) == "NPC-")) {
+	if ((C.ID == 0) || C.IsNpc()) {
 
 		// Starts the timer and exits from dialog if necessary
 		C.ArousalSettings.OrgasmTimer = (C.ID == 0) ? CurrentTime + 5000 : CurrentTime + (Math.random() * 10000) + 5000;
@@ -329,7 +329,7 @@ function ActivityOrgasmPrepare(C) {
 		ActivityChatRoomArousalSync(C);
 
 		// If an NPC orgasmed, it will raise her love based on the horny trait
-		if ((C.AccountName.substring(0, 4) == "NPC_") || (C.AccountName.substring(0, 4) == "NPC-"))
+		if (C.IsNpc())
 			if ((C.Love == null) || (C.Love < 60) || (C.IsOwner()) || (C.IsOwnedByPlayer()) || C.IsLoverPrivate())
 				NPCLoveChange(C, Math.floor((NPCTraitGet(C, "Horny") + 100) / 20) + 1);
 
@@ -434,7 +434,7 @@ function ActivityRun(C, Activity) {
 
 	// If the player does the activity on herself or an NPC, we calculate the result right away
 	if ((C.ArousalSettings.Active == "Hybrid") || (C.ArousalSettings.Active == "Automatic"))
-		if ((C.ID == 0) || (C.AccountName.substring(0, 4) == "NPC_") || (C.AccountName.substring(0, 4) == "NPC-"))
+		if ((C.ID == 0) || C.IsNpc())
 			ActivityEffect(Player, C, Activity, C.FocusGroup.Name);
 
 	// If the player does the activity on someone else, we calculate the progress for the player right away
@@ -470,7 +470,7 @@ function ActivityArousalItem(Source, Target, Asset) {
 	if (AssetActivity != null) {
 		var Activity = AssetGetActivity(Target.AssetFamily, AssetActivity);
 		if ((Source.ID == 0) && (Target.ID != 0)) ActivityRunSelf(Source, Target, Activity);
-		if (((Target.ArousalSettings != null) && ((Target.ArousalSettings.Active == "Hybrid") || (Target.ArousalSettings.Active == "Automatic"))) && ((Target.ID == 0) || (Target.AccountName.substring(0, 4) == "NPC_") || (Target.AccountName.substring(0, 4) == "NPC-")))
+		if (((Target.ArousalSettings != null) && ((Target.ArousalSettings.Active == "Hybrid") || (Target.ArousalSettings.Active == "Automatic"))) && ((Target.ID == 0) || (Target.IsNpc())))
 			ActivityEffect(Source, Target, AssetActivity, Asset.Group.Name);
 	}
 }

--- a/BondageClub/Scripts/Server.js
+++ b/BondageClub/Scripts/Server.js
@@ -231,7 +231,7 @@ function ServerAppearanceBundle(Appearance) {
 function ServerValidateProperties(C, Item) {
 
 	// No validations for NPCs
-	if ((C.AccountName.substring(0, 4) == "NPC_") || (C.AccountName.substring(0, 4) == "NPC-")) return;
+	if (C.IsNpc()) return;
 
 	// For each effect on the item
 	if ((Item.Property != null) && (Item.Property.Effect != null)) {


### PR DESCRIPTION
# Summary
This PR removes all string compares to determine wether a Character is an NPC and replaces them with the new `IsNpc` function. That way, it's easier to change that check, if need arises one day...