### PR TITLE
Bugfix: Fix for ServerAppearanceLoadFromBundle for private room NPCs

### DIFF
--- a/BondageClub/Scripts/Character.js
+++ b/BondageClub/Scripts/Character.js
@@ -84,15 +84,7 @@ function CharacterReset(CharacterID, CharacterAssetFamily) {
 		IsOwner: function () { return ((NPCEventGet(this, "EndSubTrial") > 0) || (this.Name == Player.Owner.replace("NPC-", ""))) },
 		IsLoverOfPlayer: function () { return this.IsLover(Player); },
 		IsLover: function (C) { return ((this.GetLoversNumbers().indexOf(C.MemberNumber) >= 0) || (((this.Lover != null) && (this.Lover.trim() == C.Name)) || (NPCEventGet(this, "Girlfriend") > 0))); },
-		GetLoversNumbers: function (MembersOnly) {
-			var LoversNumbers = [];
-			if (typeof this.Lovership == "undefined") return [];
-			for (let L = 0; L < this.Lovership.length; L++) {
-				if (this.Lovership[L].MemberNumber) { LoversNumbers.push(this.Lovership[L].MemberNumber); }
-				else if (this.Lovership[L].Name && (MembersOnly == null || MembersOnly == false)) { LoversNumbers.push(this.Lovership[L].Name); }
-			}
-			return LoversNumbers;
-		},
+		GetLoversNumbers: function (MembersOnly) { return CharacterGetLoversNumbers(this, MembersOnly); },
 		GetDeafLevel: function () {
 			var deafLevel = 0;
 			for (let A = 0; A < this.Appearance.length; A++) {
@@ -1093,4 +1085,21 @@ function CharacterHasBlockedItem(C, BlockList) {
 			if ((C.Appearance[A].Asset != null) && (C.Appearance[A].Asset.Category != null) && (C.Appearance[A].Asset.Category.indexOf(BlockList[B]) >= 0))
 				return true;
 	return false;
+}
+
+/**
+ * Retrieves the member numbers of the given character
+ * @param {Character} C - The character to retrieve the lovers numbers from
+ * @param {Boolean} [MembersOnly] - Whether to omit NPC lovers - defaults to false (NPCs will be included by default)
+ * @returns {Array<String | Number>} - A list of member numbers or NPC account names representing the lovers of the
+ * given character
+ */
+function CharacterGetLoversNumbers(C, MembersOnly) {
+	var LoversNumbers = [];
+	if (typeof C.Lovership == "undefined") return [];
+	for (let L = 0; L < C.Lovership.length; L++) {
+		if (C.Lovership[L].MemberNumber) { LoversNumbers.push(C.Lovership[L].MemberNumber); }
+		else if (C.Lovership[L].Name && (MembersOnly == null || MembersOnly == false)) { LoversNumbers.push(C.Lovership[L].Name); }
+	}
+	return LoversNumbers;
 }

--- a/BondageClub/Scripts/Server.js
+++ b/BondageClub/Scripts/Server.js
@@ -429,7 +429,7 @@ function ServerAppearanceLoadFromBundle(C, AssetFamily, Bundle, SourceMemberNumb
 	// We do not check if the load is from the Player
 	var FromSelf = (SourceMemberNumber != null) && (SourceMemberNumber == C.MemberNumber);
 	var FromOwner = (SourceMemberNumber != null) && (C.Ownership != null) && ((SourceMemberNumber == C.Ownership.MemberNumber) || FromSelf);
-	var LoverNumbers = C.GetLoversNumbers();
+	var LoverNumbers = CharacterGetLoversNumbers(C);
 	var FromLoversOrOwner = (SourceMemberNumber != null) && (LoverNumbers.length != 0) && (LoverNumbers.includes(SourceMemberNumber) || FromOwner);
 
 	// Clears the appearance to begin


### PR DESCRIPTION
`C.GetLoversNumbers()` was being called on NPCs in the player's private room when entering it. However, NPCs at this point are just data objects, rather than full `Character` instances, and therefore don't have the `GetLoversNumbers` method. I've moved that method out into a separate character function so that it can be reused on pure data objects, and corrected the offending line in `ServerAppearanceLoadFromBundle`.