### PR TITLE
Fix multicolor picker crash

### DIFF
--- a/BondageClub/Scripts/Character.js
+++ b/BondageClub/Scripts/Character.js
@@ -656,6 +656,10 @@ function CharacterRefresh(C, Push) {
 			}
 			ActivityDialogBuild(C);
 		}
+		if (DialogColor != null) { 
+			if (ItemColorItem == null || InventoryGet(C, ItemColorItem.Asset.Group.Name) == null || InventoryGet(C, ItemColorItem.Asset.Group.Name).Asset.Name != ItemColorItem.Asset.Name)
+				ItemColorExit();
+		}
 	}
 }
 


### PR DESCRIPTION
- fixed a crash when the character is refreshed while in the multicolor picker (if the item is removed or changed, it crashes because the menu is not closed as expected)