### PR TITLE
Improvement: Adds AllowColorizeAll & HideColoring attributes

### DIFF
--- a/BondageClub/Assets/Female3DCG/Female3DCG.js
+++ b/BondageClub/Assets/Female3DCG/Female3DCG.js
@@ -1947,7 +1947,7 @@ var AssetFemale3DCG = [
 			{
 				Name: "ShockCollar", Fetish: ["Leather", "Masochism"], Value: 80, Difficulty: 50, Time: 15, Random: false, AllowLock: true, BuyGroup: "ShockCollar", Effect: ["ReceiveShock"], ExpressionTrigger: [{ Name: "Soft", Group: "Eyebrows", Timer: 10 }], AllowType: ["", "Blink"], Extended: true, AlwaysExtend: true, Activity: "ShockItem", Layer: [
 					{ Name: "Collar", HasType: false, AllowTypes: ["", "Blink"] },
-					{ Name: "Light", AllowTypes: ["Blink"] },
+					{ Name: "Light", AllowTypes: ["Blink"], HideColoring: true },
 				], DynamicBeforeDraw: true, DynamicScriptDraw: true,
 			},
 			{ Name: "ShockCollarRemote", Value: -1, Random: false, Wear: false, BuyGroup: "ShockCollar", Activity: "ShockItem", Effect: ["TriggerShock"], ExpressionTrigger: [{ Name: "Soft", Group: "Eyebrows", Timer: 10 }, { Name: "Soft", Group: "Blush", Timer: 15 }, { Name: "Closed", Group: "Eyes", Timer: 5 }] },
@@ -2004,7 +2004,7 @@ var AssetFemale3DCG = [
 			{
 				Name: "CollarShockUnit", Fetish: ["Masochism"], Value: 80, Difficulty: 6, Time: 5, Random: false, AllowLock: true, BuyGroup: "ShockCollar", Prerequisite: "Collared", Effect: ["ReceiveShock"], ExpressionTrigger: [{ Name: "Medium", Group: "Blush", Timer: 15 }], AllowType: ["", "Blink"], Extended: true, AlwaysExtend: true, Activity: "ShockItem", Layer: [
 					{ Name: "Unit", AllowTypes: ["", "Blink"], HasType: false },
-					{ Name: "Light", AllowTypes: ["Blink"] },
+					{ Name: "Light", AllowTypes: ["Blink"], HideColoring: true },
 				], DynamicBeforeDraw: true, DynamicScriptDraw: true,
 			},
 			{ Name: "ShockCollarRemote", Value: -1, Random: false, Wear: false, BuyGroup: "ShockCollar", Activity: "ShockItem", Effect: ["TriggerShock"], ExpressionTrigger: [{ Name: "Soft", Group: "Eyebrows", Timer: 10 }, { Name: "Soft", Group: "Blush", Timer: 15 }, { Name: "Closed", Group: "Eyes", Timer: 5 }] },

--- a/BondageClub/Screens/Character/ItemColor/ItemColor.js
+++ b/BondageClub/Screens/Character/ItemColor/ItemColor.js
@@ -470,7 +470,10 @@ function ItemColorStateBuild(c, item, x, y, width, height) {
 			};
 		})
 		.sort((g1, g2) => g1.colorIndex = g2.colorIndex);
-	colorGroups.unshift({ name: null, layers: [], colorIndex: -1 });
+
+	if (item.Asset.AllowColorizeAll) {
+		colorGroups.unshift({ name: null, layers: [], colorIndex: -1 });
+	}
 
 	let colors;
 	if (Array.isArray(item.Color)) {
@@ -532,7 +535,7 @@ function ItemColorStateBuild(c, item, x, y, width, height) {
  * @returns {Layer[]} - The colourable layers
  */
 function ItemColorGetColorableLayers(item) {
-	return item.Asset.Layer.filter(layer => !layer.CopyLayerColor && layer.AllowColorize);
+	return item.Asset.Layer.filter(layer => !layer.CopyLayerColor && layer.AllowColorize && !layer.HideColoring);
 }
 
 /**

--- a/BondageClub/Scripts/Asset.js
+++ b/BondageClub/Scripts/Asset.js
@@ -12,6 +12,7 @@ var Pose = [];
  * @property {string | null} CopyLayerColor - if not null, specifies that this layer should always copy the color of the named layer
  * @property {string} [ColorGroup] - specifies the name of a color group that this layer belongs to. Any layers within the same color group
  * can be colored together via the item color UI
+ * @property {boolean} HideColoring - whether or not this layer can be coloured in the colouring UI
  * @property {string[] | null} AllowTypes - A list of allowed extended item types that this layer permits - the layer will only be drawn if
  * the item type matches one of these types. If null, the layer is considered to permit all extended types.
  * @property {boolean} HasType - whether or not the layer has separate assets per type. If not, the extended type will not be included in
@@ -154,6 +155,7 @@ function AssetAdd(NewAsset) {
 		DynamicAfterDraw: (typeof NewAsset.DynamicAfterDraw === 'boolean') ? NewAsset.DynamicAfterDraw : false,
 		DynamicScriptDraw: (typeof NewAsset.DynamicScriptDraw === 'boolean') ? NewAsset.DynamicScriptDraw : false,
 		HasType: (typeof NewAsset.HasType === 'boolean') ? NewAsset.HasType : true,
+		AllowColorizeAll: typeof NewAsset.AllowColorizeAll === 'boolean' ? NewAsset.AllowColorizeAll : true,
 	}
 	A.Layer = AssetBuildLayer(NewAsset, A);
 	AssetAssignColorIndices(A);
@@ -188,6 +190,7 @@ function AssetMapLayer(Layer, AssetDefinition, A, I) {
 		AllowColorize: AssetLayerAllowColorize(Layer, AssetDefinition),
 		CopyLayerColor: Layer.CopyLayerColor || null,
 		ColorGroup: Layer.ColorGroup,
+		HideColoring: typeof Layer.HideColoring === "boolean" ? Layer.HideColoring : false,
 		AllowTypes: Array.isArray(Layer.AllowTypes) ? Layer.AllowTypes : null,
 		HasType: typeof Layer.HasType === "boolean" ? Layer.HasType : A.HasType,
 		ParentGroupName: Layer.ParentGroup,


### PR DESCRIPTION
## Summary

* Adds a new `AllowColorizeAll` attribute at the asset level, which can be used to toggle the "Whole Item" option when colouring a multi-colourable item. Defaults to `true`
* Adds a new `HideColoring` attribute at the layer level, which can be used to hide a particular layer from the multi-colouring UI. Defaults to `false`
* Updates the shock collar and collar shock unit to prevent the light layer from showing in the colouring UI using the new `HideColoring` attribute