### PR TITLE
Self-Bondage Difficulty for Extended Types

### DIFF
--- a/BondageClub/Screens/Inventory/ItemDevices/BondageBench/BondageBench.js
+++ b/BondageClub/Screens/Inventory/ItemDevices/BondageBench/BondageBench.js
@@ -12,11 +12,11 @@ var InventoryItemDevicesBondageBenchOptions = [
 	},
 	{
 		Name: "Light",
+		SelfBondageLevel: 2,
 		Prerequisite: ["NoOuterClothes"],
 		Property: {
 			Type: "Light",
 			Difficulty: 2,
-			SelfBondage: 2,
 			AllowLock: true,
 			SetPose: ["LegsClosed", "BaseUpper"],
 			Effect: ["Block", "Prone", "Freeze", "Mounted"],
@@ -25,11 +25,11 @@ var InventoryItemDevicesBondageBenchOptions = [
 	},
 	{
 		Name: "Normal",
+		SelfBondageLevel: 3,
 		Prerequisite: ["NoOuterClothes"],
 		Property: {
 			Type: "Normal",
 			Difficulty: 3,
-			SelfBondage: 3,
 			AllowLock: true,
 			SetPose: ["LegsClosed", "BaseUpper"],
 			Effect: ["Block", "Prone", "Freeze", "Mounted"],
@@ -38,11 +38,11 @@ var InventoryItemDevicesBondageBenchOptions = [
 	},
 	{
 		Name: "Heavy",
+		SelfBondageLevel: 6,
 		Prerequisite: ["NoOuterClothes"],
 		Property: {
 			Type: "Heavy",
 			Difficulty: 6,
-			SelfBondage: 6,
 			AllowLock: true,
 			SetPose: ["LegsClosed", "BaseUpper"],
 			Effect: ["Block", "Prone", "Freeze", "Mounted"],
@@ -51,11 +51,11 @@ var InventoryItemDevicesBondageBenchOptions = [
 	},
 	{
 		Name: "Full",
+		SelfBondageLevel: 9,
 		Prerequisite: ["NoOuterClothes"],
 		Property: {
 			Type: "Full",
 			Difficulty: 9,
-			SelfBondage: 9,
 			AllowLock: true,
 			SetPose: ["LegsClosed", "BaseUpper"],
 			Effect: ["Block", "Prone", "Freeze", "Mounted"],

--- a/BondageClub/Scripts/ExtendedItem.js
+++ b/BondageClub/Scripts/ExtendedItem.js
@@ -335,10 +335,16 @@ function ExtendedItemHandleOptionClick(C, Options, Option, IsSelfBondage, IsClot
  * of the requirements they do not meet
  */
 function ExtendedItemRequirementCheckMessage(Option, IsSelfBondage) {
-	if (IsSelfBondage && SkillGetLevelReal(Player, "SelfBondage") < Option.SelfBondageLevel) {
-		return DialogFind(Player, "RequireSelfBondage" + Option.SelfBondageLevel);
-	} else if (!IsSelfBondage && SkillGetLevelReal(Player, "Bondage") < Option.BondageLevel) {
-		return DialogFind(Player, "RequireBondageLevel").replace("ReqLevel", Option.BondageLevel);
+	if (IsSelfBondage) {
+		let RequiredLevel = Option.SelfBondageLevel || Math.max(DialogFocusItem.Asset.SelfBondage, Option.BondageLevel);
+		if (SkillGetLevelReal(Player, "SelfBondage") < RequiredLevel) {
+			return DialogFind(Player, "RequireSelfBondage" + RequiredLevel);
+		}
+	} else {
+		let RequiredLevel = Option.BondageLevel;
+		if (SkillGetLevelReal(Player, "Bondage") < RequiredLevel) {
+			return DialogFind(Player, "RequireBondageLevel").replace("ReqLevel", RequiredLevel);
+		}
 	}
 	return null;
 }


### PR DESCRIPTION
When an extended item type has no SelfBondageLevel setting, it defaults to 0. This allows some types to be easier to apply to oneself than to someone else which isn't very consistent. The ItemArms HempRope options being a prime example.

Now the self-bondage type difficulty copies the Asset's overall self-bondage setting or the type's BondageLevel, whichever is higher, when a SelfBondageLevel has not been set.

Also includes a fix to the BondageBench settings.