### PR TITLE
Fix: Bluetooth Earbuds option selection

### DIFF
--- a/BondageClub/Screens/Inventory/ItemEars/BluetoothEarbuds/BluetoothEarbuds.js
+++ b/BondageClub/Screens/Inventory/ItemEars/BluetoothEarbuds/BluetoothEarbuds.js
@@ -26,16 +26,21 @@ function InventoryItemEarsBluetoothEarbudsClick() {
 
 /**
  * Forwards the call to InventoryItemEarsHeadphoneEarPlugsPublishAction 
+ * @param {Character} C - The target character
+ * @param {Option} Option - The currently selected Option
+ * @param {Option} PreviousOption - The previously selected Option
  * @returns {void} - Nothing
  */
-function InventoryItemEarsBluetoothEarbudsPublishAction() {
-	InventoryItemEarsHeadphoneEarPlugsPublishAction();
+function InventoryItemEarsBluetoothEarbudsPublishAction(C, Option, PreviousOption) {
+	InventoryItemEarsHeadphoneEarPlugsPublishAction(C, Option, PreviousOption);
 }
 
 /**
  * Forwards the call to 	InventoryItemEarsHeadphoneEarPlugsNpcDialog 
+ * @param {Character} C - The NPC to whom the restraint is applied
+ * @param {Option} Option - The chosen option for this extended item
  * @returns {void} - Nothing
  */
-function InventoryItemEarsBluetoothEarbudsNpcDialog() {
-	InventoryItemEarsHeadphoneEarPlugsNpcDialog();
+function InventoryItemEarsBluetoothEarbudsNpcDialog(C, Option) {
+	InventoryItemEarsHeadphoneEarPlugsNpcDialog(C, Option);
 }


### PR DESCRIPTION
The Bluetooth Earbuds extended option functions were redirected into the Headphone Ear Plugs ones, but some parameters were missing resulting in nothing happening on clicking an option. Now fixed.