### PR TITLE
Bugfix: Ensures FriendNames & SubmissivesList are initialised on character creation

### DIFF
--- a/BondageClub/Screens/Character/Creation/Creation.js
+++ b/BondageClub/Screens/Character/Creation/Creation.js
@@ -89,6 +89,8 @@ function CreationResponse(data) {
 			Player.FriendList = [];
 			Player.GhostList = [];
 			Player.Lovership = [];
+			Player.FriendNames = new Map();
+			Player.SubmissivesList = new Set();
 
 			// Imports logs, inventory and Sarah status from the Bondage College
 			CreationMessage = "";


### PR DESCRIPTION
## Summary

`Player.FriendNames` and `Player.SubmissivesList` are initialised for players on login, but are not initialised for players on character creation. This means that interacting with other players or the friends list straight after character creation can cause the friends list not to work properly, with the following errors:

```
FriendList.js:146 Uncaught TypeError: undefined is not iterable (cannot read property Symbol(Symbol.iterator))
    at Function.from (<anonymous>)
    at FriendListLoadFriendList (FriendList.js:146)
    at ServerAccountQueryResult (Server.js:664)
    at r.<anonymous> (Server.js:51)
    at r.emit (index.js:83)
    at r.onevent (index.js:83)
    at r.onpacket (index.js:83)
    at r.<anonymous> (index.js:83)
    at r.emit (index.js:83)
    at r.ondecoded (index.js:83)
```

```
Server.js:216 Uncaught TypeError: Cannot read property 'keys' of undefined
    at ServerPlayerRelationsSync (Server.js:216)
    at ChatRoomListManage (ChatRoom.js:1640)
    at CommonDynamicFunctionParams (Common.js:233)
    at DialogClick (Dialog.js:1334)
    at CommonClick (Common.js:173)
    at Click ((index):367)
    at HTMLCanvasElement.onclick ((index):409)
```

This PR ensures the `FriendNames` and `SubmissivesList` collections are initialised on character creation to prevent this issue.

## Steps to reproduce

1. Create a new character
2. Open your friend list (error 1 above)
3. Add another player as a friend (error 2 above)