### PR TITLE
Bugfix: Colour picker error

### DIFF
--- a/BondageClub/Scripts/ColorPicker.js
+++ b/BondageClub/Scripts/ColorPicker.js
@@ -10,6 +10,7 @@
 
 var ColorPickerX, ColorPickerY, ColorPickerWidth, ColorPickerHeight;
 var ColorPickerInitialHSV, ColorPickerLastHSV, ColorPickerHSV, ColorPickerCallback, ColorPickerSourceElement;
+var ColorPickerCSS;
 
 var ColorPickerHueBarHeight = 40;
 var ColorPickerSVPanelGap = 20;
@@ -174,13 +175,13 @@ function ColorPickerSelectFromPallete(Event) {
  * @returns {void} - Nothing
  */
 function ColorPickerNotify() {
-    var Color = ColorPickerHSVToCSS(ColorPickerHSV);
+	ColorPickerCSS = ColorPickerHSVToCSS(ColorPickerHSV);
     if (ColorPickerCallback) {
-        ColorPickerCallback(Color);
+        ColorPickerCallback(ColorPickerCSS);
     }
 
     if (ColorPickerSourceElement) {
-        ColorPickerSourceElement.value = Color;
+        ColorPickerSourceElement.value = ColorPickerCSS;
     }
 }
 
@@ -209,7 +210,7 @@ function ColorPickerCSSColorEquals(Color1, Color2) {
     // convert short hand hex color to standard format
     if (Color1.length == 4) Color1 = "#" + Color1[1] + Color1[1] + Color1[2] + Color1[2] + Color1[3] + Color1[3];
     if (Color2.length == 4) Color2 = "#" + Color2[1] + Color2[1] + Color2[2] + Color2[2] + Color2[3] + Color2[3];
-    return Color1 == Color2;
+    return Color1 === Color2;
 }
 
 /**
@@ -255,6 +256,7 @@ function ColorPickerDraw(X, Y, Width, Height, Src, Callback) {
         ColorPickerInitialHSV = Object.assign({}, HSV);
         ColorPickerLastHSV =  Object.assign({}, HSV);
         ColorPickerHSV =  Object.assign({}, HSV);
+        ColorPickerCSS = Color;
         ColorPickerRemoveEventListener();   // remove possible duplicated attached event listener, just in case
         ColorPickerAttachEventListener();
     } else {
@@ -262,12 +264,12 @@ function ColorPickerDraw(X, Y, Width, Height, Src, Callback) {
         if (ColorPickerSourceElement != null) {
             var UserInputColor = ColorPickerSourceElement.value.trim().toUpperCase();
             if (CommonIsColor(UserInputColor)) {
-                var PrevColor = ColorPickerHSVToCSS(ColorPickerHSV).toUpperCase();
-                if (!ColorPickerCSSColorEquals(UserInputColor, PrevColor)) {
+                if (!ColorPickerCSSColorEquals(UserInputColor, ColorPickerCSS)) {
                     if (ColorPickerCallback) {
                         // Fire callback due to source element changed by user interaction
                         ColorPickerCallback(UserInputColor);
                     }
+                    ColorPickerCSS = UserInputColor;
                     ColorPickerHSV = ColorPickerCSSToHSV(UserInputColor, ColorPickerHSV);
                 }
             }


### PR DESCRIPTION
## Summary

This fixes an issue that would cause the colour picker callback to be called continuously due to a rounding error in the conversion between CSS RGB values and HSV values, which would result in errors on attempting to leave the colour picker when certain colour picker values were entered into the colour picker input.

The reason this happens is that the colour picker does an internal colour equality check between it's stored HSV value (which was converted from the input value) and the current input value. For some colours, converting from CSS --> HSV --> CSS would not return the exact same CSS colour due to rounding errors. For example, converting the CSS value `#3b1866` to HSV and back would return the CSS value `#3b1766`, causing the equality check to fail every time, meaning the colour picker callback would get called every frame.

This bugfix changes the colour picker to test against the last CSS colour entered into the picker directly, rather than passing it through HSV conversion and back before comparison, which should prevent this sort of issue occurring in the future.

## Steps to reproduce

1. Equip an item that only permits a single colour
2. Change the colour of that item in the colour picker
3. Enter the colour `#3b1866` (this is an intermittent bug that only occurs with certain CSS values, but this colour is known to reproduce the bug)
4. Note that the item colour does not update properly
5. Click the accept button
6. Note that the console now displays an error:
```
Uncaught TypeError: ItemColorState is null
    ItemColorOnPickerChange https://www.bondageprojects.com/college/R61/BondageClub/Screens/Character/ItemColor/ItemColor.js:199
    later https://www.bondageprojects.com/college/R61/BondageClub/Scripts/Common.js:384
    setTimeout handler*later https://www.bondageprojects.com/college/R61/BondageClub/Scripts/Common.js:381
```