### PR TITLE
Bugfix: Vibrator mode error

### DIFF
--- a/BondageClub/Scripts/VibratorMode.js
+++ b/BondageClub/Scripts/VibratorMode.js
@@ -537,7 +537,7 @@ function VibratorModeStateUpdateRest(C, Arousal, TimeSinceLastChange, OldIntensi
  */
 function VibratorModeSetProperty(Item, Property) {
 	Property = VibratorModeSetDynamicProperties(Property);
-	if (Array.isArray(Item.Property.Effect)) {
+	if (Item.Property && Array.isArray(Item.Property.Effect)) {
 		Item.Property.Effect.forEach(Effect => {
 			if (!["Egged", "Vibrating", "Edged"].includes(Effect)) {
 				Property.Effect.push(Effect);


### PR DESCRIPTION
## Summary

This fixes an issue where the vibrator mode script would cause an error when opening the vibrator menu on several of the vibrators using the `VibratorMode` script while not locked.

This is the stack trace of the error in question, as reported on Discord:

![Stack trace](https://cdn.discordapp.com/attachments/775739838195826728/775752770610397184/unknown.png)