### PR TITLE
Fix: Exception when triggering shocks on self

### DIFF
--- a/BondageClub/Screens/Inventory/ItemNeckAccessories/CollarShockUnit/CollarShockUnit.js
+++ b/BondageClub/Screens/Inventory/ItemNeckAccessories/CollarShockUnit/CollarShockUnit.js
@@ -75,12 +75,13 @@ function InventoryItemNeckAccessoriesCollarShockUnitTrigger() {
 	Dictionary.push({ AssetName: DialogFocusItem.Asset.Name });
 	Dictionary.push({ AssetGroupName: DialogFocusItem.Asset.Group.Name });
 		
-	ChatRoomPublishCustomAction("TriggerShock" + DialogFocusItem.Property.Intensity, true, Dictionary);
+	ChatRoomPublishCustomAction("TriggerShock" + DialogFocusItem.Property.Intensity, false, Dictionary);
 		
 	if (C.ID == Player.ID) {
 		// The Player shocks herself
 		ActivityArousalItem(C, C, DialogFocusItem.Asset);
 	}
+	if (CurrentScreen == "ChatRoom") DialogLeave();
 	
     CharacterSetFacialExpression(C, "Eyebrows", "Soft", 10);
     CharacterSetFacialExpression(C, "Blush", "Soft", 15);


### PR DESCRIPTION
The shock trigger function on the shock collar (`InventoryItemNeckAccessoriesCollarShockUnitTrigger()`; which is also used for the dildo, clamps and plug) calls `ChatRoomPublishCustomAction()` with `LeaveDialog` set to `true` which causes it to clear `DialogFocusItem` and in turn throw an exception when trying to update arousal if the player shocks themself resulting in no arousal or facial expression updates.

Changes `LeaveDialog` to `false` in the call and to call `LeaveDialog()` manually later if in a chat room.