### PR TITLE
 Extended Item - Miscellaneous Improvements part 2

### DIFF
--- a/BondageClub/Screens/Inventory/ItemAddon/BondageBenchStraps/BondageBenchStraps.js
+++ b/BondageClub/Screens/Inventory/ItemAddon/BondageBenchStraps/BondageBenchStraps.js
@@ -71,10 +71,10 @@ function InventoryItemAddonBondageBenchStrapsNpcDialog(C, Option) {
 
 /**
  * Validation used when switching between types.
+ * @param {Character} C - The character wearing the item
  * @returns {boolean} - Whether or not the change can occur.
  */
-function InventoryItemAddonBondageBenchStrapsValidate() {
-	var C = CharacterGetCurrent();
+function InventoryItemAddonBondageBenchStrapsValidate(C) {
 	var Allowed = true;
 	if (InventoryGet(C, "Cloth") != null || InventoryGet(C, "ClothLower") != null) {
 		DialogExtendedMessage = DialogFind(Player, "RemoveClothesForItem");

--- a/BondageClub/Screens/Inventory/ItemArms/DuctTape/DuctTape.js
+++ b/BondageClub/Screens/Inventory/ItemArms/DuctTape/DuctTape.js
@@ -102,11 +102,11 @@ function InventoryItemArmsDuctTapeNpcDialog(C, Option) {
 
 /**
  * Validate function that checks, if the restrained character wears outer clothes. If so, the duct tape cannot be applied
+ * @param {Character} C - The character wearing the item
  * @param {Option} Option - The option to be applied on the character. Not used in this item
- * @returns 
+ * @returns {boolean} - Returns false and sets DialogExtendedMessage, if the chosen option is not possible.
  */
-function InventoryItemArmsDuctTapeValidate(Option) {
-	var C = CharacterGetCurrent();
+function InventoryItemArmsDuctTapeValidate(C, Option) {
 	var Allowed = true;
 
 	if (InventoryGet(C, "Cloth") || InventoryGet(C, "ClothLower")) {

--- a/BondageClub/Screens/Inventory/ItemArms/SturdyLeatherBelts/SturdyLeatherBelts.js
+++ b/BondageClub/Screens/Inventory/ItemArms/SturdyLeatherBelts/SturdyLeatherBelts.js
@@ -40,8 +40,7 @@ function InventoryItemArmsSturdyLeatherBeltsClick() {
 	ExtendedItemClick(InventoryItemArmsSturdyLeatherBeltsOptions);
 }
 
-function InventoryItemArmsSturdyLeatherBeltsValidate() {
-	var C = CharacterGetCurrent();
+function InventoryItemArmsSturdyLeatherBeltsValidate(C) {
 	var Allowed = true;
 
 	if (DialogFocusItem.Property.LockedBy && !DialogCanUnlock(C, DialogFocusItem)) {

--- a/BondageClub/Screens/Inventory/ItemArms/Web/Web.js
+++ b/BondageClub/Screens/Inventory/ItemArms/Web/Web.js
@@ -105,9 +105,7 @@ function InventoryItemArmsWebClick() {
 	ExtendedItemClick(InventoryItemArmsWebOptions);
 }
 
-function InventoryItemArmsWebValidate(Option) {
-	var C = CharacterGetCurrent();
-
+function InventoryItemArmsWebValidate(C, Option) {
 	// Validates some prerequisites before allowing more advanced poses
 	if (Option.Prerequisite) {
 		var Allowed = true;

--- a/BondageClub/Screens/Inventory/ItemArms/Web/Web.js
+++ b/BondageClub/Screens/Inventory/ItemArms/Web/Web.js
@@ -125,6 +125,7 @@ function InventoryItemArmsWebValidate(C, Option) {
 		CharacterAppearanceSetItem(C, "ItemArms", Web.Asset, Web.Color, DifficultyFactor, null, false);
 		InventoryGet(C, "ItemArms").Property = Web.Property;
 		CharacterRefresh(C);
+		DialogFocusItem = InventoryGet(C, C.FocusGroup.Name);
 
 		return Allowed;
 	}

--- a/BondageClub/Screens/Inventory/ItemFeet/Chains/Chains.js
+++ b/BondageClub/Screens/Inventory/ItemFeet/Chains/Chains.js
@@ -49,8 +49,7 @@ function InventoryItemFeetChainsNpcDialog(C, Option) {
 	C.CurrentDialog = DialogFind(C, "ChainBondage" + Option.Name, "ItemFeet");
 }
 
-function InventoryItemFeetChainsValidate(Option) {
-	var C = CharacterGetCurrent();
+function InventoryItemFeetChainsValidate(C, Option) {
 	if (Option.Prerequisite != null && !InventoryAllow(C, Option.Prerequisite, true)) {
 		DialogExtendedMessage = DialogText;
 		return false;

--- a/BondageClub/Screens/Inventory/ItemFeet/SturdyLeatherBelts/SturdyLeatherBelts.js
+++ b/BondageClub/Screens/Inventory/ItemFeet/SturdyLeatherBelts/SturdyLeatherBelts.js
@@ -38,8 +38,7 @@ function InventoryItemFeetSturdyLeatherBeltsClick() {
 	ExtendedItemClick(InventoryItemFeetSturdyLeatherBeltsOptions);
 }
 
-function InventoryItemFeetSturdyLeatherBeltsValidate() {
-	var C = CharacterGetCurrent();
+function InventoryItemFeetSturdyLeatherBeltsValidate(C) {
 	var Allowed = true;
 
 	if (DialogFocusItem.Property.LockedBy && !DialogCanUnlock(C, DialogFocusItem)) {

--- a/BondageClub/Screens/Inventory/ItemLegs/Chains/Chains.js
+++ b/BondageClub/Screens/Inventory/ItemLegs/Chains/Chains.js
@@ -36,7 +36,7 @@ function InventoryItemLegsChainsNpcDialog(C, Option) {
 	C.CurrentDialog = DialogFind(C, "ChainBondage" + Option.Name, "ItemLegs");
 }
 
-function InventoryItemLegsChainsValidate(Option) {
+function InventoryItemLegsChainsValidate() {
 	var Allowed = true;
 	if (InventoryItemHasEffect(DialogFocusItem, "Lock", true)) {
 		DialogExtendedMessage = DialogFind(Player, "CantChangeWhileLocked");

--- a/BondageClub/Screens/Inventory/ItemLegs/DuctTape/DuctTape.js
+++ b/BondageClub/Screens/Inventory/ItemLegs/DuctTape/DuctTape.js
@@ -40,8 +40,7 @@ function InventoryItemLegsDuctTapeNpcDialog(C, Option) {
 	C.CurrentDialog = DialogFind(C, "DuctTapePose" + Option.Name, "ItemLegs");
 }
 
-function InventoryItemLegsDuctTapeValidate(Option) {
-	var C = CharacterGetCurrent();
+function InventoryItemLegsDuctTapeValidate(C, Option) {
 	var Allowed = true;
 
 	if (Option.Property.Type != null && InventoryGet(C, "ClothLower")) {

--- a/BondageClub/Screens/Inventory/ItemLegs/SturdyLeatherBelts/SturdyLeatherBelts.js
+++ b/BondageClub/Screens/Inventory/ItemLegs/SturdyLeatherBelts/SturdyLeatherBelts.js
@@ -31,8 +31,7 @@ function InventoryItemLegsSturdyLeatherBeltsClick() {
 	ExtendedItemClick(InventoryItemLegsSturdyLeatherBeltsOptions);
 }
 
-function InventoryItemLegsSturdyLeatherBeltsValidate() {
-	var C = CharacterGetCurrent();
+function InventoryItemLegsSturdyLeatherBeltsValidate(C) {
 	var Allowed = true;
 
 	if (DialogFocusItem.Property.LockedBy && !DialogCanUnlock(C, DialogFocusItem)) {

--- a/BondageClub/Screens/Inventory/ItemNose/NoseRing/NoseRing.js
+++ b/BondageClub/Screens/Inventory/ItemNose/NoseRing/NoseRing.js
@@ -91,12 +91,12 @@ function InventoryItemNoseNoseRingNpcDialog(C, Option) {
 
 /**
  * Validates, if the chosen option is possible. Sets the global variable 'DialogExtendedMessage' to the appropriate error message, if not.
+ * @param {Character} C - The character wearing the item
  * @param {Option} Option - The next option to use on the character
  * @returns {boolean} - Returns false and sets DialogExtendedMessage, if the chosen option is not possible.
  */
-function InventoryItemNoseNoseRingValidate(Option) {
+function InventoryItemNoseNoseRingValidate(C, Option) {
 	var ChainShortPrerequisites = true;
-	let C = CharacterGetCurrent();
 	switch (Option.Name) {
 		case "Base":
 			break;

--- a/BondageClub/Scripts/ExtendedItem.js
+++ b/BondageClub/Scripts/ExtendedItem.js
@@ -235,7 +235,7 @@ function ExtendedItemSetType(C, Options, Option, IsCloth) {
 	// An extendable item may provide a validation function. Returning false from the validation function will drop out of
 	// this function, and the new type will not be applied.
 	if (typeof window[FunctionPrefix + "Validate"] === "function") {
-		if (CommonCallFunctionByName(FunctionPrefix + "Validate", Option) === false) {
+		if (CommonCallFunctionByName(FunctionPrefix + "Validate", C, Option) === false) {
 			return;
 		}
 	}

--- a/BondageClub/Scripts/ExtendedItem.js
+++ b/BondageClub/Scripts/ExtendedItem.js
@@ -131,11 +131,9 @@ function ExtendedItemDraw(Options, DialogPrefix, OptionsPerPage, ShowImages = tr
 	OptionsPerPage = OptionsPerPage || Math.min(Options.length, XYPositions.length - 1);
 	
 	// If we have to paginate, draw the back/next buttons
-	if (ItemOptionsOffset >= OptionsPerPage) {
-		DrawButton(1555, 25, 90, 90, "", "White", "Icons/Prev.png");
-	}
-	if (ItemOptionsOffset + OptionsPerPage < Options.length) {
-		DrawButton(1665, 25, 90, 90, "", "White", "Icons/Next.png");
+	if (Options.length > OptionsPerPage) {
+		DrawButton(1665, 240, 90, 90, "", "White", "Icons/Prev.png");
+		DrawButton(1775, 240, 90, 90, "", "White", "Icons/Next.png");
 	}
 	
 	// Draw the header and item
@@ -201,11 +199,13 @@ function ExtendedItemClick(Options, IsCloth, OptionsPerPage, ShowImages = true) 
 	}
 	
 	// Pagination buttons
-	if (MouseIn(1555, 25, 90, 90) && ItemOptionsOffset >= OptionsPerPage) {
-		ExtendedItemSetOffset(ItemOptionsOffset - OptionsPerPage);
+	if (MouseIn(1665, 240, 90, 90) && Options.length > OptionsPerPage) {
+		if (ItemOptionsOffset - OptionsPerPage < 0) ExtendedItemSetOffset(OptionsPerPage * (Math.ceil(Options.length / OptionsPerPage) - 1));
+		else ExtendedItemSetOffset(ItemOptionsOffset - OptionsPerPage);
 	}
-	if (MouseIn(1665, 25, 90, 90) && ItemOptionsOffset + OptionsPerPage < Options.length) {
-		ExtendedItemSetOffset(ItemOptionsOffset + OptionsPerPage);
+	if (MouseIn(1775, 240, 90, 90) && Options.length > OptionsPerPage) {
+		if (ItemOptionsOffset + OptionsPerPage >= Options.length) ExtendedItemSetOffset(0);
+		else ExtendedItemSetOffset(ItemOptionsOffset + OptionsPerPage);
 	}
 	
 	// Options

--- a/BondageClub/Scripts/ExtendedItem.js
+++ b/BondageClub/Scripts/ExtendedItem.js
@@ -146,13 +146,12 @@ function ExtendedItemDraw(Options, DialogPrefix, OptionsPerPage, ShowImages = tr
 
 	// Draw the possible variants and their requirements, arranged based on the number per page
 	for (let I = ItemOptionsOffset; I < Options.length && I < ItemOptionsOffset + OptionsPerPage; I++) {
-		var C = CharacterGetCurrent();
 		var PageOffset = I - ItemOptionsOffset;
 		var X = XYPositions[OptionsPerPage][PageOffset][0];
 		var Y = XYPositions[OptionsPerPage][PageOffset][1];
+		
 		var Option = Options[I];
-		var Height = (ShowImages) ? 275 : 55;
-		var Hover = (MouseX >= X) && (MouseX < X + 225) && (MouseY >= Y) && (MouseY < Y + Height) && !CommonIsMobile;
+		var Hover = MouseIn(X, Y, 225, 55 + ImageHeight) && !CommonIsMobile;
 		var FailSkillCheck = !!ExtendedItemRequirementCheckMessage(Option, IsSelfBondage);
 		var IsSelected = DialogFocusItem.Property.Type == Option.Property.Type;
 		var Blocked = InventoryIsPermissionBlocked(C, DialogFocusItem.Asset.DynamicName(Player), DialogFocusItem.Asset.DynamicGroupName, Option.Property.Type);
@@ -216,21 +215,21 @@ function ExtendedItemClick(Options, IsCloth, OptionsPerPage, ShowImages = true) 
 		var Y = XYPositions[OptionsPerPage][PageOffset][1];
 		var Option = Options[I];
 		if (MouseIn(X, Y, 225, 55 + ImageHeight)) {
-			ExtendedItemHandleOptionClick(Options, Option, IsSelfBondage, IsCloth);
+			ExtendedItemHandleOptionClick(C, Options, Option, IsSelfBondage, IsCloth);
 		}
 	}
 }
 
 /**
  * Handler function for setting the type of an extended item
+ * @param {Character} C - The character wearing the item
  * @param {ExtendedItemOption[]} Options - An Array of type definitions for each allowed extended type. The first item in the array should
  *     be the default option.
  * @param {ExtendedItemOption} Option - The selected type definition
  * @param {boolean} IsCloth - Whether or not the click is performed on a clothing item.
  * @returns {void} Nothing
  */
-function ExtendedItemSetType(Options, Option, IsCloth) {
-	var C = CharacterGetCurrent() || CharacterAppearanceSelection;
+function ExtendedItemSetType(C, Options, Option, IsCloth) {
 	var FunctionPrefix = ExtendedItemFunctionPrefix();
 
 	// An extendable item may provide a validation function. Returning false from the validation function will drop out of
@@ -294,6 +293,7 @@ function ExtendedItemSetType(Options, Option, IsCloth) {
 
 /**
  * Handler function called when an option on the type selection screen is clicked
+ * @param {Character} C - The character wearing the item
  * @param {ExtendedItemOption[]} Options - An Array of type definitions for each allowed extended type. The first item in the array should
  *     be the default option.
  * @param {ExtendedItemOption} Option - The selected type definition
@@ -301,8 +301,7 @@ function ExtendedItemSetType(Options, Option, IsCloth) {
  * @param {boolean} IsCloth - Whether or not the click is performed on a clothing item.
  * @returns {void} Nothing
  */
-function ExtendedItemHandleOptionClick(Options, Option, IsSelfBondage, IsCloth) {
-	var C = CharacterGetCurrent();
+function ExtendedItemHandleOptionClick(C, Options, Option, IsSelfBondage, IsCloth) {
 	if (ExtendedItemPermissionMode) {
 		if (Option.Property.Type == null || (C.ID == 0 && DialogFocusItem.Property.Type == Option.Property.Type)) return;
 		InventoryTogglePermission(DialogFocusItem, Option.Property.Type);
@@ -315,7 +314,7 @@ function ExtendedItemHandleOptionClick(Options, Option, IsSelfBondage, IsCloth) 
 		if (requirementMessage) {
 			DialogExtendedMessage = requirementMessage;
 		} else {
-			ExtendedItemSetType(Options, Option, IsCloth);
+			ExtendedItemSetType(C, Options, Option, IsCloth);
 		}
 	}
 }


### PR DESCRIPTION
The following small changes have been made for ExtendedItem:
- The character variable C is being passed to other ExtendedItem functions and into the Validate functions, mainly to help avoid the risk of the extended clothes error noted in #1463 occurring in future. #1493 will need to be changed to fit this, so I'll make the change in whichever of the two PRs is merged second.
- When a Web option failed the prerequisite checks, it was exiting the options screen instead of staying in it. I think due to #1386.
- For extended items with multiple pages of options, both the Previous and Next buttons will now always be visible and going past the first or last page will wrap around. They've been repositioned to avoid overlapping the item preview image at the top.