### PR TITLE
Bugfix: Vibrator mode fixes

### DIFF
--- a/BondageClub/Scripts/Character.js
+++ b/BondageClub/Scripts/Character.js
@@ -1094,7 +1094,13 @@ function CharacterIsEdged(C) {
 	// Get every vibrating item acting on an orgasm zone
 	const VibratingItems = C.Appearance
 		.filter(A => OrgasmZones.indexOf(A.Asset.ArousalZone) >= 0)
-		.filter(Item => Item && Item.Property && typeof Item.Property.Intensity === "number" && Item.Property.Intensity >= 0);
+		.filter(Item => {
+			return Item && Item.Property
+			       && Array.isArray(Item.Property.Effect)
+			       && Item.Property.Effect.includes("Vibrating")
+			       && typeof Item.Property.Intensity === "number"
+			       && Item.Property.Intensity >= 0;
+		});
 
 	// Return true if every vibrating item on an orgasm zone has the "Edged" effect
 	return !!VibratingItems.length && VibratingItems.every(Item => Item.Property.Effect && Item.Property.Effect.includes("Edged"));

--- a/BondageClub/Scripts/Character.js
+++ b/BondageClub/Scripts/Character.js
@@ -1094,13 +1094,13 @@ function CharacterIsEdged(C) {
 	// Get every vibrating item acting on an orgasm zone
 	const VibratingItems = C.Appearance
 		.filter(A => OrgasmZones.indexOf(A.Asset.ArousalZone) >= 0)
-		.filter(Item => {
-			return Item && Item.Property
-			       && Array.isArray(Item.Property.Effect)
-			       && Item.Property.Effect.includes("Vibrating")
-			       && typeof Item.Property.Intensity === "number"
-			       && Item.Property.Intensity >= 0;
-		});
+		.filter(Item => Item
+		                && Item.Property
+		                && Array.isArray(Item.Property.Effect)
+		                && Item.Property.Effect.includes("Vibrating")
+		                && typeof Item.Property.Intensity === "number"
+		                && Item.Property.Intensity >= 0,
+		);
 
 	// Return true if every vibrating item on an orgasm zone has the "Edged" effect
 	return !!VibratingItems.length && VibratingItems.every(Item => Item.Property.Effect && Item.Property.Effect.includes("Edged"));

--- a/BondageClub/Scripts/VibratorMode.js
+++ b/BondageClub/Scripts/VibratorMode.js
@@ -570,6 +570,7 @@ function VibratorModePublish(C, Item, OldIntensity, Intensity) {
 	if (Item.Property.ItemMemberNumber) Dictionary.push({ Tag: "ItemMemberNumber", MemberNumber: Item.Property.ItemMemberNumber });
 	if (CurrentScreen == "ChatRoom") {
 		ServerSend("ChatRoomChat", { Content: "Vibe" + Direction + "To" + Intensity, Type: "Action", Dictionary });
+		CharacterLoadEffect(C);
 		ChatRoomCharacterItemUpdate(C, Item.Asset.Group.Name);
 		ActivityChatRoomArousalSync(C);
 	}


### PR DESCRIPTION
## Summary

This fixes some cases where the Deny and Edge vibrator modes were not working as intended:

1. Adds stricter checks for vibrating items in the `CharacterIsEdged` function to prevent items like shock toys from counting as "vibrating"
2. Adds a `CharaterLoadEffect` call to the `VibratorMode` code to ensure the player's effect array is up to date on vibrator changes