### PR TITLE
Fix: Login NPC Collar

### DIFF
--- a/BondageClub/Screens/Character/Login/Login.js
+++ b/BondageClub/Screens/Character/Login/Login.js
@@ -25,6 +25,7 @@ function LoginDoNextThankYou() {
 	LoginThankYou = CommonRandomItemFromList(LoginThankYou, LoginThankYouList);
 	CharacterRelease(Player, false);
 	CharacterAppearanceFullRandom(Player);
+	if (InventoryGet(Player, "ItemNeck") != null) InventoryRemove(Player, "ItemNeck", false);
 	CharacterFullRandomRestrain(Player);
 	LoginThankYouNext = CommonTime() + 4000;
 }


### PR DESCRIPTION
When a collar is equipped to the Login screen's random NPC, all random NPCs from then on will have that same collar (provided other assets don't hide it). This can be seen by simply waiting for a while on the screen.
The reason for this is that `CharacterFullRandomRestrain` has a chance to add a random asset from ItemNeck, but since nearly every asset in the group is not a restraint, `CharacterRelease` does not remove it for the next NPC. 
This has been fixed by removing the ItemNeck asset each loop. I don't think there's anywhere else in the game repeatedly applying full restraints and releasing like this so this is the simplest fix.