### PR TITLE
Chat Search - Game Label fix

### DIFF
--- a/BondageClub/Screens/Online/ChatSearch/ChatSearch.js
+++ b/BondageClub/Screens/Online/ChatSearch/ChatSearch.js
@@ -137,7 +137,10 @@ function ChatSearchNormalDraw() {
 
 				// Determine the hover text starting position to ensure there's enough room
 				let Height = 58;
-				let ListHeight = Height * ((ChatSearchResult[C].Friends.length > 0 ? 1 : 0) + ChatSearchResult[C].Friends.length + (ChatSearchResult[C].BlockCategory.length > 0 ? 1 : 0));
+				let ListHeight = Height * (
+					(ChatSearchResult[C].Friends.length > 0 ? 1 : 0) + ChatSearchResult[C].Friends.length
+					+ (ChatSearchResult[C].BlockCategory.length > 0 ? 1 : 0)
+					+ (ChatSearchResult[C].Game != "" ? 1 : 0));
 				let ListY = Math.min(Y, 872 - ListHeight);
 
 				// Builds the friend list as hover text


### PR DESCRIPTION
Similar to part 1 of #1614, this considers the Game label in the chatroom button popup's start position to avoid going too far down when near the bottom.