### PR TITLE
Fixed a bug where the futuristic belt would shock you for tampering

### DIFF
--- a/BondageClub/Screens/Inventory/ItemPelvis/FuturisticChastityBelt/FuturisticChastityBelt.js
+++ b/BondageClub/Screens/Inventory/ItemPelvis/FuturisticChastityBelt/FuturisticChastityBelt.js
@@ -119,7 +119,7 @@ function AssetsItemPelvisFuturisticChastityBeltScriptUpdatePlayer(data) {
 	var Item = data.Item
 	if (Item.Property.NextShockTime - CurrentTime <= 0) {
 		// Punish the player if they try to mess with the groin area
-		if (Item.Property.PunishStruggle && Player.FocusGroup && DialogProgressPrevItem != null && DialogProgressStruggleCount > 0) {
+		if (Item.Property.PunishStruggle && Player.FocusGroup && DialogProgress >= 0 && DialogProgressPrevItem != null && DialogProgressStruggleCount > 0) {
 			var inFocus = false
 			for (var Z = 0; Z < InventoryItemPelvisFuturisticChastityBeltTamperZones.length; Z++)
 				if (Player.FocusGroup.Name == InventoryItemPelvisFuturisticChastityBeltTamperZones[Z])


### PR DESCRIPTION
Bug would happen if you applied another item and then focused on the belt. Now DialogProgress must be >= 0 to indicate that the user is in the struggle menu.