### PR TITLE
Arousal bar animation disappears when progress = 0

### DIFF
--- a/BondageClub/Scripts/Drawing.js
+++ b/BondageClub/Scripts/Drawing.js
@@ -192,7 +192,7 @@ function DrawArousalMeter(C, X, Y, Zoom) {
 						Progress = C.ArousalSettings.VibratorLevel
 					}
 										
-					if (Progress >= 0) // -1 is disabled
+					if (Progress > 0) // -1 is disabled
 						var max_time = 5000 // 5 seconds
 						DrawArousalGlow(X + ((C.ArousalZoom ? 50 : 90) * Zoom), Y + ((C.ArousalZoom ? 200 : 400) * Zoom), C.ArousalZoom ? Zoom : Zoom * 0.2, Progress, Player.ArousalSettings.VFX == "VFXAnimated" || (Player.ArousalSettings.VFX == "VFXAnimatedTemp" && C.ArousalSettings.ChangeTime != null && CommonTime() - C.ArousalSettings.ChangeTime < max_time), Math.max(0, (max_time + C.ArousalSettings.ChangeTime - CommonTime())/ max_time), ((C.ArousalSettings.OrgasmTimer != null) && (typeof C.ArousalSettings.OrgasmTimer === "number") && !isNaN(C.ArousalSettings.OrgasmTimer) && (C.ArousalSettings.OrgasmTimer > 0)));
 				}


### PR DESCRIPTION
This is to stop the blue blinking from blinking all the time