### PR TITLE
Kicked in Chatroom Subscreen Fix

### DIFF
--- a/BondageClub/Screens/Online/ChatSearch/ChatSearch.js
+++ b/BondageClub/Screens/Online/ChatSearch/ChatSearch.js
@@ -340,10 +340,8 @@ function ChatSearchClickPermission() {
  */
 function ChatSearchResponse(data) {
 	if ((data != null) && (typeof data === "string") && (data != "")) {
-		if (((data == "RoomBanned") || (data == "RoomKicked")) && (CurrentScreen == "ChatRoom")) {
-			if (CurrentCharacter != null) DialogLeave();
-			ElementRemove("InputChat");
-			ElementRemove("TextAreaChatLog");
+		if (((data == "RoomBanned") || (data == "RoomKicked")) && ServerPlayerIsInChatRoom()) {
+			ChatRoomClearAllElements();
 			CommonSetScreen("Online", "ChatSearch");
 			CharacterDeleteAllOnline();
 			ChatSearchSetLastChatRoom("")

--- a/BondageClub/Scripts/Server.js
+++ b/BondageClub/Scripts/Server.js
@@ -116,17 +116,7 @@ function ServerDisconnect(data) {
 		if (CurrentScreen != "Relog") {
 
 			// Exits out of the chat room or a sub screen of the chatroom, so we'll be able to get in again when we log back
-			if (
-				(CurrentScreen == "ChatRoom")
-				|| (CurrentScreen == "ChatAdmin")
-				|| (CurrentScreen == "GameLARP")
-				|| ((CurrentScreen == "Appearance") && (CharacterAppearanceReturnRoom == "ChatRoom"))
-				|| ((CurrentScreen == "InformationSheet") && (InformationSheetPreviousScreen == "ChatRoom"))
-				|| ((CurrentScreen == "Title") && (InformationSheetPreviousScreen == "ChatRoom"))
-				|| ((CurrentScreen == "OnlineProfile") && (InformationSheetPreviousScreen == "ChatRoom"))
-				|| ((CurrentScreen == "FriendList") && (InformationSheetPreviousScreen == "ChatRoom") && (FriendListReturn == null))
-				|| ((CurrentScreen == "Preference") && (InformationSheetPreviousScreen == "ChatRoom"))
-			) {
+			if (ServerPlayerIsInChatRoom()) {
 				RelogChatLog = document.getElementById("TextAreaChatLog").cloneNode(true);
 				RelogChatLog.id = "RelogChatLog";
 				RelogChatLog.name = "RelogChatLog";
@@ -144,6 +134,22 @@ function ServerDisconnect(data) {
 
 		}
 	}
+}
+
+/**
+ * Returns whether the player is currently in a chatroom or viewing a subscreen while in a chatroom
+ * @returns {boolean} - True if in a chatroom 
+ */
+function ServerPlayerIsInChatRoom() {
+	return (CurrentScreen == "ChatRoom")
+		|| (CurrentScreen == "ChatAdmin")
+		|| (CurrentScreen == "GameLARP")
+		|| ((CurrentScreen == "Appearance") && (CharacterAppearanceReturnRoom == "ChatRoom"))
+		|| ((CurrentScreen == "InformationSheet") && (InformationSheetPreviousScreen == "ChatRoom"))
+		|| ((CurrentScreen == "Title") && (InformationSheetPreviousScreen == "ChatRoom"))
+		|| ((CurrentScreen == "OnlineProfile") && (InformationSheetPreviousScreen == "ChatRoom"))
+		|| ((CurrentScreen == "FriendList") && (InformationSheetPreviousScreen == "ChatRoom") && (FriendListReturn == null))
+		|| ((CurrentScreen == "Preference") && (InformationSheetPreviousScreen == "ChatRoom"));
 }
 
 /** Sends a message with the given data to the server via socket.emit */


### PR DESCRIPTION
If a player is viewing a subscreen in a chat room (wardrobe, profile, etc) and gets kicked or banned, on exiting the subscreen they still see the chat room despite no longer being in it. This fix re-uses the disconnect check so that they properly jump to the chat search page regardless of what subscreen they're in.