### PR TITLE
Fix: Error for leashed player when leash holder fails to enter a room

### DIFF
--- a/BondageClub/Screens/Online/ChatSearch/ChatSearch.js
+++ b/BondageClub/Screens/Online/ChatSearch/ChatSearch.js
@@ -377,7 +377,7 @@ function ChatSearchResultResponse(data) {
 function ChatSearchQuery() {
 	var Query = ElementValue("InputSearch").toUpperCase().trim();
 	// Prevent spam searching the same thing.
-	if (ChatRoomJoinLeash != "") {
+	if (ChatRoomJoinLeash != null && ChatRoomJoinLeash != "") {
 		Query = ChatRoomJoinLeash.toUpperCase().trim();
 	}
 	

--- a/BondageClub/Scripts/Server.js
+++ b/BondageClub/Scripts/Server.js
@@ -691,7 +691,7 @@ function ServerAccountBeep(data) {
 				ServerBeep.Message = ServerBeep.Message + " " + DialogFind(Player, "InRoom") + " \"" + ServerBeep.ChatRoomName + "\" " + (data.ChatRoomSpace === "Asylum" ? DialogFind(Player, "InAsylum") : '');
 			FriendListBeepLog.push({ MemberNumber: data.MemberNumber, MemberName: data.MemberName, ChatRoomName: data.ChatRoomName, ChatRoomSpace: data.ChatRoomSpace, Sent: false, Time: new Date() });
 			if (CurrentScreen == "FriendList") ServerSend("AccountQuery", { Query: "OnlineFriends" });
-		} else if (data.BeepType == "Leash" && ChatRoomLeashPlayer == data.MemberNumber) {
+		} else if (data.BeepType == "Leash" && ChatRoomLeashPlayer == data.MemberNumber && data.ChatRoomName) {
 			if (Player.OnlineSharedSettings && Player.OnlineSharedSettings.AllowPlayerLeashing != false && ( CurrentScreen != "ChatRoom" || !ChatRoomData || (CurrentScreen == "ChatRoom" && ChatRoomData.Name != data.ChatRoomName))) {
 				if (ChatRoomCanBeLeashed(Player)) {
 					


### PR DESCRIPTION
When the player holding a leash fails to enter a room, either because it's full or because they try to create a room with a name that already exists, the leashed player gets sent a `Leash` beep with no room set, causing `ChatRoomJoinLeash` to be set to null and in turn cause an error in `ChatSearchQuery()` until `ChatRoomJoinLeash` is changed again.

Adds checks both in `ChatSearchQuery()` which fixes the resulting error and in `ServerAccountBeep()` which avoids causing it in the first place.