### PR TITLE
College Entrance Colour Check fix

### DIFF
--- a/BondageClub/Screens/Room/CollegeEntrance/CollegeEntrance.js
+++ b/BondageClub/Screens/Room/CollegeEntrance/CollegeEntrance.js
@@ -106,7 +106,13 @@ function CollegeEntranceIsWearingTennisClothes() {
  * @returns {boolean} - Returns TRUE if the player is wearing college clothes
  */
 function CollegeEntranceIsWearingCollegeClothes() {
-	if ((InventoryGet(Player, "Cloth") == null) || (InventoryGet(Player, "Cloth").Asset.Name != "CollegeOutfit1") || ((InventoryGet(Player, "Cloth").Color != null) && (InventoryGet(Player, "Cloth").Color != "Default"))) return false;
+	let CurrentClothes = InventoryGet(Player, "Cloth");
+	if ((CurrentClothes == null)
+		|| (CurrentClothes.Asset.Name != "CollegeOutfit1")
+		|| (CurrentClothes.Color[0] != "Default")
+		|| !(CurrentClothes.Color[1] == "#202020" || CurrentClothes.Color[1] == "Default")
+		|| (CurrentClothes.Color[2] != "Default"))
+		return false;
 	if (InventoryGet(Player, "Socks") == null) return false;
 	if (InventoryGet(Player, "Shoes") == null) return false;
 	if (InventoryGet(Player, "Wings") != null) return false;


### PR DESCRIPTION
The adding of multicolouring to the college uniform meant the College Entrance conditions were no longer working for the default colour check, blocking entrance altogether. This has been corrected.