### PR TITLE
Changed references in maid disabling script from CurrentTime to CommonTime()

### DIFF
--- a/BondageClub/Screens/Room/Gambling/Gambling.js
+++ b/BondageClub/Screens/Room/Gambling/Gambling.js
@@ -25,7 +25,7 @@ var GamblingToothpickCount = 0; // available Toothpicks
  * Checks if the player is helpless (maids disabled) or not.
  * @returns {boolean} - Returns true if the player still has time remaining after asking the maids to stop helping in the maid quarters
  */
-function GamblingIsMaidsDisabled() {  var expire = LogValue("MaidsDisabled", "Maid") - CurrentTime ; return (expire > 0)  }
+function GamblingIsMaidsDisabled() {  var expire = LogValue("MaidsDisabled", "Maid") - CommonTime() ; return (expire > 0)  }
 
 
 // Returns TRUE if a dialog is permitted

--- a/BondageClub/Screens/Room/MaidQuarters/MaidQuarters.js
+++ b/BondageClub/Screens/Room/MaidQuarters/MaidQuarters.js
@@ -473,5 +473,5 @@ function MaidQuartersNotFromOwner() {
 
 function MaidQuartersSetMaidsDisabled(minutes) {
 	var millis = minutes * 60000
-	LogAdd("MaidsDisabled", "Maid", CurrentTime + millis);
+	LogAdd("MaidsDisabled", "Maid", CommonTime() + millis);
 }

--- a/BondageClub/Screens/Room/MainHall/MainHall.js
+++ b/BondageClub/Screens/Room/MainHall/MainHall.js
@@ -46,34 +46,34 @@ function MainHallPlayerNeedsHelpAndHasNoOwnerOrLoverItem() {
  * Checks if the player is helpless (maids disabled) or not.
  * @returns {boolean} - Returns true if the player still has time remaining after asking the maids to stop helping in the maid quarters
  */
-function MainHallIsMaidsDisabled() {  var expire = LogValue("MaidsDisabled", "Maid") - CurrentTime ; return (expire > 0)  }
+function MainHallIsMaidsDisabled() {  var expire = LogValue("MaidsDisabled", "Maid") - CommonTime() ; return (expire > 0)  }
 
 /**
  * Checks for the dialog options to help the player know how much time is left before the maids can help them
  * @returns {boolean} - Returns TRUE if the remaining duration fits within the time range
  */
-function MainHallMaidsDisabledMinutesLeft() { var expire = LogValue("MaidsDisabled", "Maid") - CurrentTime; return (expire > 0  && expire < 600000)}
-function MainHallMaidsDisabledHourLeft() { var expire = LogValue("MaidsDisabled", "Maid") - CurrentTime; return (expire >= 600000 && expire < 3600000) }
-function MainHallMaidsDisabledDaysLeft1() { var expire = LogValue("MaidsDisabled", "Maid") - CurrentTime; return (expire >= 3600000 && expire < 86400000) }
-function MainHallMaidsDisabledDaysLeft2() { var expire = LogValue("MaidsDisabled", "Maid") - CurrentTime; return (expire >= 86400000 && expire < 172800000) }
-function MainHallMaidsDisabledDaysLeft3() { var expire = LogValue("MaidsDisabled", "Maid") - CurrentTime; return (expire >= 172800000 && expire < 259200000) }
-function MainHallMaidsDisabledDaysLeft4() { var expire = LogValue("MaidsDisabled", "Maid") - CurrentTime; return (expire >= 259200000 && expire < 345600000) }
-function MainHallMaidsDisabledDaysLeft5() { var expire = LogValue("MaidsDisabled", "Maid") - CurrentTime; return (expire >= 345600000 && expire < 432000000) }
-function MainHallMaidsDisabledDaysLeft6() { var expire = LogValue("MaidsDisabled", "Maid") - CurrentTime; return (expire >= 432000000 && expire < 518400000) }
-function MainHallMaidsDisabledDaysLeft7() { var expire = LogValue("MaidsDisabled", "Maid") - CurrentTime; return (expire >= 518400000 && expire < 604800000) }
-function MainHallMaidsDisabledDaysLeft8() { var expire = LogValue("MaidsDisabled", "Maid") - CurrentTime; return (expire >= 3700000) }//604800000) } // I added an extra 100 seconds as sometimes CurrentTime is not super accurate
+function MainHallMaidsDisabledMinutesLeft() { var expire = LogValue("MaidsDisabled", "Maid") - CommonTime(); return (expire > 0  && expire < 600000)}
+function MainHallMaidsDisabledHourLeft() { var expire = LogValue("MaidsDisabled", "Maid") - CommonTime(); return (expire >= 600000 && expire < 3600000) }
+function MainHallMaidsDisabledDaysLeft1() { var expire = LogValue("MaidsDisabled", "Maid") - CommonTime(); return (expire >= 3600000 && expire < 86400000) }
+function MainHallMaidsDisabledDaysLeft2() { var expire = LogValue("MaidsDisabled", "Maid") - CommonTime(); return (expire >= 86400000 && expire < 172800000) }
+function MainHallMaidsDisabledDaysLeft3() { var expire = LogValue("MaidsDisabled", "Maid") - CommonTime(); return (expire >= 172800000 && expire < 259200000) }
+function MainHallMaidsDisabledDaysLeft4() { var expire = LogValue("MaidsDisabled", "Maid") - CommonTime(); return (expire >= 259200000 && expire < 345600000) }
+function MainHallMaidsDisabledDaysLeft5() { var expire = LogValue("MaidsDisabled", "Maid") - CommonTime(); return (expire >= 345600000 && expire < 432000000) }
+function MainHallMaidsDisabledDaysLeft6() { var expire = LogValue("MaidsDisabled", "Maid") - CommonTime(); return (expire >= 432000000 && expire < 518400000) }
+function MainHallMaidsDisabledDaysLeft7() { var expire = LogValue("MaidsDisabled", "Maid") - CommonTime(); return (expire >= 518400000 && expire < 604800000) }
+function MainHallMaidsDisabledDaysLeft8() { var expire = LogValue("MaidsDisabled", "Maid") - CommonTime(); return (expire >= 3700000) }//604800000) } // I added an extra 100 seconds as sometimes CurrentTime is not super accurate
 
 /**
  * Checks for the dialog options to help the maid determine which dialog options she can give the player to extend the duration
  
  * @returns {boolean} - Returns TRUE if the remaining duration fits within the time range
  */
-function MainHallMaidsDisabledAtLeast30MinutesLeft() { var expire = LogValue("MaidsDisabled", "Maid") - CurrentTime; return (expire < 1800000) }
-function MainHallMaidsDisabledAtLeast1HourLeft() { var expire = LogValue("MaidsDisabled", "Maid") - CurrentTime; return (expire < 3600000) }
-function MainHallMaidsDisabledAtLeast12HourLeft() { var expire = LogValue("MaidsDisabled", "Maid") - CurrentTime; return (expire < 43200000) }
-function MainHallMaidsDisabledAtLeastDaysLeft1() { var expire = LogValue("MaidsDisabled", "Maid") - CurrentTime; return (expire < 86400000) }
-function MainHallMaidsDisabledAtLeastDaysLeft3() { var expire = LogValue("MaidsDisabled", "Maid") - CurrentTime; return (expire < 259200000) }
-function MainHallMaidsDisabledAtLeastDaysLeft7() { var expire = LogValue("MaidsDisabled", "Maid") - CurrentTime; return (expire < 604800000) }
+function MainHallMaidsDisabledAtLeast30MinutesLeft() { var expire = LogValue("MaidsDisabled", "Maid") - CommonTime(); return (expire < 1800000) }
+function MainHallMaidsDisabledAtLeast1HourLeft() { var expire = LogValue("MaidsDisabled", "Maid") - CommonTime(); return (expire < 3600000) }
+function MainHallMaidsDisabledAtLeast12HourLeft() { var expire = LogValue("MaidsDisabled", "Maid") - CommonTime(); return (expire < 43200000) }
+function MainHallMaidsDisabledAtLeastDaysLeft1() { var expire = LogValue("MaidsDisabled", "Maid") - CommonTime(); return (expire < 86400000) }
+function MainHallMaidsDisabledAtLeastDaysLeft3() { var expire = LogValue("MaidsDisabled", "Maid") - CommonTime(); return (expire < 259200000) }
+function MainHallMaidsDisabledAtLeastDaysLeft7() { var expire = LogValue("MaidsDisabled", "Maid") - CommonTime(); return (expire < 604800000) }
 /**
  * Checks if the dialog option to trick the maid is available
  * @returns {boolean} - Returns TRUE if the maid can be tricked
@@ -502,5 +502,5 @@ function MainHallKeyDown() {
 
 function MainHallSetMaidsDisabled(minutes) {
 	var millis = minutes * 60000
-	LogAdd("MaidsDisabled", "Maid", CurrentTime + millis);
+	LogAdd("MaidsDisabled", "Maid", CommonTime() + millis);
 }

--- a/BondageClub/Screens/Room/MainHall/MainHall.js
+++ b/BondageClub/Screens/Room/MainHall/MainHall.js
@@ -61,7 +61,7 @@ function MainHallMaidsDisabledDaysLeft4() { var expire = LogValue("MaidsDisabled
 function MainHallMaidsDisabledDaysLeft5() { var expire = LogValue("MaidsDisabled", "Maid") - CurrentTime; return (expire >= 345600000 && expire < 432000000) }
 function MainHallMaidsDisabledDaysLeft6() { var expire = LogValue("MaidsDisabled", "Maid") - CurrentTime; return (expire >= 432000000 && expire < 518400000) }
 function MainHallMaidsDisabledDaysLeft7() { var expire = LogValue("MaidsDisabled", "Maid") - CurrentTime; return (expire >= 518400000 && expire < 604800000) }
-function MainHallMaidsDisabledDaysLeft8() { var expire = LogValue("MaidsDisabled", "Maid") - CurrentTime; return (expire >= 3600000) }//604800000) }
+function MainHallMaidsDisabledDaysLeft8() { var expire = LogValue("MaidsDisabled", "Maid") - CurrentTime; return (expire >= 3700000) }//604800000) } // I added an extra 100 seconds as sometimes CurrentTime is not super accurate
 
 /**
  * Checks for the dialog options to help the maid determine which dialog options she can give the player to extend the duration

--- a/BondageClub/Screens/Room/Management/Management.js
+++ b/BondageClub/Screens/Room/Management/Management.js
@@ -25,7 +25,7 @@ var ManagementTimer = 0;
  * Checks if the player is helpless (maids disabled) or not.
  * @returns {boolean} - Returns true if the player still has time remaining after asking the maids to stop helping
  */
-function ManagementIsMaidsDisabled() { var expire = LogValue("MaidsDisabled", "Maid") - CurrentTime ; return (expire > 0 ) }
+function ManagementIsMaidsDisabled() { var expire = LogValue("MaidsDisabled", "Maid") - CommonTime() ; return (expire > 0 ) }
 /**
  * Checks if the player has a special title such as maid, mistress, kidnapper, etc.
  * @returns {boolean} - TRUE if the player has a special title.

--- a/BondageClub/Screens/Room/Photographic/Photographic.js
+++ b/BondageClub/Screens/Room/Photographic/Photographic.js
@@ -13,7 +13,7 @@ var PhotographicSelectText = "";
  * Checks if the player is helpless (maids disabled) or not.
  * @returns {boolean} - Returns true if the player still has time remaining after asking the maids to stop helping
  */
-function PhotographicIsMaidsDisabled() { var expire = LogValue("MaidsDisabled", "Maid") - CurrentTime ; return (expire > 0 ) }
+function PhotographicIsMaidsDisabled() { var expire = LogValue("MaidsDisabled", "Maid") - CommonTime() ; return (expire > 0 ) }
 
 function PhotographicPlayerCanChangeCloth() {return Player.CanChange() && !Player.IsRestrained()}
 function PhotographicPlayerHatAvailable() {return PhotographicAppearanceAvailable(Player, "Hat");}


### PR DESCRIPTION
Changed references to CurrentTime to CommonTime() as it is more reliable.

Also added 100 seconds to the bug detection timer in Mainhall.js. This timer is meant to protect against people being locked out of maids for far longer than necessary. It shouldn't ever happen unless there is a bug, and is mainly meant to protect against being indefinitely bound. Adding 100 seconds should not do anything, but it might stop a rare bug I encountered that I am unable to repro, in which the bug notice appeared but disappeared after I called the maids again.