### PR TITLE
Fix: All diapers count as being diapered in the nursery

### DIFF
--- a/BondageClub/Screens/Room/Nursery/Nursery.js
+++ b/BondageClub/Screens/Room/Nursery/Nursery.js
@@ -33,7 +33,9 @@ function NurseryPlayerLostBinky() { return Player.CanTalk() && !NurseryPlayerKee
 function NurseryPlayerLostBinkyAgain() { return Player.CanTalk() && NurseryPlayerKeepsLoosingBinky }
 function NurseryPlayerWearingBabyDress() { return (CharacterAppearanceGetCurrentValue(Player, "Cloth", "Name") == "AdultBabyDress1" || CharacterAppearanceGetCurrentValue(Player, "Cloth", "Name") == "AdultBabyDress2" || CharacterAppearanceGetCurrentValue(Player, "Cloth", "Name") == "AdultBabyDress3") }
 function NurseryPlayerReadyToAppologise() { return (NurseryPlayerBadBabyStatus <= 1) }
-function NurseryPlayerDiapered() { return (CharacterAppearanceGetCurrentValue(Player, "Panties", "Name") == "Diapers1") }
+function NurseryPlayerDiapered() {
+	return (CharacterAppearanceGetCurrentValue(Player, "Panties", "Name").toUpperCase().indexOf("DIAPER", 0) >= 0);
+}
 function NurseryPlayerReadyDiapered() { return (NurseryPlayerDiapered() && !NurseryPlayerInappropriateCloth) }
 function NurseryPlayerCanRegress() { return !InventoryGet(Player, "ItemMouth3") && !InventoryGroupIsBlocked(Player, "ItemMouth3") }
 


### PR DESCRIPTION
# Summary
Fixes that only the plain diaper count as being diapered when it comes to enter the nursery.

# Details
## What it does
Changed the `PlayerDiapered`Check in `Nursery.js`

## Testing
Tested that on my local instance of the game. The nurses accept other diapers now as well, when the player wants to enter the nursery for a second time.