### PR TITLE
Feature: Darken room if both eyes are closed

### DIFF
--- a/BondageClub/Scripts/Character.js
+++ b/BondageClub/Scripts/Character.js
@@ -51,7 +51,10 @@ function CharacterReset(CharacterID, CharacterAssetFamily) {
 		/** Look for blindness effects and return the worst (limited by settings), Light: 1, Normal: 2, Heavy: 3 */
 		GetBlindLevel: function () {
 			let blindLevel = 0;
-			if (this.Effect.includes("BlindHeavy")) blindLevel = 3;
+			if ((this.Effect.includes("BlindHeavy")) ||
+				((this.Appearance.filter(A => A.Asset.Group.Name === "Eyes")[0].Property.Expression === "Closed") &&
+				(this.Appearance.filter(A => A.Asset.Group.Name === "Eyes2")[0].Property.Expression === "Closed"))
+				) blindLevel = 3;
 			else if (this.Effect.includes("BlindNormal")) blindLevel = 2;
 			else if (this.Effect.includes("BlindLight")) blindLevel = 1;
 			// Light sensory deprivation setting limits blindness

--- a/BondageClub/Scripts/Character.js
+++ b/BondageClub/Scripts/Character.js
@@ -52,9 +52,9 @@ function CharacterReset(CharacterID, CharacterAssetFamily) {
 		GetBlindLevel: function () {
 			let blindLevel = 0;
 			if ((this.Effect.includes("BlindHeavy")) ||
-				((this.Appearance.filter(A => A.Asset.Group.Name === "Eyes")[0].Property.Expression === "Closed") &&
-				(this.Appearance.filter(A => A.Asset.Group.Name === "Eyes2")[0].Property.Expression === "Closed"))
-				) blindLevel = 3;
+			((InventoryGet(this, "Eyes").Property.Expression === "Closed") &&
+			(InventoryGet(this, "Eyes2").Property.Expression === "Closed"))
+			) blindLevel = 3;
 			else if (this.Effect.includes("BlindNormal")) blindLevel = 2;
 			else if (this.Effect.includes("BlindLight")) blindLevel = 1;
 			// Light sensory deprivation setting limits blindness


### PR DESCRIPTION
# Summary
If the character closes both eyes, the maximum blind level is applied, so that the room gets dark.
This does not happen, when the character blinks, but only if the eyes are closed on purpose.

# Details
## What was changed
A simple if statement added to `GetBlindLevel`in `Character.js

## Testing
This was tested on my local copy of the game and works in the single player, as well as the multi player rooms.
If the player keeps one eye open, by winking, the effect does not trigger.