### PR TITLE
Fix: Missing ignored rooms in chat room filter

### DIFF
--- a/BondageClub/Screens/Online/ChatSearch/ChatSearch.js
+++ b/BondageClub/Screens/Online/ChatSearch/ChatSearch.js
@@ -405,7 +405,7 @@ function ChatSearchQuerySort() {
 }
 
 /**
- * Calculates starting offset for the ignored rooms list when displaying result filtering.
+ * Calculates starting offset for the ignored rooms list when displaying results in filter/permission mode.
  * @param {number} shownRooms - Number of rooms shown before the ignored rooms.
  * @returns {number} - Starting offset for ingored rooms
  */

--- a/BondageClub/Screens/Online/ChatSearch/ChatSearch.js
+++ b/BondageClub/Screens/Online/ChatSearch/ChatSearch.js
@@ -212,9 +212,13 @@ function ChatSearchPermissionDraw() {
 			}
 			ShownRooms++;
 		}
-		
+
+		const IgnoredRoomsOffset = ChatSearchCalculateIgnoredRoomsOffset(ShownRooms);
+		if (IgnoredRoomsOffset < 0)
+			return;
+
 		// Display ignored rooms that are no longer present
-		for (let C = ChatSearchResultOffset; C < ChatSearchIgnoredRooms.length && ShownRooms < ChatSearchRoomsPerPage; C++) {
+		for (let C = IgnoredRoomsOffset; C < ChatSearchIgnoredRooms.length && ShownRooms < ChatSearchRoomsPerPage; C++) {
 			var isIgnored = !ChatSearchResult.map(Room => Room.Name.toUpperCase()).includes(ChatSearchIgnoredRooms[C]);
 			if (isIgnored) {
 				var Hover = (MouseX >= X) && (MouseX <= X + 630) && (MouseY >= Y) && (MouseY <= Y + 85) && !CommonIsMobile;
@@ -298,8 +302,12 @@ function ChatSearchClickPermission() {
 		ShownRooms++;
 	}
 	
+	const IgnoredRoomsOffset = ChatSearchCalculateIgnoredRoomsOffset(ShownRooms);
+	if (IgnoredRoomsOffset < 0)
+		return;
+
 	// Clicks for the extra hidden rooms
-	for (let C = ChatSearchResultOffset; C < ChatSearchIgnoredRooms.length && ShownRooms < ChatSearchRoomsPerPage; C++) {
+	for (let C = IgnoredRoomsOffset; C < ChatSearchIgnoredRooms.length && ShownRooms < ChatSearchRoomsPerPage; C++) {
 		var isIgnored = !ChatSearchResult.map(Room => Room.Name.toUpperCase()).includes(ChatSearchIgnoredRooms[C]);
 		if (isIgnored) {
 			// If the click is valid
@@ -394,4 +402,13 @@ function ChatSearchQuerySort() {
 	// Friendlist option overrides basic order, but keeps full rooms at the back for each number of each different total of friends.
 	if (Player.OnlineSettings && Player.OnlineSettings.SearchFriendsFirst)
 		ChatSearchResult.sort((R1, R2) => R2.Friends.length - R1.Friends.length);
+}
+
+/**
+ * Calculates starting offset for the ignored rooms list when displaying result filtering.
+ * @param {number} shownRooms - Number of rooms shown before the ignored rooms.
+ * @returns {number} - Starting offset for ingored rooms
+ */
+function ChatSearchCalculateIgnoredRoomsOffset(shownRooms) {
+	return ChatSearchResultOffset + shownRooms - ChatSearchResult.length;
 }


### PR DESCRIPTION
Because looping through the ignored rooms that are not in the latest search results starts at `ChatSearchResultOffset`, which is 24 on page 2, they do not get drawn in the filter list when they get pushed to page 2 or higher.

Changes the initial offset to be calculated based on page offset, already shown rooms and total rooms in the search results (`ChatSearchResultOffset + shownRooms - ChatSearchResult.length`).
