### PR TITLE
Fix: asylum bedroom softlocks

### DIFF
--- a/BondageClub/Screens/Character/Appearance/Appearance.js
+++ b/BondageClub/Screens/Character/Appearance/Appearance.js
@@ -37,9 +37,8 @@ function CharacterAppearanceBuildAssets(C) {
 
 }
 
-// 
 /**
- * Makes sure the character appearance is valid from inventory and asset requirement
+ * Makes sure the character appearance is valid from inventory and asset requirement. This function is called during the login process.
  * @param {Character} C - The character whose appearance is checked
  * @returns {void} - Nothing
  */
@@ -54,7 +53,7 @@ function CharacterAppearanceValidate(C) {
 		}
 
 	// Remove items flagged as "Remove At Login"
-	if (!Player.GameplaySettings || !Player.GameplaySettings.DisableAutoRemoveLogin)
+	if (LogQuery("Committed", "Asylum") || !Player.GameplaySettings || !Player.GameplaySettings.DisableAutoRemoveLogin)
 		for (let A = C.Appearance.length - 1; A >= 0; A--)
 			if (C.Appearance[A].Asset.RemoveAtLogin) {
 				C.Appearance.splice(A, 1);


### PR DESCRIPTION
- fixed a bug where you would be softlocked on the sybian when relogging in the asylum

This basically happens to things that have IsRestraint set to false and RemoveAtLogin set to true while you have the check to keep everything on you when logging WHILE you log into the asylum and that item needs to have something that conflicts with clothes in general (patient clothes) or you have >50 rep and cant use your arms.

After verification, it only happens to the sybian currently, however to prevent this from happening ever again, I added a check to bypass "keep all" in the login process if you are about to be sent to the asylum.

This change will only make it so you no longer keep teddy bears or the sybian when relogging in the asylum