### PR TITLE
Bugfix: Prevents players from colouring items they shouldn't be able to

### DIFF
--- a/BondageClub/Scripts/Dialog.js
+++ b/BondageClub/Scripts/Dialog.js
@@ -539,7 +539,7 @@ function DialogCanUseRemote(C, Item) {
  */
 function DialogCanColor(Item) {
 	const CanUnlock = InventoryItemHasEffect(Item, "Lock", true) ? DialogCanUnlock(Player, Item) : true;
-	return (Player.CanInteract() && CanUnlock) || DialogAlwaysAllowRestraint()
+	return (Player.CanInteract() && CanUnlock) || DialogAlwaysAllowRestraint();
 }
 
 /**

--- a/BondageClub/Scripts/Dialog.js
+++ b/BondageClub/Scripts/Dialog.js
@@ -310,10 +310,10 @@ function DialogPrerequisite(D) {
 }
 
 /**
- * Checks, if the player owns a key to unlock a given item or is able to unlock the item
- * @param {Character} C - The character whose inventory and ability to unlock the lock should be checked
+ * Checks whether the player is able to unlock the provided item on the provided character
+ * @param {Character} C - The character on whom the item is equipped
  * @param {Item} Item - The item that should be unlocked
- * @returns {boolean} - Returns true, if the character can unlock the given item, false otherwise
+ * @returns {boolean} - Returns true, if the player can unlock the given item, false otherwise
  */
 function DialogCanUnlock(C, Item) {
 	if ((C.ID != 0) && !Player.CanInteract()) return false;
@@ -533,12 +533,13 @@ function DialogCanUseRemote(C, Item) {
 }
 
 /**
- * Checks whether the player can color the given item
+ * Checks whether the player can color the given item on the given character
+ * @param {Character} C - The character on whom the item is equipped
  * @param {Item} Item - The item to check the player's ability to color against
  * @returns {boolean} - TRUE if the player is able to color the item, FALSE otherwise
  */
-function DialogCanColor(Item) {
-	const CanUnlock = InventoryItemHasEffect(Item, "Lock", true) ? DialogCanUnlock(Player, Item) : true;
+function DialogCanColor(C, Item) {
+	const CanUnlock = InventoryItemHasEffect(Item, "Lock", true) ? DialogCanUnlock(C, Item) : true;
 	return (Player.CanInteract() && CanUnlock) || DialogAlwaysAllowRestraint();
 }
 
@@ -578,7 +579,7 @@ function DialogMenuButtonBuild(C) {
 		if ((Item != null) && !IsItemLocked && InventoryItemHasEffect(Item, "Enclose", true) && Player.CanInteract() && InventoryAllow(C, Item.Asset.Prerequisite) && !IsGroupBlocked) DialogMenuButton.push("Escape");
 		if (DialogCanUseRemote(C, Item)) DialogMenuButton.push("Remote");
 		if ((Item != null) && Item.Asset.Extended && ((Player.CanInteract()) || DialogAlwaysAllowRestraint() || Item.Asset.AlwaysInteract) && (!IsGroupBlocked || Item.Asset.AlwaysExtend) && (!Item.Asset.OwnerOnly || (C.IsOwnedByPlayer())) && (!Item.Asset.LoverOnly || (C.IsLoverOfPlayer()))) DialogMenuButton.push("Use");
-		if (DialogCanColor(Item)) DialogMenuButton.push("ColorPick");
+		if (DialogCanColor(C, Item)) DialogMenuButton.push("ColorPick");
 
 		// Make sure the target player zone is allowed for an activity
 		if ((C.FocusGroup.Activity != null) && ((!C.IsEnclose() && !Player.IsEnclose()) || C.ID == 0) && ActivityAllowed() && (C.ArousalSettings != null) && (C.ArousalSettings.Zone != null) && (C.ArousalSettings.Active != null) && (C.ArousalSettings.Active != "Inactive"))

--- a/BondageClub/Scripts/Dialog.js
+++ b/BondageClub/Scripts/Dialog.js
@@ -533,6 +533,16 @@ function DialogCanUseRemote(C, Item) {
 }
 
 /**
+ * Checks whether the player can color the given item
+ * @param {Item} Item - The item to check the player's ability to color against
+ * @returns {boolean} - TRUE if the player is able to color the item, FALSE otherwise
+ */
+function DialogCanColor(Item) {
+	const CanUnlock = InventoryGetItemProperty(Item, "LockedBy") ? DialogCanUnlock(Player, Item) : true;
+	return (Player.CanInteract() && CanUnlock) || DialogAlwaysAllowRestraint()
+}
+
+/**
  * Build the buttons in the top menu
  * @param {Character} C - The character for whom the dialog is prepared
  * @returns {void} - Nothing
@@ -568,7 +578,7 @@ function DialogMenuButtonBuild(C) {
 		if ((Item != null) && !IsItemLocked && InventoryItemHasEffect(Item, "Enclose", true) && Player.CanInteract() && InventoryAllow(C, Item.Asset.Prerequisite) && !IsGroupBlocked) DialogMenuButton.push("Escape");
 		if (DialogCanUseRemote(C, Item)) DialogMenuButton.push("Remote");
 		if ((Item != null) && Item.Asset.Extended && ((Player.CanInteract()) || DialogAlwaysAllowRestraint() || Item.Asset.AlwaysInteract) && (!IsGroupBlocked || Item.Asset.AlwaysExtend) && (!Item.Asset.OwnerOnly || (C.IsOwnedByPlayer())) && (!Item.Asset.LoverOnly || (C.IsLoverOfPlayer()))) DialogMenuButton.push("Use");
-		if ((Player.CanInteract()) || DialogAlwaysAllowRestraint()) DialogMenuButton.push("ColorPick");
+		if (DialogCanColor(Item)) DialogMenuButton.push("ColorPick");
 
 		// Make sure the target player zone is allowed for an activity
 		if ((C.FocusGroup.Activity != null) && ((!C.IsEnclose() && !Player.IsEnclose()) || C.ID == 0) && ActivityAllowed() && (C.ArousalSettings != null) && (C.ArousalSettings.Zone != null) && (C.ArousalSettings.Active != null) && (C.ArousalSettings.Active != "Inactive"))

--- a/BondageClub/Scripts/Dialog.js
+++ b/BondageClub/Scripts/Dialog.js
@@ -538,7 +538,7 @@ function DialogCanUseRemote(C, Item) {
  * @returns {boolean} - TRUE if the player is able to color the item, FALSE otherwise
  */
 function DialogCanColor(Item) {
-	const CanUnlock = InventoryGetItemProperty(Item, "LockedBy") ? DialogCanUnlock(Player, Item) : true;
+	const CanUnlock = InventoryItemHasEffect(Item, "Lock", true) ? DialogCanUnlock(Player, Item) : true;
 	return (Player.CanInteract() && CanUnlock) || DialogAlwaysAllowRestraint()
 }
 


### PR DESCRIPTION
## Summary

Removes the colour picker button from the dialog menu buttons when the item is locked and the player is unable to unlock the item.