### PR TITLE
Chat Search Friends Position fix

### DIFF
--- a/BondageClub/Screens/Online/ChatSearch/ChatSearch.js
+++ b/BondageClub/Screens/Online/ChatSearch/ChatSearch.js
@@ -124,18 +124,21 @@ function ChatSearchNormalDraw() {
 		}
 
 		// Draws the hovering text of friends in the current room
-		if (!CommonIsMobile && (MouseX >= 25) && (MouseX < 1975) && (MouseY >= 25) && (MouseY < 875)) {
+		if (!CommonIsMobile && MouseIn(25, 25, 1950, 850)) {
 
 			// Finds the room where the mouse is hovering
 			X = 25;
 			Y = 25;
 			for (let C = ChatSearchResultOffset; C < ChatSearchResult.length && C < (ChatSearchResultOffset + ChatSearchRoomsPerPage); C++) {
-
+				
 				// Builds the friend list and shows it
-				if ((MouseX >= X) && (MouseX <= X + 630) && (MouseY >= Y) && (MouseY <= Y + 85) && (ChatSearchResult[C].Friends != null) && (ChatSearchResult[C].Friends.length > 0)) {
-					DrawTextWrap(TextGet("FriendsInRoom") + " " + ChatSearchResult[C].Name, (X > 1000) ? 685 : X + 660, (Y > 352) ? 352 : Y, 630, 60, "black", "#FFFF88", 1);
+				if (MouseIn(X, Y, 630, 85) && ChatSearchResult[C].Friends != null && ChatSearchResult[C].Friends.length > 0) {
+					let ListHeight = 60 * (1 + ChatSearchResult[C].Friends.length);
+					let ListY = Math.min(Y, 872 - ListHeight);
+
+					DrawTextWrap(TextGet("FriendsInRoom") + " " + ChatSearchResult[C].Name, (X > 1000) ? 685 : X + 660, ListY, 630, 60, "black", "#FFFF88", 1);
 					for (let F = 0; F < ChatSearchResult[C].Friends.length; F++)
-						DrawTextWrap(ChatSearchResult[C].Friends[F].MemberName + " (" + ChatSearchResult[C].Friends[F].MemberNumber + ")", (X > 1000) ? 685 : X + 660, ((Y > 352) ? 352 : Y) + 60 + F * 60, 630, 60, "black", "#FFFF88", 1);
+						DrawTextWrap(ChatSearchResult[C].Friends[F].MemberName + " (" + ChatSearchResult[C].Friends[F].MemberNumber + ")", (X > 1000) ? 685 : X + 660, ListY + 60 + F * 60, 630, 60, "black", "#FFFF88", 1);
 				}
 
 				// Moves the next window position


### PR DESCRIPTION
The 'Friend in room' hovering text for chat room buttons is mispositioned sometimes. 
When the room button is low enough, currently if below Y = 352 i.e. row 4, then the hovering text is positioned at row 4. This is presumably to ensure there's enough space to display a long list of friends without overlapping the bottom buttons and/or running offscreen. However for a short list of friends, the text often appears far above the room button and looks incorrect.
Now the height of this text is calculated so that it's only moved up when it will go too low, and ends up still beside beside the room button.