### PR TITLE
Fix reference error

### DIFF
--- a/BondageClub/Scripts/Drawing.js
+++ b/BondageClub/Scripts/Drawing.js
@@ -6,6 +6,7 @@
 "use strict";
 var MainCanvas;
 var ColorCanvas;
+var DialogLeaveDueToItem = false
 
 // A bank of all the chached images
 var DrawCacheImage = {};


### PR DESCRIPTION
Fixes ReferenceError: DialogLeaveDueToItem is not defined by adding var DialogLeaveDueToItem in globals