### PR TITLE
Bugfix: Fixes alpha masks for the open crotch straitdress

### DIFF
--- a/BondageClub/Assets/Female3DCG/Female3DCG.js
+++ b/BondageClub/Assets/Female3DCG/Female3DCG.js
@@ -1968,7 +1968,7 @@ var AssetFemale3DCG = [
 				Effect: ["Block", "Prone"],
 				Block: ["ItemPelvis", "ItemTorso", "ItemBreast", "ItemHands", "ItemFeet", "ItemNipples", "ItemNipplesPiercings", "ItemLegs"],
 				AllowActivePose: ["Kneel"],
-				Alpha: [{Group: ["BodyLower"], Masks: [[135, 462, 75, 120], [290, 462, 75, 120], [135, 582, 230, 418]]}],
+				Alpha: [{Masks: [[0, 362, 500, 100], [0, 462, 210, 120], [290, 462, 210, 120], [0, 582, 500, 418]]}],
 				Layer: [
 					{ Name: "Latex" },
 					{ Name: "Belts" }


### PR DESCRIPTION
## Summary

Fixes alpha masks for the open crotch straitdress. Previously the masks were only being applied to the lower body group, which caused clipping issues when the lower body size was larger than the upper body size. See the screenshot below for an example.

![Bug](https://cdn.discordapp.com/attachments/554378725916147722/792128799663849522/unknown.png)