### PR TITLE
Improvement: Font system refinements

### DIFF
--- a/BondageClub/Screens/Character/Preference/Preference.js
+++ b/BondageClub/Screens/Character/Preference/Preference.js
@@ -48,7 +48,7 @@ var PreferenceVisibilityBlockList = [];
 var PreferenceVisibilityResetClicked = false;
 var PreferenceDifficultyLevel = null;
 var PreferenceDifficultyAccept = false;
-var PreferenceGraphicsFontList = ["Arial", "Times New Roman", "Papyrus", "Comic Sans", "Impact", "Verdana", "Century Gothic", "Georgia", "Courier New", "Copperplate"];
+var PreferenceGraphicsFontList = ["Arial", "TimesNewRoman", "Papyrus", "ComicSans", "Impact", "HelveticaNeue", "Verdana", "CenturyGothic", "Georgia", "CourierNew", "Copperplate"];
 var PreferenceGraphicsFontIndex = 0;
 
 /**
@@ -994,16 +994,17 @@ function PreferenceSubscreenGraphicsRun() {
 	MainCanvas.textAlign = "left";
 	DrawText(TextGet("VFXPreferences"), 500, 125, "Black", "Gray");
 	DrawText(TextGet("VFX"), 800, 246, "Black", "Gray");
-   DrawText(TextGet("GraphicsFont"), 800, 336, "Black", "Gray");
+	DrawText(TextGet("GraphicsFont"), 800, 336, "Black", "Gray");
+	DrawTextFit(TextGet("GraphicsFontDisclaimer"), 500, 406, 1400, "Black", "Gray");
 
 	MainCanvas.textAlign = "center";
 	DrawBackNextButton(500, 212, 250, 64, TextGet(Player.ArousalSettings.VFX), "White", "",
 		() => TextGet(PreferenceSettingsVFXList[(PreferenceSettingsVFXIndex + PreferenceSettingsVFXList.length - 1) % PreferenceSettingsVFXList.length]),
 		() => TextGet(PreferenceSettingsVFXList[(PreferenceSettingsVFXIndex + 1) % PreferenceSettingsVFXList.length]));
 
-   DrawBackNextButton(500, 300, 250, 64, TextGet(Player.GraphicsSettings.Font), "White", "",
-      () => TextGet(PreferenceGraphicsFontList[(PreferenceGraphicsFontIndex + PreferenceGraphicsFontList.length - 1) % PreferenceGraphicsFontList.length]),
-      () => TextGet(PreferenceGraphicsFontList[(PreferenceGraphicsFontIndex + 1) % PreferenceGraphicsFontList.length]));
+	DrawBackNextButton(500, 300, 250, 64, TextGet(Player.GraphicsSettings.Font), "White", "",
+		() => TextGet(PreferenceGraphicsFontList[(PreferenceGraphicsFontIndex + PreferenceGraphicsFontList.length - 1) % PreferenceGraphicsFontList.length]),
+		() => TextGet(PreferenceGraphicsFontList[(PreferenceGraphicsFontIndex + 1) % PreferenceGraphicsFontList.length]));
 }
 
 /**
@@ -1016,11 +1017,13 @@ function PreferenceSubscreenGraphicsClick() {
 		if (MouseX <= 625) PreferenceSettingsVFXIndex = (PreferenceSettingsVFXList.length + PreferenceSettingsVFXIndex - 1) % PreferenceSettingsVFXList.length;
 		else PreferenceSettingsVFXIndex = (PreferenceSettingsVFXIndex + 1) % PreferenceSettingsVFXList.length;
 		Player.ArousalSettings.VFX = PreferenceSettingsVFXList[PreferenceSettingsVFXIndex];
-   }
-   if (MouseIn(500, 300, 250, 64)) {
+	}
+	if (MouseIn(500, 300, 250, 64)) {
 		if (MouseX <= 625) PreferenceGraphicsFontIndex = (PreferenceGraphicsFontList.length + PreferenceGraphicsFontIndex - 1) % PreferenceGraphicsFontList.length;
-      else PreferenceGraphicsFontIndex = (PreferenceGraphicsFontIndex + 1) % PreferenceGraphicsFontList.length;
-   	Player.GraphicsSettings.Font = PreferenceGraphicsFontList[PreferenceGraphicsFontIndex];
+		else PreferenceGraphicsFontIndex = (PreferenceGraphicsFontIndex + 1) % PreferenceGraphicsFontList.length;
+		Player.GraphicsSettings.Font = PreferenceGraphicsFontList[PreferenceGraphicsFontIndex];
+		CommonGetFont.clearCache();
+		CommonGetFontName.clearCache();
 	}
 }
 

--- a/BondageClub/Screens/Character/Preference/Text_Preference.csv
+++ b/BondageClub/Screens/Character/Preference/Text_Preference.csv
@@ -219,13 +219,15 @@ VisibilityLocked,All items are forced visible under the Extreme difficulty mode
 LeaveSave,Accept changes
 LeaveNoSave,Cancel changes
 GraphicsFont,Game Font
+GraphicsFontDisclaimer,Fallback fonts will be used if your chosen font is unsupported on your device.
 Arial,Arial
-Times New Roman,Times New Roman
+TimesNewRoman,Times New Roman
 Papyrus,Papyrus
-Comic Sans,Comic Sans
+ComicSans,Comic Sans
 Impact,Impact
 Verdana,Verdana
-Century Gothic,Century Gothic
+HelveticaNeue,Helvetica Neue
+CenturyGothic,Century Gothic
 Georgia,Georgia
-Courier New,Courier New
+CourierNew,Courier New
 Copperplate,Copperplate

--- a/BondageClub/Screens/Online/ChatSearch/ChatSearch.js
+++ b/BondageClub/Screens/Online/ChatSearch/ChatSearch.js
@@ -46,7 +46,7 @@ function ChatSearchRun() {
 	
 	// Draw the bottom controls
 	if (ChatSearchMessage == "") ChatSearchMessage = "EnterName";
-	DrawText(TextGet(ChatSearchMessage), 255, 935, "White", "Gray");
+	DrawTextFit(TextGet(ChatSearchMessage), 255, 935, 490, "White", "Gray");
 	ElementPosition("InputSearch",  740, 926, 470);
 	DrawButton(980, 898, 280, 64, TextGet("SearchRoom"), "White");
 	DrawButton(1280, 898, 280, 64, TextGet("CreateRoom"), "White");

--- a/BondageClub/Scripts/Common.js
+++ b/BondageClub/Scripts/Common.js
@@ -18,7 +18,7 @@ var CutsceneStage = 0;
  * @constant
  * @type {Object.<String, [String[], String]>}
  */
