### PR TITLE
Beta bugfix: Makes ItemColorExit more resilient

### DIFF
--- a/BondageClub/Screens/Character/ItemColor/ItemColor.js
+++ b/BondageClub/Screens/Character/ItemColor/ItemColor.js
@@ -73,16 +73,9 @@ let ItemColorGroupNames;
  * @returns {void} - Nothing
  */
 function ItemColorLoad(c, item, x, y, width, height) {
+	ItemColorReset();
 	ItemColorCharacter = c;
 	ItemColorItem = item;
-	ItemColorCurrentMode = ItemColorMode.DEFAULT;
-	ItemColorStateKey = null;
-	ItemColorState = null;
-	ItemColorPage = 0;
-	ItemColorLayerPages = {};
-	ItemColorPickerBackup = null;
-	ItemColorPickerIndices = [];
-	ItemColorExitListeners = [];
 	ItemColorBackup = AppearanceItemStringify(item);
 	ItemColorStateBuild(c, item, x, y, width, height);
 	if (ItemColorState.simpleMode) {
@@ -595,7 +588,25 @@ function ItemColorOnExit(callback) {
  */
 function ItemColorFireExit(save) {
 	ItemColorExitListeners.forEach(listener => listener(ItemColorCharacter, ItemColorItem, save));
+	ItemColorReset();
+}
+
+/**
+ * Resets color UI related global variables back to their default states.
+ * @returns {void} - Nothing
+ */
+function ItemColorReset() {
+	ItemColorCharacter = null;
+	ItemColorItem = null;
+	ItemColorCurrentMode = ItemColorMode.DEFAULT;
+	ItemColorStateKey = null;
+	ItemColorState = null;
+	ItemColorPage = 0;
+	ItemColorLayerPages = {};
+	ItemColorPickerBackup = null;
+	ItemColorPickerIndices = [];
 	ItemColorExitListeners = [];
+	ItemColorBackup = null;
 	ItemColorLayerNames = null;
 	ItemColorGroupNames = null;
 }

--- a/BondageClub/Screens/Character/ItemColor/ItemColor.js
+++ b/BondageClub/Screens/Character/ItemColor/ItemColor.js
@@ -312,8 +312,10 @@ function ItemColorExit() {
 			return ItemColorPickerCancel();
 		case ItemColorMode.DEFAULT:
 		default:
-			Object.assign(ItemColorItem, AppearanceItemParse(ItemColorBackup));
-			CharacterLoadCanvas(ItemColorCharacter);
+			if (ItemColorBackup && ItemColorCharacter) {
+				Object.assign(ItemColorItem, AppearanceItemParse(ItemColorBackup));
+				CharacterLoadCanvas(ItemColorCharacter);
+			}
 			ItemColorFireExit(false);
 	}
 }

--- a/BondageClub/Scripts/Character.js
+++ b/BondageClub/Scripts/Character.js
@@ -661,8 +661,9 @@ function CharacterRefresh(C, Push) {
 			}
 			ActivityDialogBuild(C);
 		}
-		if (DialogColor != null) { 
-			if (ItemColorItem == null || InventoryGet(C, ItemColorItem.Asset.Group.Name) == null || InventoryGet(C, ItemColorItem.Asset.Group.Name).Asset.Name != ItemColorItem.Asset.Name)
+		if (DialogColor != null) {
+			const FocusItem = C && C.FocusGroup ? InventoryGet(C, C.FocusGroup.Name): null;
+			if (ItemColorItem == null || FocusItem == null || FocusItem.Asset.Name != ItemColorItem.Asset.Name)
 				ItemColorExit();
 		}
 	}

--- a/BondageClub/Scripts/Character.js
+++ b/BondageClub/Scripts/Character.js
@@ -662,9 +662,14 @@ function CharacterRefresh(C, Push) {
 			ActivityDialogBuild(C);
 		}
 		if (DialogColor != null) {
-			const FocusItem = C && C.FocusGroup ? InventoryGet(C, C.FocusGroup.Name): null;
-			if (ItemColorItem == null || FocusItem == null || FocusItem.Asset.Name != ItemColorItem.Asset.Name)
+			const FocusItem = C && C.FocusGroup ? InventoryGet(C, C.FocusGroup.Name) : null;
+			if ((ItemColorItem && !FocusItem) || (!ItemColorItem && FocusItem) || InventoryGetItemProperty(ItemColorItem, "Name") !== InventoryGetItemProperty(FocusItem, "Name")) {
 				ItemColorExit();
+				DialogColor = null;
+				DialogColorSelect = null;
+				ElementRemove("InputColor");
+				DialogMenuButtonBuild(C);
+			}
 		}
 	}
 }

--- a/BondageClub/Scripts/Element.js
+++ b/BondageClub/Scripts/Element.js
@@ -235,17 +235,20 @@ function ElementPosition(ElementID, X, Y, W, H) {
 
 	// Sets the element style
 	var E = document.getElementById(ElementID);
-	Object.assign(E.style, {
-		fontSize: Font + "px",
-		fontFamily: "Arial",
-		position: "absolute",
-		left: Left + "px",
-		top: Top + "px",
-		width: Width + "px",
-		height: Height + "px",
-		display: "inline"
-	});
-
+	if (E) {
+		Object.assign(E.style, {
+			fontSize: Font + "px",
+			fontFamily: "Arial",
+			position: "absolute",
+			left: Left + "px",
+			top: Top + "px",
+			width: Width + "px",
+			height: Height + "px",
+			display: "inline"
+		});
+	} else {
+		console.warn("A call to ElementPosition was made on non-existent element with ID '" + ElementID + "'");
+	}
 }
 
 /** 


### PR DESCRIPTION
## Summary

This makes 2 changes which can cause errors on character update within the colour picker:

* Refines the conditions upon which `ItemColorExit` is called upon character refresh so that it is only called when needed
* Updates the `ItemColorExit` function to be more resilient to in cases where `ItemColorLoad` has never been called

These changes should fix errors like this from occurring:

![](https://cdn.discordapp.com/attachments/764509482528669708/765569181411967016/unknown.png)