### PR TITLE
Unlocked Gag Garble fix

### DIFF
--- a/BondageClub/Scripts/Speech.js
+++ b/BondageClub/Scripts/Speech.js
@@ -54,8 +54,8 @@ function SpeechGetGagLevel(C, AssetGroup) {
 		if (item.Asset.Group.Name === AssetGroup) {
 			var EffectArray = [];
 			if (item.Property &&
-			    Array.isArray(item.Property.Effect) &&
-			    !(typeof item.Property.Type === "undefined" && item.Property.Effect.length === 1 && item.Property.Effect[0] === "Lock")
+				Array.isArray(item.Property.Effect) &&
+				!(typeof item.Property.Type === "undefined")
 			) EffectArray = item.Property.Effect;
 			else if (Array.isArray(item.Asset.Effect)) EffectArray = item.Asset.Effect;
 			else if (Array.isArray(item.Asset.Group.Effect)) EffectArray = item.Asset.Group.Effect;

--- a/BondageClub/Scripts/Timer.js
+++ b/BondageClub/Scripts/Timer.js
@@ -65,13 +65,10 @@ function TimerInventoryRemove() {
 						delete Character[C].Appearance[A].Property.ShowTimer;
 						delete Character[C].Appearance[A].Property.EnableRandomInput;
 						delete Character[C].Appearance[A].Property.MemberNumberList;
-						if (Character[C].Appearance[A].Property.Effect != null) {
+						if (Character[C].Appearance[A].Property.Effect != null)
 							for (let E = 0; E < Character[C].Appearance[A].Property.Effect.length; E++)
 								if (Character[C].Appearance[A].Property.Effect[E] == "Lock")
 									Character[C].Appearance[A].Property.Effect.splice(E, 1);
-							if (!Character[C].Appearance[A].Property.Effect.length) Character[C].Appearance[A].Property.Effect = undefined;
-						}
-
 
 						// If we're removing a lock and we're in a chatroom, send a chatroom message
 						if (LockName && CurrentScreen === "ChatRoom") {


### PR DESCRIPTION
This is a part 2 for the fix from #1274. When a non-extended item gag is locked then unlocked, it no longer garbles text. 
The original PR restored the garbling while the gag was still locked, but not when it was unlocked again.
Now Property.Effect, which will always be non-garbling for non-extended gags, will only override Asset.Effect if Type is undefined, which ensures this will only happen for extended gags.