### PR TITLE
Blocked Handheld Toy - Inventory Order fix

### DIFF
--- a/BondageClub/Scripts/Dialog.js
+++ b/BondageClub/Scripts/Dialog.js
@@ -498,7 +498,7 @@ function DialogInventoryAdd(C, NewInv, NewInvWorn, SortOrder) {
 			return;
 
 	// If the item is blocked, we show it at the end of the list
-	if (InventoryIsPermissionBlocked(C, NewInv.Asset.Name, NewInv.Asset.Group.Name) || !InventoryCheckLimitedPermission(C, NewInv))
+	if (InventoryIsPermissionBlocked(C, NewInv.Asset.DynamicName(Player), NewInv.Asset.DynamicGroupName) || !InventoryCheckLimitedPermission(C, NewInv))
 		SortOrder = DialogSortOrderBlocked;
 
 	// Creates a new dialog inventory item


### PR DESCRIPTION
When a player tries to use a handheld toy on a target who has blocked that specific toy, the item still appears as the first option in the group with a white background, as if usable. Clicking on it does nothing.
A fix has been put in so that the item now moves to the end of the list highlighted red, the same as other items.