### PR TITLE
Bugfix: Issue with non-lockable items

### DIFF
--- a/BondageClub/Assets/Female3DCG/Female3DCG.js
+++ b/BondageClub/Assets/Female3DCG/Female3DCG.js
@@ -3202,6 +3202,7 @@ var AssetFemale3DCG = [
 				Effect: ["Mounted"],
 				AllowEffect: ["Block", "Prone", "Freeze", "Mounted", "Lock"],
 				AllowType: ["Light", "Normal", "Heavy", "Full"],
+				AllowLock: true,
 				AllowLockType: ["Light", "Normal", "Heavy", "Full"],
 				Layer: [
 					{ Name: "Bench", AllowColorize: true, Priority: 1, HasType: false },

--- a/BondageClub/Scripts/Dialog.js
+++ b/BondageClub/Scripts/Dialog.js
@@ -588,11 +588,12 @@ function DialogMenuButtonBuild(C) {
 		if ((Item != null) && (C.ID == 0) && (!Player.CanInteract() || (IsItemLocked && !DialogCanUnlock(C, Item))) && (DialogMenuButton.indexOf("Unlock") < 0) && InventoryAllow(C, Item.Asset.Prerequisite) && !IsGroupBlocked) DialogMenuButton.push("Struggle");
 		if (IsItemLocked && !Player.IsBlind() && (Item.Property != null) && (Item.Property.LockedBy != null) && (Item.Property.LockedBy != "")) DialogMenuButton.push("InspectLock");
 		if ((Item != null) && !IsItemLocked && Player.CanInteract() && InventoryAllow(C, Item.Asset.Prerequisite) && !IsGroupBlocked) {
-			if ((Item.Asset.AllowLock) ||
-				(Item.Asset.Extended && Item.Property && Item.Property.AllowLock !== false && Item.Asset.AllowLockType.indexOf(Item.Property.Type) >= 0)) {
-				DialogMenuButton.push("Lock");
+			if (Item.Asset.AllowLock && (!Item.Property || (Item.Property && Item.Property.AllowLock !== false))) {
+				if (!Item.Asset.AllowLockType || Item.Asset.AllowLockType.includes(Item.Property.Type)) {
+					DialogMenuButton.push("Lock");
+				}
 			}
-		} 
+		}
 		if ((Item != null) && !IsItemLocked && !InventoryItemHasEffect(Item, "Mounted", true) && !InventoryItemHasEffect(Item, "Enclose", true) && Player.CanInteract() && InventoryAllow(C, Item.Asset.Prerequisite) && !IsGroupBlocked) DialogMenuButton.push("Remove");
 		if ((Item != null) && !IsItemLocked && InventoryItemHasEffect(Item, "Mounted", true) && Player.CanInteract() && InventoryAllow(C, Item.Asset.Prerequisite) && !IsGroupBlocked) DialogMenuButton.push("Dismount");
 		if ((Item != null) && !IsItemLocked && InventoryItemHasEffect(Item, "Enclose", true) && Player.CanInteract() && InventoryAllow(C, Item.Asset.Prerequisite) && !IsGroupBlocked) DialogMenuButton.push("Escape");

--- a/BondageClub/Scripts/Inventory.js
+++ b/BondageClub/Scripts/Inventory.js
@@ -642,14 +642,16 @@ function InventoryLock(C, Item, Lock, MemberNumber) {
 	if (typeof Item === 'string') Item = InventoryGet(C, Item);
 	if (typeof Lock === 'string') Lock = { Asset: AssetGet(C.AssetFamily, "ItemMisc", Lock) };
 	if (Item && Lock && Lock.Asset.IsLock) {
-		if (Item.Asset.AllowLock || Item.Asset.Extended && Item.Property && Item.Property.AllowLock !== false && Item.Asset.AllowLockType.indexOf(Item.Property.Type)>=0) {
-			if (Item.Property == null) Item.Property = {};
-			if (Item.Property.Effect == null) Item.Property.Effect = [];
-			if (Item.Property.Effect.indexOf("Lock") < 0) Item.Property.Effect.push("Lock");
-			Item.Property.LockedBy = Lock.Asset.Name;
-			if (MemberNumber != null) Item.Property.LockMemberNumber = MemberNumber;
-			if (Lock.Asset.RemoveTimer > 0) TimerInventoryRemoveSet(C, Item.Asset.Group.Name, Lock.Asset.RemoveTimer);
-			CharacterRefresh(C, true);
+		if (Item.Asset.AllowLock && (!Item.Property || Item.Property.AllowLock !== false)) {
+			if (!Item.Asset.AllowLockType || Item.Asset.AllowLockType.includes(Item.Property.Type)) {
+				if (Item.Property == null) Item.Property = {};
+				if (Item.Property.Effect == null) Item.Property.Effect = [];
+				if (Item.Property.Effect.indexOf("Lock") < 0) Item.Property.Effect.push("Lock");
+				Item.Property.LockedBy = Lock.Asset.Name;
+				if (MemberNumber != null) Item.Property.LockMemberNumber = MemberNumber;
+				if (Lock.Asset.RemoveTimer > 0) TimerInventoryRemoveSet(C, Item.Asset.Group.Name, Lock.Asset.RemoveTimer);
+				CharacterRefresh(C, true);
+			}
 		}
 	}
 }

--- a/BondageClub/Scripts/Server.js
+++ b/BondageClub/Scripts/Server.js
@@ -238,9 +238,15 @@ function ServerValidateProperties(C, Item) {
 
 			// Make sure the item or its subtype can be locked, remove any lock that's invalid
 			var Effect = Item.Property.Effect[E];
-			if ((Effect == "Lock") && ((Item.Asset.AllowLock == null) || (Item.Asset.AllowLock == false) || (InventoryGetLock(Item) == null) || (InventoryIsPermissionBlocked(C, Item.Property.LockedBy, "ItemMisc"))) &&
-				// Check if a lock on the items sub type is allowed
-				!(Item.Asset.Extended && Item.Property && Item.Property.AllowLock !== false && Item.Asset.AllowLockType.indexOf(Item.Property.Type) >= 0)) {
+			if ((Effect == "Lock") &&
+			    (
+			        !Item.Asset.AllowLock ||
+				    (InventoryGetLock(Item) == null) ||
+				    (InventoryIsPermissionBlocked(C, Item.Property.LockedBy, "ItemMisc")) ||
+				    (Item.Property && Item.Property.AllowLock === false) ||
+				    // Check if a lock on the items sub type is allowed
+				    (Item.Property && Item.Asset.AllowLockType && !Item.Asset.AllowLockType.includes(Item.Property.Type))
+			    )) {
 				delete Item.Property.LockedBy;
 				delete Item.Property.LockMemberNumber;
 				delete Item.Property.CombinationNumber;


### PR DESCRIPTION
## Summary

This is a follow-up fix to #1657, which broke the adding/removing of non-lockable items. I've tested this one pretty thoroughly now and I'm pretty sure it covers all bases.

## Steps to reproduce

1. Character A applies a non-lockable item (eg. duct tape) to player B
2. When the progress bar is full, the game crashes, and an error is displayed in the console (see below)

![Stack trace](https://cdn.discordapp.com/attachments/777214710297788417/777241971633815552/unknown.png)