### PR TITLE
Fix: New characters and blindness check

### DIFF
--- a/BondageClub/Scripts/Character.js
+++ b/BondageClub/Scripts/Character.js
@@ -51,12 +51,18 @@ function CharacterReset(CharacterID, CharacterAssetFamily) {
 		/** Look for blindness effects and return the worst (limited by settings), Light: 1, Normal: 2, Heavy: 3 */
 		GetBlindLevel: function () {
 			let blindLevel = 0;
-			if ((this.Effect.includes("BlindHeavy")) ||
-			((InventoryGet(this, "Eyes").Property.Expression === "Closed") &&
-			(InventoryGet(this, "Eyes2").Property.Expression === "Closed"))
-			) blindLevel = 3;
-			else if (this.Effect.includes("BlindNormal")) blindLevel = 2;
-			else if (this.Effect.includes("BlindLight")) blindLevel = 1;
+			if (InventoryGet(this, "Eyes").Property && InventoryGet(this, "Eyes").Property.Expression &&
+				InventoryGet(this, "Eyes2").Property && InventoryGet(this, "Eyes2").Property.Expression) {
+				if ((InventoryGet(this, "Eyes").Property.Expression === "Closed") &&
+					(InventoryGet(this, "Eyes2").Property.Expression === "Closed")) {
+						blindLevel = 3;
+				}
+			}
+			if (blindLevel == 0) {
+				if (this.Effect.includes("BlindHeavy")) blindLevel = 3;
+				else if (this.Effect.includes("BlindNormal")) blindLevel = 2;
+				else if (this.Effect.includes("BlindLight")) blindLevel = 1;
+			}
 			// Light sensory deprivation setting limits blindness
 			if (this.GameplaySettings && this.GameplaySettings.SensDepChatLog == "SensDepLight") blindLevel = Math.min(2, blindLevel);
 			return blindLevel;

--- a/BondageClub/Scripts/Character.js
+++ b/BondageClub/Scripts/Character.js
@@ -51,11 +51,11 @@ function CharacterReset(CharacterID, CharacterAssetFamily) {
 		/** Look for blindness effects and return the worst (limited by settings), Light: 1, Normal: 2, Heavy: 3 */
 		GetBlindLevel: function () {
 			let blindLevel = 0;
-			if (InventoryGet(this, "Eyes").Property && InventoryGet(this, "Eyes").Property.Expression &&
-				InventoryGet(this, "Eyes2").Property && InventoryGet(this, "Eyes2").Property.Expression) {
-				if ((InventoryGet(this, "Eyes").Property.Expression === "Closed") &&
-					(InventoryGet(this, "Eyes2").Property.Expression === "Closed")) {
-						blindLevel = 3;
+			let eyes1 = InventoryGet(this, "Eyes");
+			let eyes2 = InventoryGet(this, "Eyes2");
+			if (eyes1.Property && eyes1.Property.Expression && eyes2.Property && eyes2.Property.Expression) {
+				if ((eyes1.Property.Expression === "Closed") && (eyes2.Property.Expression === "Closed")) {
+					blindLevel = 3;
 				}
 			}
 			if (blindLevel == 0) {


### PR DESCRIPTION
# Summary
This fixes a bug that was introduced with #1702 
When a new character is created, the check in `GetBlindLevel` raised a null pointer exception. This is now prevented.