### PR TITLE
Fix: Duplicate character IDs causing disappearing activities

### DIFF
--- a/BondageClub/Screens/Character/Login/Login.js
+++ b/BondageClub/Screens/Character/Login/Login.js
@@ -91,6 +91,7 @@ function LoginLoad() {
 
 	// Resets the player and other characters
 	Character = [];
+	NextCharacterId = 1;
 	CharacterReset(0, "Female3DCG");
 	LoginDoNextThankYou();
 	CharacterLoadCSVDialog(Player);

--- a/BondageClub/Screens/Character/Wardrobe/Wardrobe.js
+++ b/BondageClub/Screens/Character/Wardrobe/Wardrobe.js
@@ -46,7 +46,7 @@ function WardrobeLoadCharacters(Fast) {
 		if (WardrobeCharacter.length <= P && ((W == null) || !Fast)) {
 
 			// Creates a character
-			CharacterReset(Character.length, "Female3DCG");
+			CharacterReset(NextCharacterId++, "Female3DCG");
 			var C = Character[Character.length - 1];
 			C.AccountName = "Wardrobe-" + P.toString();
 			C.Name = Player.WardrobeCharacterNames[P];

--- a/BondageClub/Scripts/Character.js
+++ b/BondageClub/Scripts/Character.js
@@ -331,7 +331,7 @@ function CharacterOnlineRefresh(Char, data, SourceMemberNumber) {
  */
 function CharacterLoadOnline(data, SourceMemberNumber) {
 
-	// Checks if the NPC already exists and returns it if it's the case
+	// Checks if the character already exists and returns it if it's the case
 	var Char = null;
 	if (data.ID.toString() == Player.OnlineID)
 		Char = Player;

--- a/BondageClub/Scripts/Character.js
+++ b/BondageClub/Scripts/Character.js
@@ -1,5 +1,6 @@
 "use strict";
 var Character = [];
+var NextCharacterId = 1;
 
 /**
  * Loads a character into the buffer, creates it if it does not exist
@@ -107,10 +108,11 @@ function CharacterReset(CharacterID, CharacterAssetFamily) {
 	};
 
 	// If the character doesn't exist, we create it
-	if (CharacterID >= Character.length)
+	var CharacterIndex = Character.findIndex(c => c.ID == CharacterID);
+	if(CharacterIndex == -1)
 		Character.push(NewCharacter);
 	else
-		Character[CharacterID] = NewCharacter;
+		Character[CharacterIndex] = NewCharacter;
 
 	// Creates the inventory and default appearance
 	if (CharacterID == 0) {
@@ -272,7 +274,7 @@ function CharacterLoadNPC(NPCType) {
 			return Character[C];
 
 	// Randomize the new character
-	CharacterReset(Character.length, "Female3DCG");
+	CharacterReset(NextCharacterId++, "Female3DCG");
 	let C = Character[Character.length - 1];
 	C.AccountName = NPCType;
 	CharacterLoadCSVDialog(C);
@@ -350,7 +352,7 @@ function CharacterLoadOnline(data, SourceMemberNumber) {
 			}
 		
 		// Creates the new character from the online template
-		CharacterReset(Character.length, "Female3DCG");
+		CharacterReset(NextCharacterId++, "Female3DCG");
 		Char = Character[Character.length - 1];
 		Char.Name = data.Name;
 		Char.Lover = (data.Lover != null) ? data.Lover : "";


### PR DESCRIPTION
Multiple players sometimes get assigned the same ID by the client and when they are in the same room they can interfere with each other causing items and activities to dissapear.
It can probably cause other issues too but that is the one I noticed that caused me to investigate this.
![V3ejoP21Yn](https://user-images.githubusercontent.com/62209995/99902704-1144da00-2cc0-11eb-8c8e-4198b328ef67.gif)
Reselecting the area will show the activities again but in actual online situations this can be triggered in quick succession making the activities unusable.
### Steps to reproduce
1. Log in with three characters (let's call them A, B and C)
2. Create a room with A
3. Have B and C join the room in order
4. Their character IDs in A's client should now be A: 0, B: 2, C: 3 (1 is taken by the main hall maid)
5. Log out with B, log back in and join the room.
6. IDs will be A: 0, B: 3, C: 3.
7. Have A select an area with activities on C
8. Change B's arousal to trigger an expression change (and thus a CharacterRefresh call).
9. Activities for C will be cleared in A's client
### Fix
This happens because ID is based on the length of the `Character` array and removing a character then adding them back when logging out and back in causes them to reuse the last ID.
This PR instead changes the ID to be based on an incrementing global counter that is reset when the array is cleared (on login). Not the only possible fix but seemed like the cleanest to me.