### PR TITLE
Preference screen crash

### DIFF
--- a/BondageClub/Scripts/Server.js
+++ b/BondageClub/Scripts/Server.js
@@ -611,7 +611,10 @@ function ServerPrivateCharacterSync() {
 function ServerAccountQueryResult(data) {
 	if ((data != null) && (typeof data === "object") && !Array.isArray(data) && (data.Query != null) && (typeof data.Query === "string") && (data.Result != null)) {
 		if (data.Query == "OnlineFriends") FriendListLoadFriendList(data.Result);
-		if (data.Query == "EmailStatus") document.getElementById(data.Result ? "InputEmailOld" : "InputEmailNew").placeholder = TextGet(data.Result ? "UpdateEmailLinked" : "UpdateEmailEmpty");
+		if (data.Query == "EmailStatus" && data.Result && document.getElementById("InputEmailOld"))
+			document.getElementById("InputEmailOld").placeholder = TextGet("UpdateEmailLinked");
+		if (data.Query == "EmailStatus" && !data.Result && document.getElementById("InputEmailNew"))
+			document.getElementById("InputEmailNew").placeholder = TextGet("UpdateEmailEmpty");
 		if (data.Query == "EmailUpdate") ElementValue("InputEmailNew", TextGet(data.Result ? "UpdateEmailSuccess" : "UpdateEmailFailure"));
 	}
 }


### PR DESCRIPTION
- fixed a crash in the preference screen when switching account too fast.

If you went to email, then changed screen faster then the query, you crashed with 
```
Server.js:615 Uncaught TypeError: Cannot set property 'placeholder' of null
    at ServerAccountQueryResult (Server.js:615)
```
because the input no longer exists. This prevents it