### PR TITLE
Login NPC Overwrite fix

### DIFF
--- a/BondageClub/Screens/Character/Login/Login.js
+++ b/BondageClub/Screens/Character/Login/Login.js
@@ -12,6 +12,8 @@ var LoginThankYouNext = 0;
 var LoginSubmitted = false;
 var LoginIsRelog = false;
 var LoginErrorMessage = "";
+var LoginCharacter = null;
+
 /* DEBUG: To measure FPS - uncomment this and change the + 4000 to + 40
 var LoginLastCT = 0;
 var LoginFrameCount = 0;
@@ -23,10 +25,10 @@ var LoginFrameTotalTime = 0;*/
  */
 function LoginDoNextThankYou() {
 	LoginThankYou = CommonRandomItemFromList(LoginThankYou, LoginThankYouList);
-	CharacterRelease(Player, false);
-	CharacterAppearanceFullRandom(Player);
-	if (InventoryGet(Player, "ItemNeck") != null) InventoryRemove(Player, "ItemNeck", false);
-	CharacterFullRandomRestrain(Player);
+	CharacterRelease(LoginCharacter, false);
+	CharacterAppearanceFullRandom(LoginCharacter);
+	if (InventoryGet(LoginCharacter, "ItemNeck") != null) InventoryRemove(LoginCharacter, "ItemNeck", false);
+	CharacterFullRandomRestrain(LoginCharacter);
 	LoginThankYouNext = CommonTime() + 4000;
 }
 
@@ -93,8 +95,9 @@ function LoginLoad() {
 	Character = [];
 	CharacterNextId = 1;
 	CharacterReset(0, "Female3DCG");
-	LoginDoNextThankYou();
 	CharacterLoadCSVDialog(Player);
+	LoginCharacter = CharacterLoadNPC("NPC_Login");
+	LoginDoNextThankYou();
 	LoginStatusReset();
 	LoginErrorMessage = "";
 	LoginUpdateMessage();
@@ -131,7 +134,7 @@ function LoginRun() {
 	DrawButton(825, 870, 350, 60, TextGet(CheatAllow ? "Cheats" : "PasswordReset"), "White", "");
 
 	// Draw the character and thank you bubble
-	DrawCharacter(Player, 1400, 100, 0.9);
+	DrawCharacter(LoginCharacter, 1400, 100, 0.9);
 	if (LoginThankYouNext < CommonTime()) LoginDoNextThankYou();
 	DrawImage("Screens/" + CurrentModule + "/" + CurrentScreen + "/Bubble.png", 1400, 16);
 	DrawText(TextGet("ThankYou") + " " + LoginThankYou, 1625, 53, "Black", "Gray");
@@ -398,6 +401,7 @@ function LoginResponse(C) {
 			CharacterRefresh(Player, false);
 			ElementRemove("InputName");
 			ElementRemove("InputPassword");
+			CharacterDelete(LoginCharacter);
 			if (ManagementIsClubSlave()) CharacterNaked(Player);
 
 			// Starts the game in the main hall while loading characters in the private room


### PR DESCRIPTION
When a login crashes, it's possible on successfully logging in later to find that the character's appearance and bindings are completely changed.
This is because the Player variable is used as a placeholder for the randomly generated login screen NPC, and ends up keeping that appearance. This uses a dedicated character for the NPC instead to avoid the issue.

I'm holding this change back from this release given that we're late in the beta period, the bug is not critical if it occurs, and if there's any hidden issues with this change it could potentially be quite disruptive.