### PR TITLE
Hair Mismatch Fix

### DIFF
--- a/BondageClub/Assets/Female3DCG/Female3DCG.csv
+++ b/BondageClub/Assets/Female3DCG/Female3DCG.csv
@@ -405,27 +405,6 @@ BodyLower,Small,Small
 BodyLower,Normal,Normal
 BodyLower,Large,Large
 BodyLower,XLarge,Xlarge
-HairBack,,Back Hair
-HairBack,HairNone,None
-HairBack,HairBack1,Style 1
-HairBack,HairBack2,Style 2
-HairBack,HairBack4,Style 3
-HairBack,HairBack10,Style 4
-HairBack,HairBack14,Style 5
-HairBack,HairBack15,Style 6
-HairBack,HairBack16,Style 7
-HairBack,HairBack17,Style 8
-HairBack,HairBack18,Style 9
-HairBack,HairBack19,Style 10
-HairBack,HairBack20,Style 11
-HairBack,HairBack5,Style 12
-HairBack,HairBack8,Style 13
-HairBack,HairBack11,Style 14
-HairBack,HairBack6,Style 15
-HairBack,HairBack21,Style 16
-HairBack,HairBack22,Style 17
-HairBack,HairBack23,Style 18
-HairBack,HairBack24,Style 19
 HairFront,,Front Hair
 HairFront,HairFront1,Style 1
 HairFront,HairFront1b,Style 1b
@@ -457,6 +436,27 @@ HairFront,HairFront14,Style 14
 HairFront,HairFront14b,Style 14b
 HairFront,HairFront1,Style 15
 HairFront,HairFront1,Style 16
+HairBack,,Back Hair
+HairBack,HairNone,None
+HairBack,HairBack1,Style 1
+HairBack,HairBack2,Style 2
+HairBack,HairBack4,Style 3
+HairBack,HairBack10,Style 4
+HairBack,HairBack14,Style 5
+HairBack,HairBack15,Style 6
+HairBack,HairBack16,Style 7
+HairBack,HairBack17,Style 8
+HairBack,HairBack18,Style 9
+HairBack,HairBack19,Style 10
+HairBack,HairBack20,Style 11
+HairBack,HairBack5,Style 12
+HairBack,HairBack8,Style 13
+HairBack,HairBack11,Style 14
+HairBack,HairBack6,Style 15
+HairBack,HairBack21,Style 16
+HairBack,HairBack22,Style 17
+HairBack,HairBack23,Style 18
+HairBack,HairBack24,Style 19
 Eyes,,Left eye
 Eyes,Eyes1,Style 1
 Eyes,Eyes2,Style 2

--- a/BondageClub/Assets/Female3DCG/Female3DCG.js
+++ b/BondageClub/Assets/Female3DCG/Female3DCG.js
@@ -954,6 +954,16 @@ var AssetFemale3DCG = [
 	},
 
 	{
+		Group: "HairFront",
+		Priority: 52,
+		Left: 150,
+		Top: 50,
+		AllowNone: false,
+		Asset: ["HairFront1", "HairFront1b", "HairFront2", "HairFront2b", "HairFront3", "HairFront3b", "HairFront4", "HairFront4b", "HairFront5", "HairFront5b", "HairFront6", "HairFront6b", "HairFront7", "HairFront7b", "HairFront8", "HairFront8b", "HairFront9", "HairFront9b", "HairFront10", "HairFront10b", "HairFront11", "HairFront11b", "HairFront12", "HairFront12b", "HairFront13", "HairFront13b", "HairFront14", "HairFront14b", "HairFront15", "HairFront16"],
+		Color: ["#6a3628", "#202020", "#dcc787", "#6c2132", "#999999", "#dddddd", "#e781b1", "#81e7b1", "#81b1e7", "#eeee99", "#ee9999", "#ee99ee"]
+	},
+
+	{
 		Group: "HairBack",
 		ParentColor: "HairFront",
 		Priority: 5,
@@ -967,16 +977,6 @@ var AssetFemale3DCG = [
 		],
 		Color: ["Default", "#6a3628", "#202020", "#dcc787", "#6c2132", "#999999", "#dddddd", "#e781b1", "#81e7b1", "#81b1e7", "#eeee99", "#ee9999", "#ee99ee"],
 		InheritColor: "HairFront"
-	},
-
-	{
-		Group: "HairFront",
-		Priority: 52,
-		Left: 150,
-		Top: 50,
-		AllowNone: false,
-		Asset: ["HairFront1", "HairFront1b", "HairFront2", "HairFront2b", "HairFront3", "HairFront3b", "HairFront4", "HairFront4b", "HairFront5", "HairFront5b", "HairFront6", "HairFront6b", "HairFront7", "HairFront7b", "HairFront8", "HairFront8b", "HairFront9", "HairFront9b", "HairFront10", "HairFront10b", "HairFront11", "HairFront11b", "HairFront12", "HairFront12b", "HairFront13", "HairFront13b", "HairFront14", "HairFront14b", "HairFront15", "HairFront16"],
-		Color: ["#6a3628", "#202020", "#dcc787", "#6c2132", "#999999", "#dddddd", "#e781b1", "#81e7b1", "#81b1e7", "#eeee99", "#ee9999", "#ee99ee"]
 	},
 
 	{


### PR DESCRIPTION
The NPCs were getting mismatched colours for the front and back because while HairBack had HairFront as its parent, HairBack appeared first in the asset group list, so there was no parent colour picked yet to be copied.
The simple solution to this was to swap HairFront and HairBack in the group list order.