### PR TITLE
Add additional Y space on top of CharacterCanvas

### DIFF
--- a/BondageClub/Screens/Character/Appearance/Appearance.js
+++ b/BondageClub/Screens/Character/Appearance/Appearance.js
@@ -424,14 +424,14 @@ function CharacterApperanceSetHeightModifier(C) {
 function CharacterAppearanceBuildCanvas(C) {
 	CommonDrawCanvasPrepare(C);
 	CommonDrawAppearanceBuild(C, {
-		clearRect: (x, y, w, h) => C.Canvas.getContext("2d").clearRect(x, y, w, h),
-		clearRectBlink: (x, y, w, h) => C.CanvasBlink.getContext("2d").clearRect(x, y, w, h),
-		drawImage: (src, x, y, alphaMasks) => DrawImageCanvas(src, C.Canvas.getContext("2d"), x, y, alphaMasks),
-		drawImageBlink: (src, x, y, alphaMasks) => DrawImageCanvas(src, C.CanvasBlink.getContext("2d"), x, y, alphaMasks),
-		drawImageColorize: (src, x, y, color, fullAlpha, alphaMasks) => DrawImageCanvasColorize(src, C.Canvas.getContext("2d"), x, y, 1, color, fullAlpha, alphaMasks),
-		drawImageColorizeBlink: (src, x, y, color, fullAlpha, alphaMasks) => DrawImageCanvasColorize(src, C.CanvasBlink.getContext("2d"), x, y, 1, color, fullAlpha, alphaMasks),
-		drawCanvas: (Img, x, y, alphaMasks) => DrawCanvas(Img, C.Canvas.getContext("2d"), x, y, alphaMasks),
-		drawCanvasBlink: (Img, x, y, alphaMasks) => DrawCanvas(Img, C.CanvasBlink.getContext("2d"), x, y, alphaMasks),
+		clearRect: (x, y, w, h) => C.Canvas.getContext("2d").clearRect(x, y + CharacterCanvas_SizeY_reserve, w, h),
+		clearRectBlink: (x, y, w, h) => C.CanvasBlink.getContext("2d").clearRect(x, y + CharacterCanvas_SizeY_reserve, w, h),
+		drawImage: (src, x, y, alphaMasks) => DrawImageCanvas(src, C.Canvas.getContext("2d"), x, y + CharacterCanvas_SizeY_reserve, CommonDrawFixMasks(alphaMasks)),
+		drawImageBlink: (src, x, y, alphaMasks) => DrawImageCanvas(src, C.CanvasBlink.getContext("2d"), x, y + CharacterCanvas_SizeY_reserve, CommonDrawFixMasks(alphaMasks)),
+		drawImageColorize: (src, x, y, color, fullAlpha, alphaMasks) => DrawImageCanvasColorize(src, C.Canvas.getContext("2d"), x, y + CharacterCanvas_SizeY_reserve, 1, color, fullAlpha, CommonDrawFixMasks(alphaMasks)),
+		drawImageColorizeBlink: (src, x, y, color, fullAlpha, alphaMasks) => DrawImageCanvasColorize(src, C.CanvasBlink.getContext("2d"), x, y + CharacterCanvas_SizeY_reserve, 1, color, fullAlpha, CommonDrawFixMasks(alphaMasks)),
+		drawCanvas: (Img, x, y, alphaMasks) => DrawCanvas(Img, C.Canvas.getContext("2d"), x, y + CharacterCanvas_SizeY_reserve, CommonDrawFixMasks(alphaMasks)),
+		drawCanvasBlink: (Img, x, y, alphaMasks) => DrawCanvas(Img, C.CanvasBlink.getContext("2d"), x, y + CharacterCanvas_SizeY_reserve, CommonDrawFixMasks(alphaMasks)),
 	});
 }
 

--- a/BondageClub/Scripts/CommonDraw.js
+++ b/BondageClub/Scripts/CommonDraw.js
@@ -1,4 +1,7 @@
 "use strict";
+const CharacterCanvas_SizeY = 1000;
+const CharacterCanvas_SizeY_reserve = 400;
+
 /**
  * A callback function used for clearing a rectangular area of a canvas
  * @callback clearRect
@@ -45,13 +48,13 @@ function CommonDrawCanvasPrepare(C) {
 	if (C.Canvas == null) {
 		C.Canvas = document.createElement("canvas");
 		C.Canvas.width = 500;
-		C.Canvas.height = 1000;
-	} else C.Canvas.getContext("2d").clearRect(0, 0, 500, 1000);
+		C.Canvas.height = CharacterCanvas_SizeY + CharacterCanvas_SizeY_reserve;
+	} else C.Canvas.getContext("2d").clearRect(0, 0, 500, CharacterCanvas_SizeY + CharacterCanvas_SizeY_reserve);
 	if (C.CanvasBlink == null) {
 		C.CanvasBlink = document.createElement("canvas");
 		C.CanvasBlink.width = 500;
-		C.CanvasBlink.height = 1000;
-	} else C.CanvasBlink.getContext("2d").clearRect(0, 0, 500, 1000);
+		C.CanvasBlink.height = CharacterCanvas_SizeY + CharacterCanvas_SizeY_reserve;
+	} else C.CanvasBlink.getContext("2d").clearRect(0, 0, 500, CharacterCanvas_SizeY + CharacterCanvas_SizeY_reserve);
 
 	C.MustDraw = true;
 }
@@ -307,4 +310,15 @@ function CommonDrawFindPose(C, AllowedPoses) {
 		});
 	}
 	return Pose;
+}
+
+/**
+ * Changes masks to compensate for added Y reserve space
+ * @param {[number, number, number, number][] | null} Masks - the Alpha masks to be fixed
+ */
+function CommonDrawFixMasks(Masks) {
+	if (Array.isArray(Masks)) {
+		return Masks.map(([x, y, w, h]) => [x, y + CharacterCanvas_SizeY_reserve, w, h]);
+	}
+	return Masks;
 }

--- a/BondageClub/Scripts/GLDraw.js
+++ b/BondageClub/Scripts/GLDraw.js
@@ -22,7 +22,7 @@ window.addEventListener('load', GLDrawLoad);
 function GLDrawLoad() {
     GLDrawCanvas = document.createElement("canvas");
     GLDrawCanvas.width = 1000;
-    GLDrawCanvas.height = 1000;
+    GLDrawCanvas.height = CharacterCanvas_SizeY + CharacterCanvas_SizeY_reserve;
     GLVersion = "webgl2";
     var gl = GLDrawCanvas.getContext(GLVersion);
     if (!gl) { GLVersion = "webgl"; gl = GLDrawCanvas.getContext(GLVersion); }
@@ -76,7 +76,7 @@ function GLDrawInitCharacterCanvas(canvas) {
     if (canvas == null) {
         canvas = document.createElement("canvas");
         canvas.width = 1000;
-        canvas.height = 1000;
+        canvas.height = CharacterCanvas_SizeY + CharacterCanvas_SizeY_reserve;
     }
     if (canvas.GL == null) {
         canvas.GL = canvas.getContext(GLVersion);
@@ -85,7 +85,7 @@ function GLDrawInitCharacterCanvas(canvas) {
             return GLDrawInitCharacterCanvas(null);
         }
     } else {
-        GLDrawClearRect(canvas.GL, 0, 0, 1000, 1000);
+        GLDrawClearRect(canvas.GL, 0, 0, 1000, CharacterCanvas_SizeY + CharacterCanvas_SizeY_reserve);
     }
     if (canvas.GL.program == null) {
         GLDrawMakeGLProgam(canvas.GL);
@@ -468,18 +468,18 @@ function GLDrawHexToRGBA(color) {
  * @returns {void} - Nothing 
  */
 function GLDrawAppearanceBuild(C) {
-    GLDrawClearRect(GLDrawCanvas.GL, 0, 0, 1000, 1000);
+    GLDrawClearRect(GLDrawCanvas.GL, 0, 0, 1000, CharacterCanvas_SizeY + CharacterCanvas_SizeY_reserve);
     CommonDrawCanvasPrepare(C);
     CommonDrawAppearanceBuild(C, {
-		clearRect: (x, y, w, h) => GLDrawClearRect(GLDrawCanvas.GL, x, 1000 - y - h, w, h),
-		clearRectBlink: (x, y, w, h) => GLDrawClearRectBlink(GLDrawCanvas.GL, x, 1000 - y - h, w, h),
-		drawImage: (src, x, y, alphaMasks) => GLDrawImage(src, GLDrawCanvas.GL, x, y, 0, null, null, alphaMasks),
-		drawImageBlink: (src, x, y, alphaMasks) => GLDrawImageBlink(src, GLDrawCanvas.GL, x, y, null, null, alphaMasks),
-		drawImageColorize: (src, x, y, color, fullAlpha, alphaMasks) => GLDrawImage(src, GLDrawCanvas.GL, x, y, 0, color, fullAlpha, alphaMasks),
-		drawImageColorizeBlink: (src, x, y, color, fullAlpha, alphaMasks) => GLDrawImageBlink(src, GLDrawCanvas.GL, x, y, color, fullAlpha, alphaMasks),
-		drawCanvas: (Img, x, y, alphaMasks) => GLDraw2DCanvas(GLDrawCanvas.GL, Img, x, y, alphaMasks),
-		drawCanvasBlink: (Img, x, y, alphaMasks) => GLDraw2DCanvasBlink(GLDrawCanvas.GL, Img, x, y, alphaMasks),
-	});
+		clearRect: (x, y, w, h) => GLDrawClearRect(GLDrawCanvas.GL, x, CharacterCanvas_SizeY + CharacterCanvas_SizeY_reserve - y - h, w, h),
+		clearRectBlink: (x, y, w, h) => GLDrawClearRectBlink(GLDrawCanvas.GL, x, CharacterCanvas_SizeY + CharacterCanvas_SizeY_reserve - y - h, w, h),
+		drawImage: (src, x, y, alphaMasks) => GLDrawImage(src, GLDrawCanvas.GL, x, y + CharacterCanvas_SizeY_reserve, 0, null, null, CommonDrawFixMasks(alphaMasks)),
+		drawImageBlink: (src, x, y, alphaMasks) => GLDrawImageBlink(src, GLDrawCanvas.GL, x, y + CharacterCanvas_SizeY_reserve, null, null, CommonDrawFixMasks(alphaMasks)),
+		drawImageColorize: (src, x, y, color, fullAlpha, alphaMasks) => GLDrawImage(src, GLDrawCanvas.GL, x, y + CharacterCanvas_SizeY_reserve, 0, color, fullAlpha, CommonDrawFixMasks(alphaMasks)),
+		drawImageColorizeBlink: (src, x, y, color, fullAlpha, alphaMasks) => GLDrawImageBlink(src, GLDrawCanvas.GL, x, y + CharacterCanvas_SizeY_reserve, color, fullAlpha, CommonDrawFixMasks(alphaMasks)),
+		drawCanvas: (Img, x, y, alphaMasks) => GLDraw2DCanvas(GLDrawCanvas.GL, Img, x, y + CharacterCanvas_SizeY_reserve, CommonDrawFixMasks(alphaMasks)),
+		drawCanvasBlink: (Img, x, y, alphaMasks) => GLDraw2DCanvasBlink(GLDrawCanvas.GL, Img, x, y + CharacterCanvas_SizeY_reserve, CommonDrawFixMasks(alphaMasks)),
+    });
     C.Canvas.getContext("2d").drawImage(GLDrawCanvas, 0, 0);
     C.CanvasBlink.getContext("2d").drawImage(GLDrawCanvas, -500, 0);
 }


### PR DESCRIPTION
This will make it possible to create items "attached" to ceiling even with characters smaller than full high.

This change should be fully transparent, it's only effect should be, that negative Top values will become meaningful for item assets.
There shouldn't be any visible change at all.

The reserve space was calculated so smallest character in kneeling pose still reaches top of room