### PR TITLE
Code cleanup

### DIFF
--- a/BondageClub/Assets/Female3DCG/Female3DCG.js
+++ b/BondageClub/Assets/Female3DCG/Female3DCG.js
@@ -144,7 +144,7 @@ var AssetFemale3DCG = [
 				]
 			},
 			{ Name: "FrillyApron", Fetish: ["Lingerie"], ParentGroup: "BodyUpper", Value: -1, Left: 135, Top: 179, BuyGroup: "Maid", AllowPose: ["TapedHands", "BackBoxTie", "BackCuffs", "BackElbowTouch", "Yoked", "Hogtied", "OverTheHead"] },
-			{ Name: "BunnyCollarCuffs", Fetish: ["Pet"], ParentGroup: "BodyUpper", Value: 10, Expose: ["ItemNipples", "ItemNipplesPiercings", "ItemBreast", "ItemTorso"], AllowPose: ["AllFours", "TapedHands", "BackBoxTie", "BackCuffs", "BackElbowTouch", "Yoked", "Hogtied", "OverTheHead"] }
+			{ Name: "BunnyCollarCuffs", Fetish: ["Pet"], ParentGroup: "BodyUpper", Value: 10, AllowPose: ["AllFours", "TapedHands", "BackBoxTie", "BackCuffs", "BackElbowTouch", "Yoked", "Hogtied", "OverTheHead"] }
 		],
 		Color: ["Default", "#202020", "#808080", "#bbbbbb", "#aa8080", "#80aa80", "#8080aa", "#aaaa80", "#80aaaa", "#aa80aa", "#cc3333", "#33cc33", "#3333cc", "#cccc33", "#33cccc", "#cc33cc"]
 	},

--- a/BondageClub/Screens/Character/Appearance/Appearance.js
+++ b/BondageClub/Screens/Character/Appearance/Appearance.js
@@ -998,26 +998,6 @@ function CharacterAppearanceExit(C) {
  * @returns {void} - Nothing
  */
 function CharacterAppearanceReady(C) {
-
-	// Make sure the character has one item of each default type (not used for now)
-	if (CharacterAppearanceReturnRoom == "DO NOT USE")
-		for (let A = 0; A < AssetGroup.length; A++)
-			if ((AssetGroup[A].IsDefault) || CharacterAppearanceRequired(C, AssetGroup[A].Name)) {
-
-				// Check to find at least one item from the group
-				var Found = false;
-				for (let P = 0; P < C.Appearance.length; P++)
-					if (C.Appearance[P].Asset.Group.Name == AssetGroup[A].Name)
-						Found = true;
-
-				// If we didn't found the group, we warn the user
-				if (!Found) {
-					CharacterAppearanceHeaderText = TextGet("MustPickItem") + " " + AssetGroup[A].Name;
-					return;
-				}
-
-			}
-
 	// Exits wardrobe mode
 	ElementRemove("InputWardrobeName");
 	CharacterAppearanceMode = "";

--- a/BondageClub/Screens/Character/Preference/Preference.js
+++ b/BondageClub/Screens/Character/Preference/Preference.js
@@ -581,6 +581,7 @@ function PreferenceSubscreenOnlineRun() {
 	DrawCheckbox(500, 865, 64, 64, TextGet("BlockBodyCosplay"), Player.OnlineSharedSettings.BlockBodyCosplay);
 	DrawButton(1815, 75, 90, 90, "", "White", "Icons/Exit.png");
 	DrawCharacter(Player, 50, 50, 0.9);
+	MainCanvas.textAlign = "center";
 }
 
 /**

--- a/BondageClub/Scripts/Skill.js
+++ b/BondageClub/Scripts/Skill.js
@@ -5,7 +5,6 @@ var SkillModifierMin = -10
 var SkillLevelMaximum = 10;
 var SkillLevelMinimum = 0;
 var SkillBondageRatio = 1;
-var SkillBondageRatio = 1;
 
 /**
  * When the player progresses in a skill. Also validates the values to make sure they are within the proper ranges once changed. (level 0-10, progress 0-100)


### PR DESCRIPTION
- removed a piece of code that has been unused for nearly 2 years in appearance ready
- removed an unnecessary expose property from the bunny collar cuffs in the accessory group
- removed a duplicated var declaration in skill.js
- added a line to re-center text while drawing the preference screen to avoid compatibility problems (its the only subscreen that didnt reset the text to left after drawing checkboxes)