### PR TITLE
Fix: Leash actions on character in boxes/cages/lockers

### DIFF
--- a/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
+++ b/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
@@ -177,7 +177,7 @@ function ChatRoomCanBeLeashed(C) {
 					neckLock = InventoryGetLock(Player.Appearance[A])
 			}
 		}
-	if ((C.Effect.indexOf("Tethered") >= 0) || (C.Effect.indexOf("Mounted") >= 0) || (C.Effect.indexOf("Enclosed") >= 0)) isTrapped = true
+	if ((C.Effect.indexOf("Tethered") >= 0) || (C.Effect.indexOf("Mounted") >= 0) || (C.Effect.indexOf("Enclose") >= 0)) isTrapped = true
 	
 	if (canLeash && !isTrapped) {
 		if (!neckLock || (!neckLock.Asset.OwnerOnly && !neckLock.Asset.LoverOnly) ||


### PR DESCRIPTION
The leashing code checks for the `Enclosed` effect instead of `Enclose` which items like boxes, cages and lockers use so leash actions are not blocked while in those items.

Might conflict with #1790 since it changes a line that's moved in that PR.