### PR TITLE
Bugfix: Fixes condition for the character actions dialogue option

### DIFF
--- a/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
+++ b/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
@@ -125,7 +125,7 @@ function ChatRoomCanAssistStruggle() { return CurrentCharacter.AllowItem && !Cur
  * Checks if the character options menu is available.
  * @returns {boolean} - Whether or not the player can interact with the target character
  */
-function ChatRoomCanPerformCharacterAction() { return ChatRoomCanAssistStand() ||  ChatRoomCanAssistKneel() || ChatRoomCanAssistStruggle()}
+function ChatRoomCanPerformCharacterAction() { return ChatRoomCanAssistStand() ||  ChatRoomCanAssistKneel() || ChatRoomCanAssistStruggle() || ChatRoomCanBeLeashed(CurrentCharacter) }
 /**
  * Checks if the target character can be helped back on her feet. This is different than CurrentCharacter.CanKneel() because it listens for the current active pose and removes certain checks that are not required for someone else to help a person kneel down.
  * @returns {boolean} - Whether or not the target character can stand


### PR DESCRIPTION
## Summary

The "Character Actions" dialogue option would not always show up when the character was leashed, as the leash condition was missing from the `ChatRoomCanPerformCharacterAction` function.

## Steps to reproduce

1. Apply wooden cuffs (or any item that prevents kneeling), and a leashing item to a character
2. Note that the (Character Actions) dialogue option does not appear