### PR TITLE
Bugfix: Fixes chatroom messages on the futuristic gags

### DIFF
--- a/BondageClub/Screens/Inventory/ItemMouth/FuturisticPanelGag/FuturisticPanelGag.js
+++ b/BondageClub/Screens/Inventory/ItemMouth/FuturisticPanelGag/FuturisticPanelGag.js
@@ -227,7 +227,7 @@ function InventoryItemMouthFuturisticPanelGagDraw() {
 
 // Catches the item extension clicks
 function InventoryItemMouthFuturisticPanelGagClick() {
-	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
+	var C = CharacterGetCurrent();
 	if (!InventoryItemMouthFuturisticPanelGagValidate(C)) {
 		InventoryItemMouthFuturisticPanelGagClickAccessDenied()
 	} else {		
@@ -266,10 +266,10 @@ function InventoryItemMouthFuturisticPanelGagClick() {
 		else if (DialogFocusItem.Property.AutoPunishUndoTimeSetting != 72000000 && MouseIn(1675, 780, 200, 64)) InventoryItemMouthFuturisticPanelGagSetAutoPunishTime(C, DialogFocusItem, 72000000)
 			
 		else if (DialogFocusItem.Property.AutoPunishUndoTimeSetting && MouseIn(1675, 880, 200, 64)) {
-			InventoryItemMouthFuturisticPanelGagTrigger(Player, DialogFocusItem, false)
+			InventoryItemMouthFuturisticPanelGagTrigger(C, DialogFocusItem, false)
 			DialogFocusItem.Property.AutoPunishUndoTime = CurrentTime + DialogFocusItem.Property.AutoPunishUndoTimeSetting // Reset the deflation time
-			CharacterRefresh(Player, true); // Does not sync appearance while in the wardrobe
-			ChatRoomCharacterUpdate(Player);	
+			CharacterRefresh(C, true); // Does not sync appearance while in the wardrobe
+			ChatRoomCharacterUpdate(C);
 		}
 		
 	}


### PR DESCRIPTION
## Summary

The futuristic gags were producing incorrect chatroom messages when the "Trigger Inflation" button was pressed.

## Steps to reproduce

Two characters: "Character 1" and "Character 2".

1. Add a Futuristic Panel Gag/Futuristic Harness Panel Gag to Character 1
2. As Character 2, enter the extended item menu for the gag and hit the "Trigger Inflation" button
3. Note that the chatroom message says "Character 2's gag inflates into a mouth-filling ball.", and expression changes are applied to the wrong character as well.