### PR TITLE
Fix for pose handling

### DIFF
--- a/BondageClub/Screens/Character/Appearance/Appearance.js
+++ b/BondageClub/Screens/Character/Appearance/Appearance.js
@@ -360,7 +360,7 @@ function CharacterAppearanceVisible(C, AssetName, GroupName) {
 	if (C.Pose != null)
 		for (let A = 0; A < C.Pose.length; A++)
 			for (let P = 0; P < Pose.length; P++)
-				if (Pose[P].Name == C.Pose[A])
+				if (Pose[P].Name === C.Pose[A])
 					if ((Pose[P].Hide != null) && (Pose[P].Hide.indexOf(GroupName) >= 0))
 						return false;
 	return true;
@@ -395,7 +395,7 @@ function CharacterApperanceSetHeightModifier(C) {
 		if (C.Pose != null) 
 			for (let A = 0; A < C.Pose.length; A++)
 				for (let P = 0; P < Pose.length; P++)
-					if (Pose[P].Name == C.Pose[A])
+					if (Pose[P].Name === C.Pose[A])
 						if (Pose[P].OverrideHeight != null) {
 							// Ignore kneel, if player is hogtied. Allows the use of a short chain on hogtied players
 							// Ignore overthehead if kneeling


### PR DESCRIPTION
- fixed inappropriate pose handling

since  ["Kneel"] == "Kneel" is true but  ["Kneel"] === "Kneel" is false, you can console poses in arrays and mess up your character as only these 2 parts of the code understood this invalid data.

This can cause terrifying results! https://cdn.discordapp.com/attachments/748952474018250810/759160857804013568/Capture.PNG

Might be interesting to hotfix this to R60 before the beta