### PR TITLE
Fix: Simple Hogtie Prerequisites

### DIFF
--- a/BondageClub/Screens/Inventory/ItemArms/HempRope/HempRope.js
+++ b/BondageClub/Screens/Inventory/ItemArms/HempRope/HempRope.js
@@ -28,6 +28,7 @@ const InventoryItemArmsHempRopeOptions = [
 	}, {
 		Name: "SimpleHogtie",
 		BondageLevel: 2,
+		Prerequisite: ["NotMounted", "NotSuspended", "CannotBeHogtiedWithAlphaHood"],
 		Property: { Type: "SimpleHogtie", Effect: ["Block", "Prone"], SetPose: ["Hogtied"], Difficulty: 2 },
 		Expression: [{ Group: "Blush", Name: "Medium", Timer: 5 }]
 	}, {


### PR DESCRIPTION
The Simple Hogtie option for Hemp Rope on arms never had Prerequisites allowing it to be combined with incompatible poses like suspension and horse. The standard Hogtie prereqs have been copied over.