### PR TITLE
Scroll Chat Down with Esc Key

### DIFF
--- a/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
+++ b/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
@@ -677,6 +677,8 @@ function ChatRoomKeyDown() {
 		ElementValue("InputChat", ChatRoomLastMessage[ChatRoomLastMessageIndex]);
 	}
 
+	// On escape, scroll to the bottom of the chat
+	if (KeyPress == 27) ElementScrollToEnd("TextAreaChatLog");
 }
 
 /**

--- a/BondageClub/index.html
+++ b/BondageClub/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html style="width:100%; height:100%; padding:0px; margin:0px;">
 <head>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" />
@@ -355,7 +355,9 @@ function DocumentKeyDown(event) {
 			if (!DialogLeaveFocusItem())
 				DialogLeaveItemMenu();
 		} else if ((CurrentCharacter != null) && (CurrentScreen == "ChatRoom")) {
-			DialogLeave();
+            DialogLeave();
+        } else if ((CurrentCharacter == null) && (CurrentScreen == "ChatRoom") && (document.getElementById("TextAreaChatLog") != null)) {
+            ElementScrollToEnd("TextAreaChatLog");
 		}
 	}
 }

--- a/BondageClub/index.html
+++ b/BondageClub/index.html
@@ -355,9 +355,9 @@ function DocumentKeyDown(event) {
 			if (!DialogLeaveFocusItem())
 				DialogLeaveItemMenu();
 		} else if ((CurrentCharacter != null) && (CurrentScreen == "ChatRoom")) {
-            DialogLeave();
-        } else if ((CurrentCharacter == null) && (CurrentScreen == "ChatRoom") && (document.getElementById("TextAreaChatLog") != null)) {
-            ElementScrollToEnd("TextAreaChatLog");
+			DialogLeave();
+		} else if ((CurrentCharacter == null) && (CurrentScreen == "ChatRoom") && (document.getElementById("TextAreaChatLog") != null)) {
+			ElementScrollToEnd("TextAreaChatLog");
 		}
 	}
 }


### PR DESCRIPTION
Allowing the Escape key to move the chat scroll position to the end similar to Discord, as an alternative to lengthy page-downs or scrolling.