### PR TITLE
Bugfix: Fixes chatroom messages for the futuristic collar

### DIFF
--- a/BondageClub/Screens/Inventory/ItemNeck/FuturisticCollar/FuturisticCollar.js
+++ b/BondageClub/Screens/Inventory/ItemNeck/FuturisticCollar/FuturisticCollar.js
@@ -195,7 +195,7 @@ function InventoryItemNeckFuturisticCollarLockdown(C, LockType) {
 		var Message;
 		var Dictionary = [
 			{ Tag: "SourceCharacter", Text: Player.Name, MemberNumber: Player.MemberNumber },
-			{ Tag: "DestinationCharacter", Text: C.Name, MemberNumber: C.MemberNumber },
+			{ Tag: "DestinationCharacterName", Text: C.Name, MemberNumber: C.MemberNumber },
 		];
 
 		Message = "FuturisticCollarTriggerLockdown";
@@ -219,7 +219,7 @@ function InventoryItemNeckFuturisticCollarUnlock(C) {
 		var Message;
 		var Dictionary = [
 			{ Tag: "SourceCharacter", Text: Player.Name, MemberNumber: Player.MemberNumber },
-			{ Tag: "DestinationCharacter", Text: C.Name, MemberNumber: C.MemberNumber },
+			{ Tag: "DestinationCharacterName", Text: C.Name, MemberNumber: C.MemberNumber },
 		];
 
 		Message = "FuturisticCollarTriggerUnlock";
@@ -259,7 +259,7 @@ function InventoryItemNeckFuturisticCollarColor(C, Item) {
 		var Message;
 		var Dictionary = [
 			{ Tag: "SourceCharacter", Text: Player.Name, MemberNumber: Player.MemberNumber },
-			{ Tag: "DestinationCharacter", Text: C.Name, MemberNumber: C.MemberNumber },
+			{ Tag: "DestinationCharacterName", Text: C.Name, MemberNumber: C.MemberNumber },
 		];
 
 		Message = "FuturisticCollarTriggerColor";
@@ -282,7 +282,7 @@ function InventoryItemNeckFuturisticCollarTogglePermission(C, Item) {
 			var Message;
 			var Dictionary = [
 				{ Tag: "SourceCharacter", Text: Player.Name, MemberNumber: Player.MemberNumber },
-				{ Tag: "DestinationCharacter", Text: C.Name, MemberNumber: C.MemberNumber },
+				{ Tag: "DestinationCharacterName", Text: C.Name, MemberNumber: C.MemberNumber },
 			];
 
 			Message = "FuturisticCollarSetOpenPermission";


### PR DESCRIPTION
## Summary

Chatroom messages for the futuristic collar were being sent using `DestinationCharacter` when the text in the CSV uses `DestinationCharacterName`. This was resulting in messages like "Character'sName bindings tighten around her body with a hiss as they lock themselves automatically." 