### PR TITLE
Bugfix: Fixes floating characters when leaving the dialog screen via the escape key

### DIFF
--- a/BondageClub/Scripts/Dialog.js
+++ b/BondageClub/Scripts/Dialog.js
@@ -437,8 +437,13 @@ function DialogLeaveItemMenu() {
 	DialogEndExpression();
 	DialogItemToLock = null;
 	Player.FocusGroup = null;
-	if (CurrentCharacter)
+	if (CurrentCharacter) {
+		if (CharacterAppearanceForceUpCharacter == CurrentCharacter.MemberNumber) {
+			CharacterAppearanceForceUpCharacter = 0;
+			CharacterApperanceSetHeightModifier(CurrentCharacter);
+		}
 		CurrentCharacter.FocusGroup = null;
+	}
 	DialogInventory = null;
 	DialogProgress = -1;
 	DialogColor = null;


### PR DESCRIPTION
## Summary

This fixes a bug which leaves characters floating in the air after using the "up" button to show all of the zones on a character that is kneeling/hogtied/etc and then leaving the dialog screen via the escape key.

## Steps to reproduce

1. Enter a chatroom and kneel
2. Click on the kneeling character and hit the ^ button to show all of the character's zones
3. Hit the escape key on your keyboard
4. Note that the character is left floating in the air