### PR TITLE
Bugfix: Locks blocking type switching

### DIFF
--- a/BondageClub/Screens/Inventory/ItemDevices/BondageBench/BondageBench.js
+++ b/BondageClub/Screens/Inventory/ItemDevices/BondageBench/BondageBench.js
@@ -6,6 +6,7 @@ var InventoryItemDevicesBondageBenchOptions = [
 		Property: {
 			Type: null,
 			Difficulty: 0,
+			AllowLock: false,
 			SetPose: ["LegsClosed"],
 			Effect: ["Mounted"],
 		},
@@ -17,7 +18,6 @@ var InventoryItemDevicesBondageBenchOptions = [
 		Property: {
 			Type: "Light",
 			Difficulty: 2,
-			AllowLock: true,
 			SetPose: ["LegsClosed", "BaseUpper"],
 			Effect: ["Block", "Prone", "Freeze", "Mounted"],
 			Hide: ["HairBack", "Wings", "TailStraps", "ItemButt"],
@@ -30,7 +30,6 @@ var InventoryItemDevicesBondageBenchOptions = [
 		Property: {
 			Type: "Normal",
 			Difficulty: 3,
-			AllowLock: true,
 			SetPose: ["LegsClosed", "BaseUpper"],
 			Effect: ["Block", "Prone", "Freeze", "Mounted"],
 			Hide: ["HairBack", "Wings", "TailStraps", "ItemButt"],
@@ -43,7 +42,6 @@ var InventoryItemDevicesBondageBenchOptions = [
 		Property: {
 			Type: "Heavy",
 			Difficulty: 6,
-			AllowLock: true,
 			SetPose: ["LegsClosed", "BaseUpper"],
 			Effect: ["Block", "Prone", "Freeze", "Mounted"],
 			Hide: ["HairBack", "Wings", "TailStraps", "ItemButt"],
@@ -56,7 +54,6 @@ var InventoryItemDevicesBondageBenchOptions = [
 		Property: {
 			Type: "Full",
 			Difficulty: 9,
-			AllowLock: true,
 			SetPose: ["LegsClosed", "BaseUpper"],
 			Effect: ["Block", "Prone", "Freeze", "Mounted"],
 			Hide: ["HairBack", "Wings", "TailStraps", "ItemButt"],

--- a/BondageClub/Scripts/Dialog.js
+++ b/BondageClub/Scripts/Dialog.js
@@ -589,7 +589,7 @@ function DialogMenuButtonBuild(C) {
 		if (IsItemLocked && !Player.IsBlind() && (Item.Property != null) && (Item.Property.LockedBy != null) && (Item.Property.LockedBy != "")) DialogMenuButton.push("InspectLock");
 		if ((Item != null) && !IsItemLocked && Player.CanInteract() && InventoryAllow(C, Item.Asset.Prerequisite) && !IsGroupBlocked) {
 			if ((Item.Asset.AllowLock) ||
-				(Item.Asset.Extended && Item.Property && Item.Property.AllowLock && Item.Asset.AllowLockType.indexOf(Item.Property.Type) >= 0)) {
+				(Item.Asset.Extended && Item.Property && Item.Property.AllowLock !== false && Item.Asset.AllowLockType.indexOf(Item.Property.Type) >= 0)) {
 				DialogMenuButton.push("Lock");
 			}
 		} 
@@ -1124,7 +1124,7 @@ function DialogItemClick(ClickItem) {
 	// If we must apply a lock to an item (can trigger a daily job)
 	if (DialogItemToLock != null) {
 		if ((CurrentItem != null) &&
-			(CurrentItem.Asset.AllowLock || CurrentItem.Asset.Extended && CurrentItem.Property && CurrentItem.Property.AllowLock && CurrentItem.Asset.AllowLockType.indexOf(CurrentItem.Property.Type)>=0)) {
+			(CurrentItem.Asset.AllowLock || CurrentItem.Asset.Extended && CurrentItem.Property && CurrentItem.Property.AllowLock !== false && CurrentItem.Asset.AllowLockType.indexOf(CurrentItem.Property.Type)>=0)) {
 			InventoryLock(C, CurrentItem, ClickItem, Player.MemberNumber);
 			IntroductionJobProgress("DomLock", ClickItem.Asset.Name, true);
 			DialogItemToLock = null;

--- a/BondageClub/Scripts/ExtendedItem.js
+++ b/BondageClub/Scripts/ExtendedItem.js
@@ -247,7 +247,7 @@ function ExtendedItemSetType(C, Options, Option, IsCloth) {
 	} else {
 		let Asset = DialogFocusItem.Asset;
 		let OldOption = InventoryGet(C, Asset.Group.Name);
-		if (OldOption.Property.Effect && OldOption.Property.Effect.indexOf("Lock") >= 0 && !Option.Property.AllowLock) {
+		if (OldOption.Property.Effect && OldOption.Property.Effect.indexOf("Lock") >= 0 && Option.Property.AllowLock === false) {
 			DialogExtendedMessage = DialogFind(Player, "ExtendedItemUnlockBeforeChange");
 			return;
 		}

--- a/BondageClub/Scripts/ExtendedItem.js
+++ b/BondageClub/Scripts/ExtendedItem.js
@@ -245,9 +245,8 @@ function ExtendedItemSetType(C, Options, Option, IsCloth) {
 		DialogExtendedMessage = DialogText;
 		return;
 	} else {
-		let Asset = DialogFocusItem.Asset;
-		let OldOption = InventoryGet(C, Asset.Group.Name);
-		if (OldOption.Property.Effect && OldOption.Property.Effect.indexOf("Lock") >= 0 && Option.Property.AllowLock === false) {
+		const OldEffect= DialogFocusItem && DialogFocusItem.Property && DialogFocusItem.Property.Effect;
+		if (OldEffect && OldEffect.includes("Lock") && Option.Property.AllowLock === false) {
 			DialogExtendedMessage = DialogFind(Player, "ExtendedItemUnlockBeforeChange");
 			return;
 		}

--- a/BondageClub/Scripts/Inventory.js
+++ b/BondageClub/Scripts/Inventory.js
@@ -642,7 +642,7 @@ function InventoryLock(C, Item, Lock, MemberNumber) {
 	if (typeof Item === 'string') Item = InventoryGet(C, Item);
 	if (typeof Lock === 'string') Lock = { Asset: AssetGet(C.AssetFamily, "ItemMisc", Lock) };
 	if (Item && Lock && Lock.Asset.IsLock) {
-		if (Item.Asset.AllowLock || Item.Asset.Extended && Item.Property && Item.Property.AllowLock && Item.Asset.AllowLockType.indexOf(Item.Property.Type)>=0) {
+		if (Item.Asset.AllowLock || Item.Asset.Extended && Item.Property && Item.Property.AllowLock !== false && Item.Asset.AllowLockType.indexOf(Item.Property.Type)>=0) {
 			if (Item.Property == null) Item.Property = {};
 			if (Item.Property.Effect == null) Item.Property.Effect = [];
 			if (Item.Property.Effect.indexOf("Lock") < 0) Item.Property.Effect.push("Lock");

--- a/BondageClub/Scripts/Server.js
+++ b/BondageClub/Scripts/Server.js
@@ -240,7 +240,7 @@ function ServerValidateProperties(C, Item) {
 			var Effect = Item.Property.Effect[E];
 			if ((Effect == "Lock") && ((Item.Asset.AllowLock == null) || (Item.Asset.AllowLock == false) || (InventoryGetLock(Item) == null) || (InventoryIsPermissionBlocked(C, Item.Property.LockedBy, "ItemMisc"))) &&
 				// Check if a lock on the items sub type is allowed
-				!(Item.Asset.Extended && Item.Property && Item.Property.AllowLock && Item.Asset.AllowLockType.indexOf(Item.Property.Type) >= 0)) {
+				!(Item.Asset.Extended && Item.Property && Item.Property.AllowLock !== false && Item.Asset.AllowLockType.indexOf(Item.Property.Type) >= 0)) {
 				delete Item.Property.LockedBy;
 				delete Item.Property.LockMemberNumber;
 				delete Item.Property.CombinationNumber;


### PR DESCRIPTION
## Summary

As an unintentional result of #1449, it is not possible to change the type of items that are locked without unlocking them unless they explicitly set `Property.AllowLock = true`. After discussing with @Nina-1474, it seems like more often than not, this doesn't make sense as a default behaviour (for example, the plug gags, latex leotards, inflatable body bag, etc.). This change therefore reverses that default behaviour so that by default `Property.AllowLock` is presumed to be `true` unless it is explicitly set to false. This maintains the behaviour of the bondage bench as defined in #1449 but reverts any other extended item back to the way it was before that change. 

There may be some items for which this behaviour makes sense, but I'm not going to change any items now. I will work through the asset catalogue and make these changes where it seems appropriate in a separate PR, which I'd probably rather _not_ have merged before the release, as these would be item changes rather than fixes.

## Steps to reproduce

1. Equip a plug gag/latex leotard/inflatable body bag
2. Lock the item
3. Note that when entering the extended item screen for the item, you cannot plug/polish/inflate the item