### PR TITLE
Bugfix: Fixes a rare issue on chatroom relog

### DIFF
--- a/BondageClub/Scripts/Server.js
+++ b/BondageClub/Scripts/Server.js
@@ -425,7 +425,7 @@ function ServerAppearanceLoadFromBundle(C, AssetFamily, Bundle, SourceMemberNumb
 							}
 						}
 						ServerValidateProperties(C, NA);
-						if (C.Appearance[A].Property.LockedBy == "OwnerPadlock") InventoryLock(C, NA, { Asset: AssetGet(AssetFamily, "ItemMisc", "OwnerPadlock") }, NA.Property.LockMemberNumber);
+						if (C.Appearance[A].Property && C.Appearance[A].Property.LockedBy == "OwnerPadlock") InventoryLock(C, NA, { Asset: AssetGet(AssetFamily, "ItemMisc", "OwnerPadlock") }, NA.Property.LockMemberNumber);
 
 					}
 					Appearance.push(NA);


### PR DESCRIPTION
## Summary

Unfortunately I've not been able to identify the root cause of this, as I've only seen it once, and can't reproduce it, but I've had the same issue reported to me by others before. This fixes a rare issue where the `ServerAppearanceLoadFromBundle` function throws an error on relogging inside a chatroom and re-syncing the chatroom characters. This results in a strange visual glitch where the player enters the chatroom, and is visible to everyone else, and can interact normally and be interacted with, but is actually invisible to themselves, as the error results in them not being added to the `ChatRoomCharacter` array, even though they are present in the chatroom data.

I've added a null-check which should alleviate the issue (and probably should be there anyway), but I'm still unsure what the exact circumstances are that cause this. Below is the stack trace I got when encountering the error:

![err](https://user-images.githubusercontent.com/62729616/100943786-cdd74080-34f5-11eb-87a3-8ea367edb779.png)


