### PR TITLE
Increases max password length to 8 (for the password padlock)

### DIFF
--- a/BondageClub/Screens/Inventory/ItemMisc/PasswordPadlock/PasswordPadlock.js
+++ b/BondageClub/Screens/Inventory/ItemMisc/PasswordPadlock/PasswordPadlock.js
@@ -4,7 +4,7 @@
 function InventoryItemMiscPasswordPadlockLoad() {
 	var C = CharacterGetCurrent();
 	if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property == null)) DialogFocusSourceItem.Property = {};
-	if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property != null) && (DialogFocusSourceItem.Property.Password == null)) DialogFocusSourceItem.Property.Password = "UNLOCK";
+	if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property != null) && (DialogFocusSourceItem.Property.Password == null)) DialogFocusSourceItem.Property.Password = "PASSWORD";
 	if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property != null) && (DialogFocusSourceItem.Property.Hint == null)) DialogFocusSourceItem.Property.Hint = "Take a guess...";
 	if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property != null) && (DialogFocusSourceItem.Property.LockSet == null)) DialogFocusSourceItem.Property.LockSet = false;
 
@@ -13,13 +13,13 @@ function InventoryItemMiscPasswordPadlockLoad() {
 		if (DialogFocusSourceItem.Property && (DialogFocusSourceItem.Property.LockSet || 
 		(DialogFocusSourceItem.Property.LockMemberNumber && DialogFocusSourceItem.Property.LockMemberNumber != Player.MemberNumber))) {
 			// Normal lock interface
-			ElementCreateInput("Password", "text", "", "6");
+			ElementCreateInput("Password", "text", "", "8");
 			// the current code is shown for owners, lovers and the member whose number is on the padlock
 			if (DialogFocusSourceItem != null && ((Player.MemberNumber == DialogFocusSourceItem.Property.LockMemberNumber)
 				|| C.IsOwnedByPlayer() || C.IsLoverOfPlayer())) document.getElementById("Password").placeholder = DialogFocusSourceItem.Property.Password;
 		} else {
 			// Set a password and hint
-			ElementCreateInput("SetPassword", "text", "", "6");
+			ElementCreateInput("SetPassword", "text", "", "8");
 			ElementCreateInput("SetHint", "text", "", "140");
 			// the current code is shown for owners, lovers and the member whose number is on the padlock
 			document.getElementById("SetPassword").placeholder = DialogFocusSourceItem.Property.Password;

--- a/BondageClub/Scripts/Server.js
+++ b/BondageClub/Scripts/Server.js
@@ -297,7 +297,7 @@ function ServerValidateProperties(C, Item) {
 				var Lock = InventoryGetLock(Item);
 				if ((Item.Property.Password != null) && (typeof Item.Property.Password == "string")) {
 					var Regex = /^[A-Z]+$/;
-					if (!Item.Property.Password.toUpperCase().match(Regex) || (Item.Property.Password.length > 6)) {
+					if (!Item.Property.Password.toUpperCase().match(Regex) || (Item.Property.Password.length > 8)) {
 						Item.Property.Password = "UNLOCK";
 					}
 				} else delete Item.Property.Password;


### PR DESCRIPTION
This change was requested by players who said they can't fit anything meaningful into 6 letters. I cant remember the reason it was set to 6, but I think it had to do with the possibility of trolls setting one to random letters and being unable to figure it out. However, bruteforcing 6 letters is still hard, and in Extreme mode password padlocks are blocked for non-whitelist anyway. Hardcore players can block the locks if they are worried about it.