### PR TITLE
Bugfix: LoverOnly/OwnerOnly items getting removed on relog

### DIFF
--- a/BondageClub/Scripts/Server.js
+++ b/BondageClub/Scripts/Server.js
@@ -468,10 +468,10 @@ function ServerAppearanceLoadFromBundle(C, AssetFamily, Bundle, SourceMemberNumb
 			if ((Asset[I].Name == Bundle[A].Name) && (Asset[I].Group.Name == Bundle[A].Group) && (Asset[I].Group.Family == AssetFamily)) {
 
 				// OwnerOnly items can only get update if it comes from owner
-				if (Asset[I].OwnerOnly && (C.ID == 0) && !FromOwner) break;
+				if (SourceMemberNumber != null && Asset[I].OwnerOnly && (C.ID == 0) && !FromOwner) break;
 
 				// LoverOnly items can only get update if it comes from lover
-				if (Asset[I].LoverOnly && (C.ID == 0) && !FromLoversOrOwner) break;
+				if (SourceMemberNumber != null && Asset[I].LoverOnly && (C.ID == 0) && !FromLoversOrOwner) break;
 
 				var ColorSchema = Asset[I].Group.ColorSchema;
 				var Color = Bundle[A].Color;


### PR DESCRIPTION
## Summary

As a result of some of the changes in #1387, items marked as `LoverOnly` or `OwnerOnly` get removed on login, due to a check in `ServerAppearanceLoadFromBundle` against the source member number (which is undefined when logging in). This PR reinstates the missing checks for a login.

## Steps to reproduce

1. Equip either the Lovers Vibrator or Love Chastity Belt on a character
2. Have that character log out and log back in
3. Note that the vibrator/belt has been removed by the appearance bundle load