-var CommonFontStacks = {
+const CommonFontStacks = {
 	Arial: [["Arial"], "sans-serif"],
 	TimesNewRoman: [["Times New Roman", "Times"], "serif"],
 	Papyrus: [["Papyrus", "Ink Free", "Segoe Script", "Gabriola"], "fantasy"],

--- a/BondageClub/Scripts/Common.js
+++ b/BondageClub/Scripts/Common.js
@@ -11,6 +11,28 @@ var CommonCSVCache = {};
 var CutsceneStage = 0;
 
 /**
+ * A map of keys to common font stack definitions. Each stack definition is a
+ * two-item array whose first item is an ordered list of fonts, and whose
+ * second item is the generic fallback font family (e.g. sans-serif, serif,
+ * etc.)
+ * @constant
+ * @type {Object.<String, [String[], String]>}
+ */
+var CommonFontStacks = {
+	Arial: [["Arial"], "sans-serif"],
+	TimesNewRoman: [["Times New Roman", "Times"], "serif"],
+	Papyrus: [["Papyrus", "Ink Free", "Segoe Script", "Gabriola"], "fantasy"],
+	ComicSans: [["Comic Sans MS", "Comic Sans", "Brush Script MT", "Segoe Print"], "cursive"],
+	Impact: [["Impact", "Arial Black", "Franklin Gothic", "Arial"], "sans-serif"],
+	HelveticaNeue: [["Helvetica Neue", "Helvetica", "Arial"], "sans-serif"],
+	Verdana: [["Verdana", "Helvetica Neue", "Arial"], "sans-serif"],
+	CenturyGothic: [["Century Gothic", "Apple Gothic", "AppleGothic", "Futura"], "sans-serif"],
+	Georgia: [["Georgia", "Times"], "serif"],
+	CourierNew: [["Courier New", "Courier"], "monospace"],
+	Copperplate: [["Copperplate", "Copperplate Gothic Light"], "fantasy"],
+};
+
+/**
  * Checks if a variable is a number
  * @param {*} n - Variable to check for
  * @returns {boolean} - Returns TRUE if the variable is a finite number
@@ -271,6 +293,8 @@ function CommonCallFunctionByName(FunctionName/*, ...args */) {
 function CommonSetScreen(NewModule, NewScreen) {
 	CurrentModule = NewModule;
 	CurrentScreen = NewScreen;
+	CommonGetFont.clearCache();
+	CommonGetFontName.clearCache();
 	TextLoad();
 	if (typeof window[CurrentScreen + "Load"] === "function")
 		CommonDynamicFunction(CurrentScreen + "Load()");
@@ -442,14 +466,33 @@ function CommonMemoize(func) {
 	return memoized;
 } // CommonMemoize
 
-// Get size + font
-function CommonGetFont(size) {
-  const font = (Player && Player.GraphicsSettings && Player.GraphicsSettings.Font) || "Arial";
-  return `${size}px ${font}`;
-}
+/**
+ * Memoized getter function. Returns a font string specifying the player's
+ * preferred font and the provided size. This is memoized as it is called on
+ * every frame in many cases.
+ * @function
+ * @param {Number} size - The font size that should be specified in the
+ * returned font string
+ * @returns {String} - A font string specifying the requested font size and
+ * the player's preferred font stack. For example:
+ * 12px "Courier New", "Courier", monospace
+ */
+const CommonGetFont = CommonMemoize((size) => {
+	return `${size}px ${CommonGetFontName()}`;
+});
 
-// Get the name of the font only
-function CommonGetFontName() {
-  const font = (Player && Player.GraphicsSettings && Player.GraphicsSettings.Font) || "Arial";
-  return `${font}`;
-}
+/**
+ * Memoized getter function. Returns a font string specifying the player's
+ * preferred font stack. This is memoized as it is called on every frame in
+ * many cases.
+ * @function
+ * @returns {String} - A font string specifying the player's preferred font
+ * stack. For example:
+ * "Courier New", "Courier", monospace
+ */
+const CommonGetFontName = CommonMemoize(() => {
+	const pref = Player && Player.GraphicsSettings && Player.GraphicsSettings.Font;
+	const fontStack = CommonFontStacks[pref] || CommonFontStacks.Arial;
+	const font = fontStack[0].map(fontName => `"${fontName}"`).join(", ");
+	return `${font}, ${fontStack[1]}`;
+});


### PR DESCRIPTION
## Summary

This is something of a follow up to #1799. I was originally going to request some changes on that PR, but it got merged before I did. This PR makes some refinements to the font system which should make it a bit more resilient and performant generally, and should also make it more likely that players will see distinct font options as they click through the available choices (rather than half of them displaying as the browser default). A summary of changes:

* Adds appropriate fallback font stacks for each font, so that the chosen font more closely resembles what the user requested if their chosen font is not available on their device. This means, for example, that if "Courier New" is not available on someone's machine, it will still fall back to a monospace font, rather than the browser default (which is generally a serif font like Times New Roman).
* Adds a Helvetica Neue/Helvetica/Arial/sans-serif font stack, as this is a reasonably commonly used font stack, particularly on Apple devices
* Makes use of @SandrineBC's recently-added memoization function for efficiency purposes. On most screens, the `CommonGetFont` or `CommonGetFontName` functions are called on every frame. Memoizing them makes it much more efficient to repeatedly call them, meaning the font computation is generally only ever done once per screen. The memo caches are cleared when changing font in the preference screen, and when changing screens (via `CommonSetScreen`) to ensure the font is always in sync with the player's actual preferences.
* Changes some text in the chat search to use`DrawTextFit` rather than `DrawText`, as it was not displaying well in certain fonts
* Improves the JSDoc