### PR TITLE
Improvement: Active pose behavior

### DIFF
--- a/BondageClub/Scripts/Character.js
+++ b/BondageClub/Scripts/Character.js
@@ -905,7 +905,7 @@ function CharacterSetActivePose(C, NewPose, ForceChange) {
 	}
 	
 	// If we reset to base, we remove the poses
-	if (C.ActivePose.length == 2 && C.ActivePose.includes("BaseUpper") && C.ActivePose.includes("BaseLower")) C.ActivePose = null;
+	if (C.ActivePose.filter(P => P !== "BaseUpper" && P !== "BaseLower").length == 0) C.ActivePose = null;
 	
 	CharacterRefresh(C, false);
 }


### PR DESCRIPTION
- improved the reset to null to include cases when active pose only contains either one of the base poses

(when clicking on the kneel icon, you wont "stand up" when already standing with BaseLower)

This was the intended behavior