### PR TITLE
Beta bugfix: Don't set auto AFK if it's already set.

### DIFF
--- a/BondageClub/Scripts/AfkTimer.js
+++ b/BondageClub/Scripts/AfkTimer.js
@@ -74,6 +74,7 @@ function AfkTimerSetEnabled(Enabled) {
  */
 function AfkTimerSetIsAfk() {
     if (CurrentScreen != "ChatRoom") return;
+    if (AfkTimerIsSet) return;
     // save the current Emoticon, if there is any
     if (InventoryGet(Player, "Emoticon") && InventoryGet(Player, "Emoticon").Property && AfkTimerOldEmoticon == null) {
         AfkTimerOldEmoticon = InventoryGet(Player, "Emoticon").Property.Expression;


### PR DESCRIPTION
The automatic AFK emoticon does not get cleared if

1. Starting without an emoticon active
2. Going AFK for two or more "cycles" of the AFK check (>10 minutes)

On the second check `if (InventoryGet(Player, "Emoticon") && InventoryGet(Player, "Emoticon").Property && AfkTimerOldEmoticon == null)` will be true which sets the `AfkTimerOldEmoticon` to the AFK emoticon making the reset ineffective.

The fix checks `AfkTimerIsSet` to avoid setting it again. From what I can tell everything for auto AFK should be set by that point so it doesn't need to set anything again.