### PR TITLE
Beta bugfix: Disallow items on movie studio props

### DIFF
--- a/BondageClub/Screens/Room/MovieStudio/MovieStudio.js
+++ b/BondageClub/Screens/Room/MovieStudio/MovieStudio.js
@@ -231,9 +231,11 @@ function MovieStudioProgress(Movie, Scene, Role) {
 		MovieStudioActor1 = CharacterLoadNPC("NPC_MovieStudio_Interview_Drawer");
 		MovieStudioActor1.FixedImage = "Screens/Room/MovieStudio/Drawer.png";
 		MovieStudioActor1.Stage = "0";
+		MovieStudioActor1.AllowItem = false;
 		MovieStudioActor2 = CharacterLoadNPC("NPC_MovieStudio_Interview_XCross");
 		MovieStudioActor2.FixedImage = "Screens/Room/MovieStudio/XCross.png";
 		MovieStudioActor2.Stage = "0";
+		MovieStudioActor2.AllowItem = false;
 	}
 	if (CurrentCharacter != null) DialogLeave();
 }


### PR DESCRIPTION
Tiny bug (or at least weirdness) in the movie studio. The cross and drawers have `AllowItem` set to true allowing you to add restraints to them.

This simply sets it to false on both.