### PR TITLE
Beta fix: Player appearance backup in the movie studio

### DIFF
--- a/BondageClub/Screens/Room/MovieStudio/Dialog_NPC_MovieStudio_Director.csv
+++ b/BondageClub/Screens/Room/MovieStudio/Dialog_NPC_MovieStudio_Director.csv
@@ -40,7 +40,7 @@ FailIntro3,,,Cut!  That doesn't work hun.  You forgot to spice up your play.,,
 1024,1025,I'll be the greatest journalist!,"This is wonderful hun, you'll become a star.  Go get changed and we'll start filming when you get back.","DialogChangeReputation(""Dominant"", 2)",
 1024,1025,I will try my best Miss Director.,"This is wonderful hun, you'll become a star.  Go get changed and we'll start filming when you get back.","DialogChangeReputation(""Dominant"", -2)",
 1024,0,I've changed my mind.,"Fine, make some room for the next movie star then.",,
-1025,1026,(Go change.),You look fabulous.  Now enter the room and we'll start recording.  Remember to be curious and sexy my star!,"Change(""Journalist"")",
+1025,1026,(Go change.),You look fabulous.  Now enter the room and we'll start recording.  Remember to be curious and sexy my star!,"Change(""Journalist"", true)",
 1026,,(Start the movie.),,"Progress(""Interview"", ""1"", ""Journalist"")",
 1030,1040,(Struggles happily.),(The crew releases you and help you to dress back up.  The full team celebrates with you.),PlayerDressBack(),Player.IsRestrained()
 1030,1040,(Give a thumbs up.),(The crew helps you to dress back up.  The full team celebrates with you.),PlayerDressBack(),!Player.IsRestrained()

--- a/BondageClub/Screens/Room/MovieStudio/MovieStudio.js
+++ b/BondageClub/Screens/Room/MovieStudio/MovieStudio.js
@@ -104,8 +104,7 @@ function MovieStudioProcessDecay() {
  * @returns {void} - Nothing
  */
 function MovieStudioLoad() {
-	if (MovieStudioOriginalClothes == null) MovieStudioOriginalClothes = Player.Appearance.slice(0);
-	if (MovieStudioDirector == null) {		
+	if (MovieStudioDirector == null) {
 		MovieStudioDirector = CharacterLoadNPC("NPC_MovieStudio_Director");
 		InventoryWear(MovieStudioDirector, "Beret1", "Hat");
 		InventoryWear(MovieStudioDirector, "SunGlasses1", "Glasses");
@@ -185,16 +184,22 @@ function MovieStudioClick() {
  * @returns {void} - Nothing
  */
 function MovieStudioPlayerDressBack() {
-	Player.Appearance = MovieStudioOriginalClothes.slice(0);
+	if (MovieStudioOriginalClothes) {
+		CharacterAppearanceRestore(Player, MovieStudioOriginalClothes);
+	}
 	CharacterRefresh(Player);
 }
 
 /**
  * When the player needs to change clothes for a role in the movie
  * @param {string} Cloth - The clothes to wear
+ * @param {string} [Backup] - Whether or not to backup the player's current clothes
  * @returns {void} - Nothing
  */
-function MovieStudioChange(Cloth) {
+function MovieStudioChange(Cloth, Backup) {
+	if (Backup === "true") {
+		MovieStudioOriginalClothes = CharacterAppearanceStringify(Player);
+	}
 	if (Cloth == "Journalist") {
 		CharacterNaked(Player);
 		InventoryWear(Player, "Camera1", "ClothAccessory", "Default");


### PR DESCRIPTION
## Summary

Previously, the player's appearance would get backed up as soon as she loaded the movie studio, meaning that if she was wearing restraints that she subsequently removed whilst inside the studio, these would get re-applied on finishing the movie. This moves the appearance backup to just before starting the movie by adding a `Backup` parameter to the `MovieStudioChange` function.