### PR TITLE
Extended Items Lock fix

### DIFF
--- a/BondageClub/Scripts/ExtendedItem.js
+++ b/BondageClub/Scripts/ExtendedItem.js
@@ -246,9 +246,8 @@ function ExtendedItemSetType(C, Options, Option, IsCloth) {
 		return;
 	} else {
 		let Asset = DialogFocusItem.Asset;
-		let C = CharacterGetCurrent();
 		let OldOption = InventoryGet(C, Asset.Group.Name);
-		if (OldOption.Property.Effect.indexOf("Lock") >= 0 && !Option.Property.AllowLock) {
+		if (OldOption.Property.Effect && OldOption.Property.Effect.indexOf("Lock") >= 0 && !Option.Property.AllowLock) {
 			DialogExtendedMessage = DialogFind(Player, "ExtendedItemUnlockBeforeChange");
 			return;
 		}


### PR DESCRIPTION
A small fix to #1449 to prevent an error when a lockable extended item doesn't have an effect. To see this apply Leather Ankle Cuffs on feet and try to change the option.
I also removed an unneeded C declaration that could actually cause issues for extended clothes.