### PR TITLE
Confirm safeword

### DIFF
--- a/BondageClub/Screens/Character/Preference/Preference.js
+++ b/BondageClub/Screens/Character/Preference/Preference.js
@@ -1,6 +1,7 @@
 "use strict";
 var PreferenceBackground = "Sheet";
 var PreferenceMessage = "";
+var PreferenceSafewordConfirm = false;
 var PreferenceColorPick = "";
 var PreferenceSubscreen = "";
 var PreferenceChatColorThemeSelected = "";
@@ -384,7 +385,7 @@ function PreferenceRun() {
 	DrawCheckbox(500, 472, 64, 64, TextGet("BlindDisableExamine"), Player.GameplaySettings.BlindDisableExamine);
 	DrawCheckbox(500, 552, 64, 64, TextGet("DisableAutoRemoveLogin"), Player.GameplaySettings.DisableAutoRemoveLogin);
 	DrawCheckbox(500, 632, 64, 64, TextGet("ForceFullHeight"), Player.VisualSettings.ForceFullHeight);
-	DrawCheckbox(500, 712, 64, 64, TextGet("EnableSafeword"), Player.GameplaySettings.EnableSafeword);
+	DrawCheckbox(500, 712, 64, 64, TextGet(PreferenceSafewordConfirm ? "ConfirmSafeword" : "EnableSafeword"), Player.GameplaySettings.EnableSafeword);
 
 	MainCanvas.textAlign = "center";
 	DrawBackNextButton(500, 392, 250, 64, TextGet(Player.GameplaySettings.SensDepChatLog), "White", "",
@@ -485,8 +486,23 @@ function PreferenceClick() {
 	if (MouseIn(500, 552, 64, 64)) Player.GameplaySettings.DisableAutoRemoveLogin = !Player.GameplaySettings.DisableAutoRemoveLogin;
 	if (MouseIn(500, 632, 64, 64)) Player.VisualSettings.ForceFullHeight = !Player.VisualSettings.ForceFullHeight;
 	if (MouseIn(500, 712, 64, 64)) {
-		if (!Player.GameplaySettings.EnableSafeword && !Player.IsRestrained() && !Player.IsChaste()) Player.GameplaySettings.EnableSafeword = true;
-		else if (Player.GameplaySettings.EnableSafeword) Player.GameplaySettings.EnableSafeword = false;
+		if (!Player.GameplaySettings.EnableSafeword && !Player.IsRestrained() && !Player.IsChaste()) { 
+			if (PreferenceSafewordConfirm) {
+				Player.GameplaySettings.EnableSafeword = true;
+				PreferenceSafewordConfirm = false; 
+			} else {
+				PreferenceSafewordConfirm = true; 
+			}
+		} else if (Player.GameplaySettings.EnableSafeword) {
+			if (PreferenceSafewordConfirm) {
+				Player.GameplaySettings.EnableSafeword = false;
+				PreferenceSafewordConfirm = false; 
+			} else {
+				PreferenceSafewordConfirm = true; 
+			}
+		}
+	} else {
+		PreferenceSafewordConfirm = false;
 	}
 }
 

--- a/BondageClub/Screens/Character/Preference/Text_Preference.csv
+++ b/BondageClub/Screens/Character/Preference/Text_Preference.csv
@@ -50,6 +50,7 @@ DisableAutoRemoveLogin,Keep all of your restraints when relogging
 ForceFullHeight,Display all characters at maximum height
 EnableAfkTimer,Show AFK bubble if idle for 5 minutes
 EnableSafeword,Allow Safeword use (Cannot enable while bound).
+ConfirmSafeword,(Click to confirm) Allow Safeword use (Cannot enable while bound).
 EnableWardrobeIcon, Show Wardrobe icon to others while in the appearance menu.
 AllowFullWardrobeAccess,Allow others to alter your whole appearance.
 BlockBodyCosplay,Prevent others from changing cosplay items.


### PR DESCRIPTION
- added a confirmation prompt to the safeword checkbox to prevent misclicks

It was raised as a concern that it was too easy to misclick it and get stuck while bound, so now it requires a double click to enable/disable.