### PR TITLE
Bugfix: Fixes validation functions on futuristic mittens and breast harness

### DIFF
--- a/BondageClub/Screens/Inventory/ItemBreast/FuturisticBra2/FuturisticBra2.js
+++ b/BondageClub/Screens/Inventory/ItemBreast/FuturisticBra2/FuturisticBra2.js
@@ -13,7 +13,7 @@ var InventoryItemBreastFuturisticBra2Options = [
 
 function InventoryItemBreastFuturisticBra2Load() {
 	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
-	if (!InventoryItemMouthFuturisticPanelGagValidate(C)) {
+	if (InventoryItemMouthFuturisticPanelGagValidate(C) !== "") {
 		InventoryItemMouthFuturisticPanelGagLoadAccessDenied()
 	} else
 		ExtendedItemLoad(InventoryItemBreastFuturisticBra2Options, "FuturisticBra2Type");
@@ -21,7 +21,7 @@ function InventoryItemBreastFuturisticBra2Load() {
 
 function InventoryItemBreastFuturisticBra2Draw() {
 	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
-	if (!InventoryItemMouthFuturisticPanelGagValidate(C)) {
+	if (InventoryItemMouthFuturisticPanelGagValidate(C) !== "") {
 		InventoryItemMouthFuturisticPanelGagDrawAccessDenied()
 	} else
 		ExtendedItemDraw(InventoryItemBreastFuturisticBra2Options, "FuturisticBra2Type");
@@ -30,7 +30,7 @@ function InventoryItemBreastFuturisticBra2Draw() {
 
 function InventoryItemBreastFuturisticBra2Click() {
 	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
-	if (!InventoryItemMouthFuturisticPanelGagValidate(C)) {
+	if (InventoryItemMouthFuturisticPanelGagValidate(C) !== "") {
 		InventoryItemMouthFuturisticPanelGagClickAccessDenied()
 	} else {
 		var DialogFocusItem_Temp = DialogFocusItem
@@ -67,7 +67,7 @@ function InventoryItemBreastFuturisticBra2PublishAction(C, Option) {
 	ChatRoomPublishCustomAction(msg, true, Dictionary);
 }
 
-function InventoryItemBreastFuturisticBra2Validate(C) { 
+function InventoryItemBreastFuturisticBra2Validate(C, Option) {
 	return InventoryItemMouthFuturisticPanelGagValidate(C, Option); // All futuristic items refer to the gag
 }
 

--- a/BondageClub/Screens/Inventory/ItemHands/FuturisticMittens/FuturisticMittens.js
+++ b/BondageClub/Screens/Inventory/ItemHands/FuturisticMittens/FuturisticMittens.js
@@ -14,7 +14,7 @@ var InventoryItemHandsFuturisticMittensOptions = [
 // Loads the item extension properties
 function InventoryItemHandsFuturisticMittensLoad() {
  	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
-	if (!InventoryItemMouthFuturisticPanelGagValidate(C)) {
+	if (InventoryItemMouthFuturisticPanelGagValidate(C) !== "") {
 		InventoryItemMouthFuturisticPanelGagLoadAccessDenied()
 	} else
 	ExtendedItemLoad(InventoryItemHandsFuturisticMittensOptions, "SelectFuturisticMittensType");
@@ -23,7 +23,7 @@ function InventoryItemHandsFuturisticMittensLoad() {
 // Draw the item extension screen
 function InventoryItemHandsFuturisticMittensDraw() {
 	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
-	if (!InventoryItemMouthFuturisticPanelGagValidate(C)) {
+	if (InventoryItemMouthFuturisticPanelGagValidate(C) !== "") {
 		InventoryItemMouthFuturisticPanelGagDrawAccessDenied()
 	} else
 		ExtendedItemDraw(InventoryItemHandsFuturisticMittensOptions, "FuturisticMittensType");
@@ -32,7 +32,7 @@ function InventoryItemHandsFuturisticMittensDraw() {
 // Catches the item extension clicks
 function InventoryItemHandsFuturisticMittensClick() {
 	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
-	if (!InventoryItemMouthFuturisticPanelGagValidate(C)) {
+	if (InventoryItemMouthFuturisticPanelGagValidate(C) !== "") {
 		InventoryItemMouthFuturisticPanelGagClickAccessDenied()
 	} else
 		ExtendedItemClick(InventoryItemHandsFuturisticMittensOptions);


### PR DESCRIPTION
## Summary

This fixes some validation function calls on the Futuristic Mittens and Breast Harness, whose validation functions weren't changed by #1511 (likely due to merge order). This causes these items to appear locked when they aren't, and blocks access to their extended item screens.

## Steps to reproduce

1. Equip Futuristic Mittens or Breast Harness.
2. Note that the extended item screen for the items declares that they are locked.
3. Note that clicking the unlock button denies access