### PR TITLE
Login Random Character Fix

### DIFF
--- a/BondageClub/Screens/Character/Appearance/Appearance.js
+++ b/BondageClub/Screens/Character/Appearance/Appearance.js
@@ -154,7 +154,7 @@ function CharacterAppearanceFullRandom(C, ClothOnly) {
 	// Clear the current appearance
 	for (let A = C.Appearance.length - 1; A >= 0; A--)
 		if (C.Appearance[A].Asset.Group.Category == "Appearance")
-			if ((ClothOnly == null) || (C.Appearance[A].Asset.Group.AllowNone)) {
+			if (!ClothOnly || (C.Appearance[A].Asset.Group.AllowNone)) {
 				C.Appearance.splice(A, 1);
 			}
 

--- a/BondageClub/Screens/Character/Login/Login.js
+++ b/BondageClub/Screens/Character/Login/Login.js
@@ -24,7 +24,7 @@ var LoginFrameTotalTime = 0;*/
 function LoginDoNextThankYou() {
 	LoginThankYou = CommonRandomItemFromList(LoginThankYou, LoginThankYouList);
 	CharacterRelease(Player, false);
-	CharacterAppearanceFullRandom(Player, false);
+	CharacterAppearanceFullRandom(Player);
 	CharacterFullRandomRestrain(Player);
 	LoginThankYouNext = CommonTime() + 4000;
 }


### PR DESCRIPTION
The recent change to reduce CharacterRefresh calls passed in False to the ClothOnly parameter of the Full Random Appearance function. This revealed a long-standing bug where True and False were both being treated as True, and only undefined was treated as False.
This should fix the appearance of both the Login NPCs and the Shopkeeper after doing a job, to randomise the body as well as the clothes.