### PR TITLE
Allow room owners to block leashing

### DIFF
--- a/BondageClub/Screens/Online/ChatBlockItem/ChatBlockItem.js
+++ b/BondageClub/Screens/Online/ChatBlockItem/ChatBlockItem.js
@@ -1,6 +1,6 @@
 "use strict";
 var ChatBlockItemBackground = "Sheet";
-var ChatBlockItemList = ["ABDL", "SciFi"];
+var ChatBlockItemList = ["ABDL", "SciFi", "Leashing"];
 var ChatBlockItemCategory = [];
 var ChatBlockItemReturnData = {};
 

--- a/BondageClub/Screens/Online/ChatBlockItem/Text_ChatBlockItem.csv
+++ b/BondageClub/Screens/Online/ChatBlockItem/Text_ChatBlockItem.csv
@@ -1,4 +1,5 @@
 Title,Select the item categories to block in your chat room.  They won't be visible or usable by players.
 ABDL,Adult Baby Diaper Lovers
 SciFi,Futuristic / Sci-Fi
+Leashing,Player Leashing
 Return,Return

--- a/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
+++ b/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
@@ -151,7 +151,7 @@ function ChatRoomCanStopSlowPlayer() { return (CurrentCharacter.IsSlow() && Play
  * @returns {boolean} - TRUE if the player can interact and is allowed to interact with the current character.
  */
 function ChatRoomCanHoldLeash() { return CurrentCharacter.AllowItem && Player.CanInteract() && CurrentCharacter.OnlineSharedSettings && CurrentCharacter.OnlineSharedSettings.AllowPlayerLeashing != false && ChatRoomLeashList.indexOf(CurrentCharacter.MemberNumber) < 0
-	&& ChatRoomCanBeLeashed(CurrentCharacter)}
+	&& ChatRoomCanBeLeashed(CurrentCharacter) && (ChatRoomData && ChatRoomData.BlockCategory.indexOf("Leashing") < 0)}
 /**
  * Checks if the player can let go of the targeted player's leash
  * @returns {boolean} - TRUE if the player can interact and is allowed to interact with the current character.

--- a/BondageClub/Screens/Online/ChatSearch/Text_ChatSearch.csv
+++ b/BondageClub/Screens/Online/ChatSearch/Text_ChatSearch.csv
@@ -18,6 +18,7 @@ FriendList,Friends
 Next,Next page
 Block,Block:
 ABDL,ABDL
+Leashing,Player Leashing
 SciFi,Sci-Fi
 GameLabel,Game:
 GameLARP,LARP


### PR DESCRIPTION
This adds a "Player Leashing" toggle to the room block menu. This does not block leashes by itself but simply prevents the "Hold On To Her Leash" option from appearing on players. This will not stop a dom from having a leashed sub and bringing her into the room and taking her out (unless one of them disconnects in the process), but it will stop people from grabbing the leash of another player without first asking the room owner to turn off the block.