### PR TITLE
Optimized Scripted Assets

### DIFF
--- a/BondageClub/Scripts/Character.js
+++ b/BondageClub/Scripts/Character.js
@@ -620,6 +620,10 @@ function CharacterRefresh(C, Push) {
 	CharacterLoadEffect(C);
 	CharacterLoadPose(C);
 	CharacterLoadCanvas(C);
+	// Label often looped through checks:
+	C.RunScripts = (!C.AccountName.startsWith('Online-') || !(Player.OnlineSettings && Player.OnlineSettings.DisableAnimations)) && (!Player.GhostList || Player.GhostList.indexOf(C.MemberNumber) == -1);
+	C.HasScriptedAssets = !!C.Appearance.find(CA => CA.Asset.DynamicScriptDraw);
+	
 	if ((C.ID == 0) && (C.OnlineID != null) && ((Push == null) || (Push == true))) {
 		ChatRoomRefreshChatSettings(C);
 		ServerPlayerAppearanceSync();

--- a/BondageClub/Scripts/Drawing.js
+++ b/BondageClub/Scripts/Drawing.js
@@ -191,10 +191,7 @@ function DrawCharacter(C, X, Y, Zoom, IsHeightResizeAllowed) {
 		}
 
 		// Run any existing asset scripts
-		if (
-			(!C.AccountName.startsWith('Online-') || !(Player.OnlineSettings && Player.OnlineSettings.DisableAnimations))
-			&& (!Player.GhostList || Player.GhostList.indexOf(C.MemberNumber) == -1)
-		) {
+		if (C.RunScripts && C.HasScriptedAssets) {
 			var DynamicAssets = C.Appearance.filter(CA => CA.Asset.DynamicScriptDraw);
 			DynamicAssets.forEach(Item =>
 				window["Assets" + Item.Asset.Group.Name + Item.Asset.Name + "ScriptDraw"]({


### PR DESCRIPTION
To avoid looping through `GhostList` and the characters' appearance every frame, I've made it so the CharacterRefresh handles it.
This should help slower devices as now there won't be any performance penalty whatsoever.

Now any character without scripted assets wont even reach that code.

The only small downside is that the preferences based on scripted assets will require a character refresh to be taken into account, but that's rare and barely noticeable.

I have some other improvements in mind, but that's the simplest for now