### PR TITLE
ItemHood in Arousal menu

### DIFF
--- a/BondageClub/Screens/Character/Preference/Text_Preference.csv
+++ b/BondageClub/Screens/Character/Preference/Text_Preference.csv
@@ -202,6 +202,7 @@ ArousalZoneItemMouth,Mouth & Lips
 ArousalZoneItemHead,Head & Hair
 ArousalZoneItemNose,Nose
 ArousalZoneItemEars,Ears
+ArousalZoneItemHood,Head
 ArousalStutter,Speech stuttering:
 ArousalStutterNone,Never stutter
 ArousalStutterArousal,When you're aroused


### PR DESCRIPTION
Small followup fix to #1763: Since ItemHood now has arousal activities it needs a line in the Preferences screen text file for the Arousal menu.