### PR TITLE
Colour Name Validation

### DIFF
--- a/BondageClub/Assets/Female3DCG/Female3DCG.js
+++ b/BondageClub/Assets/Female3DCG/Female3DCG.js
@@ -998,7 +998,6 @@ var AssetFemale3DCG = [
 
 	{
 		Group: "Wings",
-		ParentColor: "Bra",
 		Priority: 3,
 		Default: false,
 		Clothing: true,

--- a/BondageClub/Screens/Character/Appearance/Appearance.js
+++ b/BondageClub/Screens/Character/Appearance/Appearance.js
@@ -185,7 +185,8 @@ function CharacterAppearanceFullRandom(C, ClothOnly) {
 				var SelectedAsset = InventoryGetRandom(C, AssetGroup[A].Name, R);
 				var SelectedColor = SelectedAsset.Group.ColorSchema[Math.floor(Math.random() * SelectedAsset.Group.ColorSchema.length)];
 				if ((SelectedAsset.Group.ColorSchema[0] == "Default") && (Math.random() < 0.5)) SelectedColor = "Default";
-				if (SelectedAsset.Group.ParentColor != "")
+				if (SelectedAsset.Group.InheritColor != null) SelectedColor = "Default";
+				else if (SelectedAsset.Group.ParentColor != "")
 					if (CharacterAppearanceGetCurrentValue(C, SelectedAsset.Group.ParentColor, "Color") != "None")
 						SelectedColor = CharacterAppearanceGetCurrentValue(C, SelectedAsset.Group.ParentColor, "Color");
 				// Rare chance of keeping eyes of a different color

--- a/BondageClub/Screens/Room/CollegeCafeteria/CollegeCafeteria.js
+++ b/BondageClub/Screens/Room/CollegeCafeteria/CollegeCafeteria.js
@@ -53,8 +53,8 @@ function CollegeCafeteriaLoad() {
 			InventoryWear(CollegeCafeteriaSidney, "H0960", "Height", "Default");
 			InventoryWear(CollegeCafeteriaSidney, "XLarge", "BodyUpper", "White");
 			InventoryWear(CollegeCafeteriaSidney, "XLarge", "BodyLower", "White");
-			InventoryWear(CollegeCafeteriaSidney, "Default", "Hands", "White");
-			InventoryWear(CollegeCafeteriaSidney, "Default", "Head", "White");
+			InventoryWear(CollegeCafeteriaSidney, "Default", "Hands", "Default");
+			InventoryWear(CollegeCafeteriaSidney, "Default", "Head", "Default");
 			InventoryWear(CollegeCafeteriaSidney, "HairBack21", "HairBack", "#222222");
 			InventoryWear(CollegeCafeteriaSidney, "HairFront6", "HairFront", "#222222");
 			InventoryWear(CollegeCafeteriaSidney, "Bandeau1", "Bra", "#222222");

--- a/BondageClub/Screens/Room/CollegeDetention/CollegeDetention.js
+++ b/BondageClub/Screens/Room/CollegeDetention/CollegeDetention.js
@@ -51,8 +51,8 @@ function CollegeDetentionYukiClothes() {
 	InventoryWear(CollegeDetentionYuki, "H0920", "Height", "Default");
 	InventoryWear(CollegeDetentionYuki, "Small", "BodyUpper", "Asian");
 	InventoryWear(CollegeDetentionYuki, "Small", "BodyLower", "Asian");
-	InventoryWear(CollegeDetentionYuki, "Default", "Hands", "Asian");
-	InventoryWear(CollegeDetentionYuki, "Default", "Head", "Asian");
+	InventoryWear(CollegeDetentionYuki, "Default", "Hands", "Default");
+	InventoryWear(CollegeDetentionYuki, "Default", "Head", "Default");
 	InventoryWear(CollegeDetentionYuki, "HairBack6", "HairBack", "#603022");
 	InventoryWear(CollegeDetentionYuki, "HairFront4", "HairFront", "#603022");
 	InventoryWear(CollegeDetentionYuki, "Ribbons2", "HairAccessory1", "#111111");

--- a/BondageClub/Screens/Room/CollegeTeacher/CollegeTeacher.js
+++ b/BondageClub/Screens/Room/CollegeTeacher/CollegeTeacher.js
@@ -32,8 +32,8 @@ function CollegeTeacherMildredClothes() {
 	InventoryWear(CollegeTeacherMildred, "H0940", "Height", "Default");
 	InventoryWear(CollegeTeacherMildred, "Normal", "BodyUpper", "White");
 	InventoryWear(CollegeTeacherMildred, "Normal", "BodyLower", "White");
-	InventoryWear(CollegeTeacherMildred, "Default", "Hands", "White");
-	InventoryWear(CollegeTeacherMildred, "Default", "Head", "White");
+	InventoryWear(CollegeTeacherMildred, "Default", "Hands", "Default");
+	InventoryWear(CollegeTeacherMildred, "Default", "Head", "Default");
 	InventoryWear(CollegeTeacherMildred, "HairBack21", "HairBack", "#626060");
 	InventoryWear(CollegeTeacherMildred, "HairFront3", "HairFront", "#626060");
 	InventoryWear(CollegeTeacherMildred, "Bra1", "Bra", "#2222AA");

--- a/BondageClub/Screens/Room/CollegeTennis/CollegeTennis.js
+++ b/BondageClub/Screens/Room/CollegeTennis/CollegeTennis.js
@@ -50,8 +50,8 @@ function CollegeTennisLoad() {
 			InventoryWear(CollegeTennisJennifer, "H0980", "Height", "Default");
 			InventoryWear(CollegeTennisJennifer, "Small", "BodyUpper", "White");
 			InventoryWear(CollegeTennisJennifer, "Small", "BodyLower", "White");
-			InventoryWear(CollegeTennisJennifer, "Default", "Hands", "White");
-			InventoryWear(CollegeTennisJennifer, "Default", "Head", "White");
+			InventoryWear(CollegeTennisJennifer, "Default", "Hands", "Default");
+			InventoryWear(CollegeTennisJennifer, "Default", "Head", "Default");
 			InventoryWear(CollegeTennisJennifer, "HairBack6", "HairBack", "#8dccce");
 			InventoryWear(CollegeTennisJennifer, "HairFront5", "HairFront", "#8dccce");
 			InventoryWear(CollegeTennisJennifer, "Bra1", "Bra", "#CCCCCC");

--- a/BondageClub/Screens/Room/CollegeTheater/CollegeTheater.js
+++ b/BondageClub/Screens/Room/CollegeTheater/CollegeTheater.js
@@ -41,8 +41,8 @@ function CollegeTheaterJuliaClothes() {
 	InventoryWear(CollegeTheaterJulia, "H0990", "Height", "Default");
 	InventoryWear(CollegeTheaterJulia, "XLarge", "BodyUpper", "White");
 	InventoryWear(CollegeTheaterJulia, "XLarge", "BodyLower", "White");
-	InventoryWear(CollegeTheaterJulia, "Default", "Hands", "White");
-	InventoryWear(CollegeTheaterJulia, "Default", "Head", "White");
+	InventoryWear(CollegeTheaterJulia, "Default", "Hands", "Default");
+	InventoryWear(CollegeTheaterJulia, "Default", "Head", "Default");
 	InventoryWear(CollegeTheaterJulia, "HairBack5", "HairBack", "#e86e37");
 	InventoryWear(CollegeTheaterJulia, "HairFront6", "HairFront", "#e86e37");
 	InventoryWear(CollegeTheaterJulia, "OuvertPerl1", "Bra", "#BB0000");

--- a/BondageClub/Screens/Room/Sarah/Sarah.js
+++ b/BondageClub/Screens/Room/Sarah/Sarah.js
@@ -123,8 +123,8 @@ function SarahLoad() {
 			InventoryWear(Sarah, "H0930", "Height", "Default");
 			InventoryWear(Sarah, "Small", "BodyUpper", "White");
 			InventoryWear(Sarah, "Small", "BodyLower", "White");
-			InventoryWear(Sarah, "Default", "Hands", "White");
-			InventoryWear(Sarah, "Default", "Head", "White");
+			InventoryWear(Sarah, "Default", "Hands", "Default");
+			InventoryWear(Sarah, "Default", "Head", "Default");
 			InventoryWear(Sarah, "HairBack19", "HairBack", "#edd6b0");
 			InventoryWear(Sarah, "HairFront11", "HairFront", "#edd6b0");
 			InventoryWear(Sarah, "Bra2", "Bra", "#a02424");
@@ -159,8 +159,8 @@ function SarahLoad() {
 		InventoryWear(Amanda, "H0950", "Height", "Default");
 		InventoryWear(Amanda, "Normal", "BodyUpper", "White");
 		InventoryWear(Amanda, "Normal", "BodyLower", "White");
-		InventoryWear(Amanda, "Default", "Hands", "White");
-		InventoryWear(Amanda, "Default", "Head", "White");
+		InventoryWear(Amanda, "Default", "Hands", "Default");
+		InventoryWear(Amanda, "Default", "Head", "Default");
 		InventoryWear(Amanda, "HairBack15", "HairBack", "#623123");
 		InventoryWear(Amanda, "HairFront4", "HairFront", "#623123");
 		InventoryAdd(Amanda, "StraponPanties", "ItemPelvis");
@@ -196,8 +196,8 @@ function SarahLoad() {
 		InventoryWear(Sophie, "H0970", "Height", "Default");
 		InventoryWear(Sophie, "Large", "BodyUpper", "White");
 		InventoryWear(Sophie, "Large", "BodyLower", "White");
-		InventoryWear(Sophie, "Default", "Hands", "White");
-		InventoryWear(Sophie, "Default", "Head", "White");
+		InventoryWear(Sophie, "Default", "Hands", "Default");
+		InventoryWear(Sophie, "Default", "Head", "Default");
 		InventoryWear(Sophie, "HairBack16", "HairBack", "#CCCCCC");
 		InventoryWear(Sophie, "HairFront1", "HairFront", "#CCCCCC");
 		CharacterArchetypeClothes(Sophie, "Mistress", "#222222");

--- a/BondageClub/Scripts/CommonDraw.js
+++ b/BondageClub/Scripts/CommonDraw.js
@@ -167,10 +167,15 @@ function CommonDrawAppearanceBuild(C, {
 		}
 
 		// Check if we need to copy the color of another asset
-		var InheritColor = (Color == "Default" ? (Layer.InheritColor || A.InheritColor || AG.InheritColor) : null);
+		let InheritColor = (Color == "Default" ? (Layer.InheritColor || A.InheritColor || AG.InheritColor) : null);
+		let ColorInterited = false;
 		if (InheritColor != null) {
 			var ParentAsset = InventoryGet(C, InheritColor);
-			if (ParentAsset != null) Color = Array.isArray(ParentAsset.Color) ? ParentAsset.Color[0] : ParentAsset.Color;
+			if (ParentAsset != null) {
+				let ParentColor = Array.isArray(ParentAsset.Color) ? ParentAsset.Color[0] : ParentAsset.Color;
+				Color = CommonDrawColorValid(ParentColor, ParentAsset.Asset.Group) ? ParentColor : "Default";
+				ColorInterited = true;
+			}
 		}
 		
 		// Before drawing hook, receives all processed data. Any of them can be overriden if returned inside an object.
@@ -224,7 +229,8 @@ function CommonDrawAppearanceBuild(C, {
 		if (Color === "Default" && A.DefaultColor) {
 			Color = Array.isArray(A.DefaultColor) ? A.DefaultColor[Layer.ColorIndex] : A.DefaultColor;
 		}
-		if (Color != null && typeof Color !== "string") {
+
+		if (!ColorInterited && !CommonDrawColorValid(Color, AG)) {
 			Color = "Default";
 		}
 
@@ -269,6 +275,22 @@ function CommonDrawAppearanceBuild(C, {
 			window["Assets" + A.Group.Name + A.Name + "AfterDraw"](DrawingData);
 		}
 	});
+}
+
+/**
+ * Determines whether the provided color is valid
+ * @param {any} Color - The color
+ * @param {any} AssetGroup - The asset group the color is being used fo
+ * @returns {boolean} - Whether the color is valid
+ */
+function CommonDrawColorValid(Color, AssetGroup) {
+	if (Color != null && typeof Color !== "string") {
+		return false;
+	}
+	if (Color != null && Color.indexOf("#") != 0 && AssetGroup.ColorSchema.indexOf(Color) < 0) {
+		return false;
+	}
+	return true;
 }
 
 /**

--- a/BondageClub/Scripts/Inventory.js
+++ b/BondageClub/Scripts/Inventory.js
@@ -356,7 +356,7 @@ function InventoryGet(C, AssetGroup) {
 function InventoryWear(C, AssetName, AssetGroup, ItemColor, Difficulty, MemberNumber) {
 	for (let A = 0; A < Asset.length; A++)
 		if ((Asset[A].Name == AssetName) && (Asset[A].Group.Name == AssetGroup)) {
-			CharacterAppearanceSetItem(C, AssetGroup, Asset[A], ((ItemColor == null) || (ItemColor == "Default")) ? Asset[A].DefaultColor : ItemColor, Difficulty, MemberNumber);
+			CharacterAppearanceSetItem(C, AssetGroup, Asset[A], ((ItemColor == null || ItemColor == "Default") && Asset[A].DefaultColor != null) ? Asset[A].DefaultColor : ItemColor, Difficulty, MemberNumber);
 			InventoryExpressionTrigger(C, InventoryGet(C, AssetGroup));
 			return;
 		}


### PR DESCRIPTION
At the moment it's possible to set an invalid colour on another user's item via console and cause an error on the item for them when it's being rendered.
The drawing code now checks that any named colour (currently only White/Asian/Black) is in the group's colour schema and otherwise replaces the invalid colour with Default. Some additional changes were needed for inherited colours as they can pass down a named colour not in the target group's schema. The head & hands settings for preset NPCs were also updated to use the Default colour inheriting to pass this validation.