### PR TITLE
Bugfix: Makes the login credits independent of framerate

### DIFF
--- a/BondageClub/Screens/Character/Login/Login.js
+++ b/BondageClub/Screens/Character/Login/Login.js
@@ -48,7 +48,7 @@ function LoginDrawCredits() {
 	else DrawText("Calculating Average FPS...", 1000, 975, "white");*/
 
 	// For each credits in the list
-	LoginCreditsPosition = LoginCreditsPosition +  (TimerRunInterval * 60) / 1000;
+	LoginCreditsPosition += (TimerRunInterval * 60) / 1000;
 	MainCanvas.font = "30px Arial";
 	for (let C = 0; C < LoginCredits.length; C++) {
 

--- a/BondageClub/Screens/Character/Login/Login.js
+++ b/BondageClub/Screens/Character/Login/Login.js
@@ -48,7 +48,7 @@ function LoginDrawCredits() {
 	else DrawText("Calculating Average FPS...", 1000, 975, "white");*/
 
 	// For each credits in the list
-	LoginCreditsPosition++;
+	LoginCreditsPosition = LoginCreditsPosition +  (TimerRunInterval * 60) / 1000;
 	MainCanvas.font = "30px Arial";
 	for (let C = 0; C < LoginCredits.length; C++) {
 


### PR DESCRIPTION
## Summary

I've now obtained a 144Hz monitor, so I can test out framerate-based differences in behaviour across the game. I've noticed that the credits on the login screen whizz past substantially faster at 144Hz than at the standard 60Hz. This change makes the credit roll speed independent of framerate.