### PR TITLE
Bugfix: Item colour resilience

### DIFF
--- a/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
+++ b/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
@@ -1370,9 +1370,11 @@ function ChatRoomSyncItem(data) {
 			if ((data.Item.Name == null) || (data.Item.Name == "")) {
 				InventoryRemove(ChatRoomCharacter[C], data.Item.Group);
 			} else {
+				var Color = data.Item.Color;
+				if (!CommonColorIsValid(Color)) Color = "Default";
 
 				// Wear the item and applies locks and properties if we need to
-				InventoryWear(ChatRoomCharacter[C], data.Item.Name, data.Item.Group, data.Item.Color, data.Item.Difficulty);
+				InventoryWear(ChatRoomCharacter[C], data.Item.Name, data.Item.Group, Color, data.Item.Difficulty);
 				if (data.Item.Property != null) {
 					var Item = InventoryGet(ChatRoomCharacter[C], data.Item.Group);
 					if (Item != null) {

--- a/BondageClub/Scripts/Common.js
+++ b/BondageClub/Scripts/Common.js
@@ -286,13 +286,26 @@ function CommonTime() {
 
 /**
  * Checks if a given value is a valid HEX color code
- * @param {string} Value - Potential HEX color code 
- * @returns {boolean} - Returns TRUE if the string is a valid HEX color 
+ * @param {string} Value - Potential HEX color code
+ * @returns {boolean} - Returns TRUE if the string is a valid HEX color
  */
 function CommonIsColor(Value) {
 	if ((Value == null) || (Value.length < 3)) return false;
 	if (/^#[0-9A-F]{3}$/i.test(Value)) Value = "#" + Value[1] + Value[1] + Value[2] + Value[2] + Value[3] + Value[3];	//convert short hand hex color to standard format
 	return /^#[0-9A-F]{6}$/i.test(Value);
+}
+
+/**
+ * Checks whether an item's color has a valid value that can be interpreted by the drawing
+ * functions. Valid values are null, undefined, strings, and an array containing any of the
+ * aforementioned types.
+ * @param {*} Color - The Color value to check
+ * @returns {boolean} - Returns TRUE if the color is a valid item color
+ */
+function CommonColorIsValid(Color) {
+	if (Color == null || typeof Color === "string") return true;
+	if (Array.isArray(Color)) return Color.every(C => C == null || typeof C === "string");
+	return false;
 }
 
 /**

--- a/BondageClub/Scripts/CommonDraw.js
+++ b/BondageClub/Scripts/CommonDraw.js
@@ -224,7 +224,10 @@ function CommonDrawAppearanceBuild(C, {
 		if (Color === "Default" && A.DefaultColor) {
 			Color = Array.isArray(A.DefaultColor) ? A.DefaultColor[Layer.ColorIndex] : A.DefaultColor;
 		}
-		
+		if (Color && typeof Color !== "string") {
+			Color = "Default";
+		}
+
 		// Draw the item on the canvas (default or empty means no special color, # means apply a color, regular text means we apply that text)
 		if ((Color != null) && (Color.indexOf("#") == 0) && Layer.AllowColorize) {
 			drawImageColorize(

--- a/BondageClub/Scripts/CommonDraw.js
+++ b/BondageClub/Scripts/CommonDraw.js
@@ -224,7 +224,7 @@ function CommonDrawAppearanceBuild(C, {
 		if (Color === "Default" && A.DefaultColor) {
 			Color = Array.isArray(A.DefaultColor) ? A.DefaultColor[Layer.ColorIndex] : A.DefaultColor;
 		}
-		if (Color && typeof Color !== "string") {
+		if (Color != null && typeof Color !== "string") {
 			Color = "Default";
 		}
 


### PR DESCRIPTION
## Summary

This adds some extra checks to `CommonDrawAppearanceBuild` and `ChatRoomSyncItem` to validate that an item's `Color` is defined properly (either `null`, `undefined`, a string or an array of those types). This isn't something that should be possible through normal gameplay, but players can currently use the console to set an item's `Color` to anything they like, for example an object like `{}`, which results in the error below (screenshot taken from discord, where players have been reporting someone's console usage causing these issues):

![Stack Trace](https://cdn.discordapp.com/attachments/554378725916147722/785226587397685268/Screenshot_415.png)

This check should prevent people from breaking other people's games via this particular loophole.

## Steps to reproduce

Character 1 and Character 2 in the same chatroom.

1. Character 2 applies an item (e.g. something in `ItemArms`) to Character 1
2. Character 2 then runs the following in the console:
```js
InventoryGet(ChatRoomCharacter[0], "ItemArms").Color = {};
ChatRoomCharacterItemUpdate(ChatRoomCharacter[0], "ItemArms");
```
or:
```js
InventoryGet(ChatRoomCharacter[0], "ItemArms").Color = false;
ChatRoomCharacterItemUpdate(ChatRoomCharacter[0], "ItemArms");
```
These currently cause the game to crash for Character 2.