### PR TITLE
Fix refresh weirdness

### DIFF
--- a/BondageClub/Screens/Character/Appearance/Appearance.js
+++ b/BondageClub/Screens/Character/Appearance/Appearance.js
@@ -930,9 +930,6 @@ function AppearanceClick() {
 					if (Block || Limited) return;
 					if (InventoryAllow(C, Item.Asset.Prerequisite)) {
 						CharacterAppearanceSetItem(C, C.FocusGroup.Name, DialogInventory[I].Asset);
-						// Update the inventory with the new worn item
-						DialogInventory = DialogInventory.map(DI => { DI.Worn = false; return DI; });
-						DialogInventory[I].Worn = true;
 					} else {
 						CharacterAppearanceHeaderTextTime = DialogTextDefaultTimer;
 						CharacterAppearanceHeaderText = DialogText;

--- a/BondageClub/Scripts/ExtendedItem.js
+++ b/BondageClub/Scripts/ExtendedItem.js
@@ -94,7 +94,7 @@ function ExtendedItemLoad(Options, DialogKey) {
 		}
 	}
 
-	ExtendedItemSetOffset(0);
+	if (ExtendedItemOffsets[ExtendedItemOffsetKey()] == null) ExtendedItemSetOffset(0);
 
 	DialogExtendedMessage = DialogFind(Player, DialogKey);
 }


### PR DESCRIPTION
- fixed a problem where if character refresh is called while browsing to an extended item with more than one page, the page was reset to 0
- fixed the red box in the appearance menu (Again) as the refresh is no longer needed since CharacterRefresh now handles the reload. It actually caused problems because the index changes now