### PR TITLE
Fix dialog leave

### DIFF
--- a/BondageClub/Scripts/Dialog.js
+++ b/BondageClub/Scripts/Dialog.js
@@ -356,6 +356,7 @@ function DialogIntro() {
  */
 function DialogLeave() {
 	if (DialogItemPermissionMode && CurrentScreen == "ChatRoom") ChatRoomCharacterUpdate(Player);
+	DialogLeaveFocusItem();
 	DialogItemPermissionMode = false;
 	DialogActivityMode = false;
 	DialogItemToLock = null;


### PR DESCRIPTION
- added leaving the focus item when leaving the overall dialog as a safety net

Places that forcefully get you out of your menu had problems with extended items with cleanup functions. This fixes all of them. (For example, try being in a padlock, custom tag, etc. while having an orgasm, it leaves the input on screen)

