### PR TITLE
Height System Rework

### DIFF
--- a/BondageClub/Assets/Female3DCG/Female3DCG.js
+++ b/BondageClub/Assets/Female3DCG/Female3DCG.js
@@ -3682,19 +3682,19 @@ var PoseFemale3DCG = [
 		Name: "Kneel",
 		Category: "BodyLower",
 		AllowMenu: true,
-		OverrideHeight: -250,
+		OverrideHeight: { Height: -250, Priority: 20 },
 		Hide: ["ItemFeet", "LeftAnklet", "RightAnklet"]
 	},
 	{
 		Name: "Horse",
 		Category: "BodyLower",
-		OverrideHeight: -75,
+		OverrideHeight: { Height: -75, Priority: 20 },
 		Hide: ["ItemFeet", "LeftAnklet", "RightAnklet"]
 	},
 	{
 		Name: "KneelingSpread",
 		Category: "BodyLower",
-		OverrideHeight: -250,
+		OverrideHeight: { Height: -250, Priority: 20 },
 		Hide: ["ItemFeet", "LeftAnklet", "RightAnklet"]
 	},
 	{
@@ -3707,32 +3707,32 @@ var PoseFemale3DCG = [
 		Name: "OverTheHead",
 		Category: "BodyUpper",
 		AllowMenu: true,
-		OverrideHeight: -25,
+		OverrideHeight: { Height: -25, Priority: 10 },
 		Hide: ["Hands"],
 	},
 	{
 		Name: "Hogtied",
 		Category: "BodyFull",
-		OverrideHeight: -575,
+		OverrideHeight: { Height: -575, Priority: 50 },
 		Hide: ["BodyLower", "Head", "Hands", "ClothLower", "Wings", "TailStraps", "Gloves", "Panties", "Pussy", "ItemHands", "ItemPelvis", "ItemVulva", "ItemVulvaPiercings", "ItemButt", "ItemLegs", "ItemFeet", "LeftAnklet", "RightAnklet"],
 		MovePosition: [{ Group: "Socks", X: 0, Y: -400 }, { Group: "Shoes", X: 0, Y: -500 }, { Group: "ItemBoots", X: 0, Y: -500 }, { Group: "SuitLower", X: 30, Y: -380 }]
 	},
 	{
 		Name: "Suspension",
 		Category: "BodyFull",
-		OverrideHeight: 150,
+		OverrideHeight: { Height: -150, Priority: 40 },
 		Hide: []
 	},
 	{
 		Name: "SuspensionHogtied",
 		Category: "BodyFull",
-		OverrideHeight: 0,
+		OverrideHeight: { Height: 0, Priority: 50 },
 		Hide: ["BodyLower", "Hands", "ClothLower", "Wings", "TailStraps", "Gloves", "Panties", "Pussy", "ItemHands", "ItemPelvis", "ItemVulva", "ItemVulvaPiercings", "ItemButt", "ItemLegs", "ItemFeet", "SuitLower", "ItemDevices", "LeftAnklet", "RightAnklet"]
 	},
 	{
 		Name: "AllFours",
 		Category: "BodyFull",
-		OverrideHeight: -560,
+		OverrideHeight: { Height: -560, Priority: 50 },
 		Hide: ["ItemFeet", "ClothLower", "SuitLower", "Nipples", "Pussy", "BodyLower", "Head", "Wings", "ItemPelvis", "ItemVulva", "ItemVulvaPiercings", "ItemLegs", "ItemBoots", "Suit", "Panties", "Bra", "Socks", "Shoes", "LeftAnklet", "RightAnklet"],
 		MovePosition: [{ Group: "TailStraps", X: 0, Y: -300 }, { Group: "ItemButt", X: 0, Y: -300 }]
 	},

--- a/BondageClub/Screens/Character/Appearance/Appearance.js
+++ b/BondageClub/Screens/Character/Appearance/Appearance.js
@@ -540,7 +540,7 @@ function AppearanceRun() {
 		if (C.ID == 0) CharacterAppearanceHeaderText = TextGet("SelectYourAppearance");
 		else CharacterAppearanceHeaderText = TextGet("SelectSomeoneAppearance").replace("TargetCharacterName", C.Name);
 	}
-	DrawCharacter(C, -600, (C.IsKneeling()) ? -1100 : -100, 4, false);
+	DrawCharacter(C, -600, -100 + 4 * C.HeightModifier, 4, false);
 	DrawCharacter(C, 750, 0, 1);
 	DrawText(CharacterAppearanceHeaderText, 400, 40, "White", "Black");
 

--- a/BondageClub/Screens/Character/Preference/Preference.js
+++ b/BondageClub/Screens/Character/Preference/Preference.js
@@ -905,10 +905,8 @@ function PreferenceSubscreenArousalRun() {
 
 		// Draws all the available character zones
 		for (let A = 0; A < AssetGroup.length; A++)
-			if ((AssetGroup[A].Zone != null) && (AssetGroup[A].Activity != null)) {
-				DrawAssetGroupZoneBackground(Player, AssetGroup[A].Zone, 0.9, 50, 50, PreferenceGetFactorColor(PreferenceGetZoneFactor(Player, AssetGroup[A].Name)));
-				DrawAssetGroupZone(Player, AssetGroup[A].Zone, 0.9, 50, 50, "#808080FF", 3);
-			}
+			if ((AssetGroup[A].Zone != null) && (AssetGroup[A].Activity != null))
+				DrawAssetGroupZone(Player, AssetGroup[A].Zone, 0.9, 50, 50, "#808080FF", 3, PreferenceGetFactorColor(PreferenceGetZoneFactor(Player, AssetGroup[A].Name)));
 
 		// The zones can be selected and drawn on the character
 		if (Player.FocusGroup != null) {
@@ -1241,8 +1239,7 @@ function PreferenceSubscreenArousalClick() {
 		for (let A = 0; A < AssetGroup.length; A++)
 			if ((AssetGroup[A].Zone != null) && (AssetGroup[A].Activity != null))
 				for (let Z = 0; Z < AssetGroup[A].Zone.length; Z++)
-					if (((Player.Pose.indexOf("Suspension") < 0) && (MouseX >= ((AssetGroup[A].Zone[Z][0] * 0.9) + 50)) && (MouseY >= (((AssetGroup[A].Zone[Z][1] - Player.HeightModifier) * 0.9) + 50)) && (MouseX <= (((AssetGroup[A].Zone[Z][0] + AssetGroup[A].Zone[Z][2]) * 0.9) + 50)) && (MouseY <= (((AssetGroup[A].Zone[Z][1] + AssetGroup[A].Zone[Z][3] - Player.HeightModifier) * 0.9) + 50)))
-						|| ((Player.Pose.indexOf("Suspension") >= 0) && (MouseX >= ((AssetGroup[A].Zone[Z][0] * 0.9) + 50)) && (MouseY >= 0.9 * ((1000 - (AssetGroup[A].Zone[Z][1] + AssetGroup[A].Zone[Z][3])) - Player.HeightModifier)) && (MouseX <= (((AssetGroup[A].Zone[Z][0] + AssetGroup[A].Zone[Z][2]) * 0.9) + 50)) && (MouseY <= 0.9 * (1000 - ((AssetGroup[A].Zone[Z][1])) - Player.HeightModifier)))) {
+					if (DialogClickedInZone(Player, AssetGroup[A].Zone[Z], 0.9, 50, 50)) {
 						Player.FocusGroup = AssetGroup[A];
 						PreferenceArousalZoneFactor = PreferenceGetZoneFactor(Player, AssetGroup[A].Name);
 					}

--- a/BondageClub/Screens/Inventory/ItemArms/Chains/Chains.js
+++ b/BondageClub/Screens/Inventory/ItemArms/Chains/Chains.js
@@ -47,7 +47,8 @@ const InventoryItemArmsChainsOptions = [
 		Name: "SuspensionHogtied",
 		BondageLevel: 8,
 		Prerequisite: ["NotMounted", "NotChained", "NotSuspended", "CannotBeHogtiedWithAlphaHood"],
-		Property: { Type: "SuspensionHogtied", Effect: ["Block", "Freeze", "Prone"], Block: ["ItemHands", "ItemLegs", "ItemFeet", "ItemBoots"], AllowActivityOn: ["ItemHands", "ItemLegs", "ItemFeet", "ItemBoots"], SetPose: ["Hogtied", "SuspensionHogtied"], Difficulty: 6 },
+		Property: { Type: "SuspensionHogtied", Effect: ["Block", "Freeze", "Prone"], Block: ["ItemHands", "ItemLegs", "ItemFeet", "ItemBoots"], AllowActivityOn: ["ItemHands", "ItemLegs", "ItemFeet", "ItemBoots"], SetPose: ["Hogtied", "SuspensionHogtied"], Difficulty: 6,
+			OverrideHeight: { Height: 0, Priority: 51, HeightRatioProportion: 0 } },
 		Expression: [{ Group: "Blush", Name: "Medium", Timer: 10 }],
 	}
 ];

--- a/BondageClub/Screens/Inventory/ItemArms/HempRope/HempRope.js
+++ b/BondageClub/Screens/Inventory/ItemArms/HempRope/HempRope.js
@@ -63,7 +63,8 @@ const InventoryItemArmsHempRopeOptions = [
 		Name: "SuspensionHogtied",
 		BondageLevel: 8,
 		Prerequisite: ["NotMounted", "NotChained", "NotSuspended", "CannotBeHogtiedWithAlphaHood"],
-		Property: { Type: "SuspensionHogtied", Effect: ["Block", "Freeze", "Prone"], Block: ["ItemHands", "ItemLegs", "ItemFeet", "ItemBoots"], AllowActivityOn: ["ItemHands", "ItemLegs", "ItemFeet", "ItemBoots"], SetPose: ["Hogtied", "SuspensionHogtied"], Difficulty: 6 },
+		Property: { Type: "SuspensionHogtied", Effect: ["Block", "Freeze", "Prone"], Block: ["ItemHands", "ItemLegs", "ItemFeet", "ItemBoots"], AllowActivityOn: ["ItemHands", "ItemLegs", "ItemFeet", "ItemBoots"], SetPose: ["Hogtied", "SuspensionHogtied"], Difficulty: 6,
+			OverrideHeight: { Height: 0, Priority: 51, HeightRatioProportion: 0 } },
 		Expression: [{ Group: "Blush", Name: "Medium", Timer: 10 }],
 	}, {
 		Name: "BedSpreadEagle",

--- a/BondageClub/Screens/Inventory/ItemArms/Web/Web.js
+++ b/BondageClub/Screens/Inventory/ItemArms/Web/Web.js
@@ -88,6 +88,7 @@ var InventoryItemArmsWebOptions = [
 			Effect: ["Block", "Freeze", "Prone"],
 			Hide: ["Cloth", "ClothLower", "ClothAccessory", "Necklace", "Shoes", "Socks"],
 			Block: ["ItemVulva", "ItemVulvaPiercings", "ItemButt", "ItemPelvis", "ItemTorso", "ItemHands", "ItemLegs", "ItemFeet", "ItemBoots", "ItemNipples", "ItemNipplesPiercings", "ItemBreast", "ItemDevices"],
+			OverrideHeight: { Height: 0, Priority: 51, HeightRatioProportion: 0 },
 		},
 	},
 ];

--- a/BondageClub/Screens/Inventory/ItemBoots/FuturisticHeels/FuturisticHeels.js
+++ b/BondageClub/Screens/Inventory/ItemBoots/FuturisticHeels/FuturisticHeels.js
@@ -3,11 +3,11 @@
 var InventoryItemBootsFuturisticHeelsOptions = [
 	{
 		Name: "Shoes",
-		Property: {Type: null, Height: 6},
+		Property: { Type: null, HeightModifier: 6 },
 	},
 	{
 		Name: "Heel",
-		Property: { Type: "Heel", Height: 16 },
+		Property: { Type: "Heel", HeightModifier: 16 },
 	},
 ]
 
@@ -33,24 +33,7 @@ function InventoryItemBootsFuturisticHeelsClick() {
 	if (InventoryItemMouthFuturisticPanelGagValidate(C) !== "") {
 		InventoryItemMouthFuturisticPanelGagClickAccessDenied()
 	} else {
-		var DialogFocusItem_Temp = DialogFocusItem
-		var origHeight = 6
-		if (DialogFocusItem_Temp && DialogFocusItem_Temp.Property && DialogFocusItem_Temp.Asset) {
-			origHeight = DialogFocusItem_Temp.Property.Height
-		}
 		ExtendedItemClick(InventoryItemBootsFuturisticHeelsOptions);
-		// Set height because height isnt a property
-		if (DialogFocusItem_Temp && DialogFocusItem_Temp.Property && DialogFocusItem_Temp.Asset) {
-			if (origHeight != DialogFocusItem_Temp.Property.Height) {
-				DialogFocusItem_Temp.Height = DialogFocusItem_Temp.Property.Height
-				DialogFocusItem_Temp.Asset.HeightModifier = DialogFocusItem_Temp.Property.Height
-				
-				
-				CharacterRefresh(C, true); // Does not sync appearance while in the wardrobe
-				ChatRoomCharacterUpdate(C);
-			}
-			
-		}
 	}
 }
 

--- a/BondageClub/Screens/Inventory/ItemBreast/FuturisticBra2/FuturisticBra2.js
+++ b/BondageClub/Screens/Inventory/ItemBreast/FuturisticBra2/FuturisticBra2.js
@@ -33,24 +33,7 @@ function InventoryItemBreastFuturisticBra2Click() {
 	if (InventoryItemMouthFuturisticPanelGagValidate(C) !== "") {
 		InventoryItemMouthFuturisticPanelGagClickAccessDenied()
 	} else {
-		var DialogFocusItem_Temp = DialogFocusItem
-		var origHeight = 6
-		if (DialogFocusItem_Temp && DialogFocusItem_Temp.Property && DialogFocusItem_Temp.Asset) {
-			origHeight = DialogFocusItem_Temp.Property.Height
-		}
 		ExtendedItemClick(InventoryItemBreastFuturisticBra2Options);
-		// Set height because height isnt a property
-		if (DialogFocusItem_Temp && DialogFocusItem_Temp.Property && DialogFocusItem_Temp.Asset) {
-			if (origHeight != DialogFocusItem_Temp.Property.Height) {
-				DialogFocusItem_Temp.Height = DialogFocusItem_Temp.Property.Height
-				DialogFocusItem_Temp.Asset.HeightModifier = DialogFocusItem_Temp.Property.Height
-				
-				
-				CharacterRefresh(C, true); // Does not sync appearance while in the wardrobe
-				ChatRoomCharacterUpdate(C);
-			}
-			
-		}
 	}
 }
 

--- a/BondageClub/Screens/Room/Shibari/Shibari.js
+++ b/BondageClub/Screens/Room/Shibari/Shibari.js
@@ -96,7 +96,11 @@ function ShibariRandomBondage(C, Level) {
 			InventoryGet(C, "ItemArms").Property = { Type: null };
 			if (Level == 1) InventoryGet(C, "ItemFeet").Property = { Type: "Suspension", SetPose: ["Suspension", "LegsClosed"], Difficulty: 0, Effect: [] };
 			if (Level == 2) InventoryGet(C, "ItemArms").Property = { Type: "Hogtied", SetPose: ["Hogtied"], Difficulty: 0, Block: ["ItemHands", "ItemLegs", "ItemFeet", "ItemBoots"], Effect: ["Block", "Freeze", "Prone"] };
-			if (Level == 3) InventoryGet(C, "ItemArms").Property = { Type: "SuspensionHogtied", SetPose: ["Hogtied", "SuspensionHogtied"], Block: ["ItemHands", "ItemLegs", "ItemFeet", "ItemBoots"], Difficulty: 0, Effect: ["Block", "Freeze", "Prone"] };
+			if (Level == 3) {
+				let SuspensionHogtiedProperty = InventoryItemArmsHempRopeOptions.find(O => O.Name == "SuspensionHogtied").Property;
+				SuspensionHogtiedProperty.Difficulty = 0;
+				InventoryGet(C, "ItemArms").Property = SuspensionHogtiedProperty;
+			}
 		}
 		CharacterRefresh(C);
 	}

--- a/BondageClub/Screens/Room/Shop/Shop.js
+++ b/BondageClub/Screens/Room/Shop/Shop.js
@@ -149,13 +149,15 @@ function ShopClick() {
 			if ((MouseX >= 500) && (MouseX < 1000) && (MouseY >= 0) && (MouseY < 1000))
 				for (let A = 0; A < AssetGroup.length; A++)
 					if ((AssetGroup[A].Category == "Item") && (AssetGroup[A].Zone != null))
-						for (let Z = 0; Z < AssetGroup[A].Zone.length; Z++)
-							if ((MouseX - 500 >= AssetGroup[A].Zone[Z][0]) && (MouseY >= AssetGroup[A].Zone[Z][1] - ShopVendor.HeightModifier) && (MouseX - 500 <= AssetGroup[A].Zone[Z][0] + AssetGroup[A].Zone[Z][2]) && (MouseY <= AssetGroup[A].Zone[Z][1] + AssetGroup[A].Zone[Z][3] - ShopVendor.HeightModifier)) {
+						for (let Z = 0; Z < AssetGroup[A].Zone.length; Z++) {
+							let YOffset = CharacterAppearanceYOffset(ShopVendor, 1);
+							if (DialogClickedInZone(ShopVendor, AssetGroup[A].Zone[Z], 1, 500, YOffset)) {
 								ShopItemOffset = 0;
 								ShopVendor.FocusGroup = AssetGroup[A];
 								ShopSelectAsset = ShopAssetFocusGroup;
 								ShopCartBuild();
 							}
+						}
 
 		// For each items in the assets with a value
 		var X = 1000;

--- a/BondageClub/Scripts/Asset.js
+++ b/BondageClub/Scripts/Asset.js
@@ -162,6 +162,7 @@ function AssetAdd(NewAsset) {
 		AllowLockType: NewAsset.AllowLockType,
 		AllowColorizeAll: typeof NewAsset.AllowColorizeAll === 'boolean' ? NewAsset.AllowColorizeAll : true,
 		AvailableLocations: NewAsset.AvailableLocations || [],
+		OverrideHeight: NewAsset.OverrideHeight,
 	}
 	A.Layer = AssetBuildLayer(NewAsset, A);
 	AssetAssignColorIndices(A);

--- a/BondageClub/Scripts/Character.js
+++ b/BondageClub/Scripts/Character.js
@@ -40,6 +40,7 @@ function CharacterReset(CharacterID, CharacterAssetFamily) {
 		HiddenItems: [],
 		WhiteList: [],
 		HeightModifier: 0,
+		HeightRatio: 1,
 		HasHiddenItems: false,
 		CanTalk: function () { return ((this.Effect.indexOf("GagVeryLight") < 0) && (this.Effect.indexOf("GagLight") < 0) && (this.Effect.indexOf("GagEasy") < 0) && (this.Effect.indexOf("GagNormal") < 0) && (this.Effect.indexOf("GagMedium") < 0) && (this.Effect.indexOf("GagHeavy") < 0) && (this.Effect.indexOf("GagVeryHeavy") < 0) && (this.Effect.indexOf("GagTotal") < 0) && (this.Effect.indexOf("GagTotal2") < 0) && (this.Effect.indexOf("GagTotal3") < 0) && (this.Effect.indexOf("GagTotal4") < 0)) },
 		CanWalk: function () { return ((this.Effect.indexOf("Freeze") < 0) && (this.Effect.indexOf("Tethered") < 0) && ((this.Pose == null) || (this.Pose.indexOf("Kneel") < 0) || (this.Effect.indexOf("KneelFreeze") < 0))) },
@@ -611,7 +612,7 @@ function CharacterLoadCanvas(C) {
 	C.AppearanceLayers = CharacterAppearanceSortLayers(C);
 
 	// Sets the total height modifier for that character
-	CharacterApperanceSetHeightModifier(C);
+	CharacterAppearanceSetHeightModifiers(C);
 	
 	// Reload the canvas
 	CharacterAppearanceBuildCanvas(C);

--- a/BondageClub/Scripts/CommonDraw.js
+++ b/BondageClub/Scripts/CommonDraw.js
@@ -45,13 +45,13 @@ function CommonDrawCanvasPrepare(C) {
 	if (C.Canvas == null) {
 		C.Canvas = document.createElement("canvas");
 		C.Canvas.width = 500;
-		C.Canvas.height = 1000;
-	} else C.Canvas.getContext("2d").clearRect(0, 0, 500, 1000);
+		C.Canvas.height = CanvasDrawHeight;
+	} else C.Canvas.getContext("2d").clearRect(0, 0, 500, CanvasDrawHeight);
 	if (C.CanvasBlink == null) {
 		C.CanvasBlink = document.createElement("canvas");
 		C.CanvasBlink.width = 500;
-		C.CanvasBlink.height = 1000;
-	} else C.CanvasBlink.getContext("2d").clearRect(0, 0, 500, 1000);
+		C.CanvasBlink.height = CanvasDrawHeight;
+	} else C.CanvasBlink.getContext("2d").clearRect(0, 0, 500, CanvasDrawHeight);
 
 	C.MustDraw = true;
 }
@@ -118,8 +118,8 @@ function CommonDrawAppearanceBuild(C, {
 			if ((!AlphaDef.Group || !AlphaDef.Group.length) &&
 				(!AlphaDef.Pose || !Array.isArray(AlphaDef.Pose) || !!CommonDrawFindPose(C, AlphaDef.Pose))) {
 				AlphaDef.Masks.forEach(rect => {
-					clearRect(rect[0], rect[1], rect[2], rect[3]);
-					clearRectBlink(rect[0], rect[1], rect[2], rect[3]);
+					clearRect(rect[0], rect[1] + CanvasUpperOverflow, rect[2], rect[3]);
+					clearRectBlink(rect[0], rect[1] + CanvasUpperOverflow, rect[2], rect[3]);
 				});
 			}
 		});
@@ -226,13 +226,17 @@ function CommonDrawAppearanceBuild(C, {
 			}
 		}
 
+		// Make any required changes to the colour
 		if (Color === "Default" && A.DefaultColor) {
 			Color = Array.isArray(A.DefaultColor) ? A.DefaultColor[Layer.ColorIndex] : A.DefaultColor;
 		}
-
 		if (!ColorInterited && !CommonDrawColorValid(Color, AG)) {
 			Color = "Default";
 		}
+
+		// Adjust for the increased canvas size
+		Y += CanvasUpperOverflow;
+		AlphaMasks = AlphaMasks.map(([x, y, w, h]) => [x, y + CanvasUpperOverflow, w, h]);
 
 		// Draw the item on the canvas (default or empty means no special color, # means apply a color, regular text means we apply that text)
 		if ((Color != null) && (Color.indexOf("#") == 0) && Layer.AllowColorize) {

--- a/BondageClub/Scripts/Dialog.js
+++ b/BondageClub/Scripts/Dialog.js
@@ -1234,8 +1234,7 @@ function DialogClick() {
 		for (let A = 0; A < AssetGroup.length; A++)
 			if ((AssetGroup[A].Category == "Item") && (AssetGroup[A].Zone != null))
 				for (let Z = 0; Z < AssetGroup[A].Zone.length; Z++)
-					if (((C.Pose.indexOf("Suspension") < 0) && (MouseX - X >= ((AssetGroup[A].Zone[Z][0] * HeightRatio) + XOffset)) && (MouseY >= (((AssetGroup[A].Zone[Z][1] - C.HeightModifier) * HeightRatio) + YOffset)) && (MouseX - X <= (((AssetGroup[A].Zone[Z][0] + AssetGroup[A].Zone[Z][2]) * HeightRatio) + XOffset)) && (MouseY <= (((AssetGroup[A].Zone[Z][1] + AssetGroup[A].Zone[Z][3] - C.HeightModifier) * HeightRatio) + YOffset)))
-						|| ((C.Pose.indexOf("Suspension") >= 0) && (MouseX - X >= ((AssetGroup[A].Zone[Z][0] * HeightRatio) + XOffset)) && (MouseY >= HeightRatio * ((1000 - (AssetGroup[A].Zone[Z][1] + AssetGroup[A].Zone[Z][3])) - C.HeightModifier)) && (MouseX - X <= (((AssetGroup[A].Zone[Z][0] + AssetGroup[A].Zone[Z][2]) * HeightRatio) + XOffset)) && (MouseY <= HeightRatio * (1000 - ((AssetGroup[A].Zone[Z][1])) - C.HeightModifier)))) {
+					if (DialogClickedInZone(C, AssetGroup[A].Zone[Z], C.HeightRatio, X, Y)) {
 						C.FocusGroup = AssetGroup[A];
 						DialogItemToLock = null;
 						DialogFocusItem = null;
@@ -1364,6 +1363,23 @@ function DialogClick() {
 			DialogSelfMenuSelected.Click();
 	}
 
+}
+
+/**
+ * Returns whether the clicked co-ordinates are inside the asset zone
+ * @param {Character} C - The character the click is on
+ * @param {Array} Zone - The 4 part array of the rectangular asset zone on the character's body: [X, Y, Width, Height]
+ * @param {number} X - The X co-ordinate of the click
+ * @param {number} Y - The Y co-ordinate of the click
+ * @param {number} Zoom - The amount the character has been zoomed
+ * @returns {boolean} - If TRUE the click is inside the zone
+ */
+function DialogClickedInZone(C, Zone, Zoom, X, Y) {
+	let Left = X + Zone[0] * Zoom;
+	let Top = C.Pose.indexOf("Suspension") >= 0 ? 1000 - (Y + (Zone[1] + Zone[3]) * Zoom) : Y + Zone[1] * Zoom;
+	let Width = Zone[2] * Zoom;
+	let Height = Zone[3] * Zoom;
+	return MouseIn(Left, Top, Width, Height);
 }
 
 /**

--- a/BondageClub/Scripts/Dialog.js
+++ b/BondageClub/Scripts/Dialog.js
@@ -1229,11 +1229,8 @@ function DialogClick() {
 		DialogLeaveItemMenu();
 		DialogLeaveFocusItem();
 		var C = (MouseX < 500) ? Player : CurrentCharacter;
-		var X = (MouseX < 500) ? 0 : 500;
-		var HeightRatio = CharacterAppearanceGetCurrentValue(C, "Height", "Zoom");
-		if ((Player != null) && (Player.VisualSettings != null) && (Player.VisualSettings.ForceFullHeight != null) && Player.VisualSettings.ForceFullHeight) HeightRatio = 1.0;
-		var XOffset = 500 * (1 - HeightRatio) / 2;
-		var YOffset = ((C.Pose.indexOf("Suspension") < 0) && (C.Pose.indexOf("SuspensionHogtied") < 0)) ? 1000 * (1 - HeightRatio) : 0;
+		let X = CharacterAppearanceXOffset(C, C.HeightRatio) + (MouseX < 500 ? 0 : 500);
+		let Y = CharacterAppearanceYOffset(C, C.HeightRatio);
 		for (let A = 0; A < AssetGroup.length; A++)
 			if ((AssetGroup[A].Category == "Item") && (AssetGroup[A].Zone != null))
 				for (let Z = 0; Z < AssetGroup[A].Zone.length; Z++)
@@ -1251,7 +1248,7 @@ function DialogClick() {
 	// If the user clicked anywhere outside the current character item zones, ensure the position is corrected
 	if (CharacterAppearanceForceUpCharacter == CurrentCharacter.MemberNumber && ((MouseX < 500) || (MouseX > 1000) || (CurrentCharacter.FocusGroup == null))) {
 		CharacterAppearanceForceUpCharacter = 0;
-		CharacterApperanceSetHeightModifier(CurrentCharacter);
+		CharacterAppearanceSetHeightModifiers(CurrentCharacter);
 	}
 
 	// In activity mode, we check if the user clicked on an activity box
@@ -1608,7 +1605,7 @@ function DialogDrawItemMenu(C) {
 			// Reset the the character's position
 			if (CharacterAppearanceForceUpCharacter == C.MemberNumber) {
 				CharacterAppearanceForceUpCharacter = 0;
-				CharacterApperanceSetHeightModifier(C);
+				CharacterAppearanceSetHeightModifiers(C);
 			}
 
 			// Rebuilds the menu

--- a/BondageClub/Scripts/Drawing.js
+++ b/BondageClub/Scripts/Drawing.js
@@ -258,14 +258,6 @@ function DrawCharacter(C, X, Y, Zoom, IsHeightResizeAllowed) {
 		var seconds = new Date().getTime();
 		var Canvas = (Math.round(seconds / 400) % C.BlinkFactor == 0) ? C.CanvasBlink : C.Canvas;
 
-		// Applies an offset to X and Y based on the HeightRatio.  If the player prefers full height, we always use 1.0
-		var HeightRatio = 1.0;
-		if ((IsHeightResizeAllowed == undefined) || IsHeightResizeAllowed) HeightRatio = CharacterAppearanceGetCurrentValue(C, "Height", "Zoom");
-		if ((Player != null) && (Player.VisualSettings != null) && (Player.VisualSettings.ForceFullHeight != null) && Player.VisualSettings.ForceFullHeight) HeightRatio = 1.0;
-		if (Zoom == null) Zoom = 1;
-		X += Zoom * Canvas.width * (1 - HeightRatio) / 2;
-		if ((C.Pose.indexOf("Suspension") < 0) && (C.Pose.indexOf("SuspensionHogtied") < 0)) Y += Zoom * Canvas.height * (1 - HeightRatio);
-
 		// If we must dark the Canvas characters
 		if ((C.ID != 0) && Player.IsBlind() && (CurrentScreen != "InformationSheet")) {
 			var CanvasH = document.createElement("canvas");
@@ -284,28 +276,34 @@ function DrawCharacter(C, X, Y, Zoom, IsHeightResizeAllowed) {
 		}
 
 		// If we must flip the canvas vertically
-		if (C.Pose.indexOf("Suspension") >= 0) {
+		let IsInverted = C.Pose.indexOf("Suspension") >= 0;
+		if (IsInverted) {
 			var CanvasH = document.createElement("canvas");
 			CanvasH.width = Canvas.width;
 			CanvasH.height = Canvas.height;
 			CanvasH.getContext("2d").rotate(Math.PI);
 			CanvasH.getContext("2d").translate(-Canvas.width, -Canvas.height);
 			// Render to the flipped canvas, and crop off the height modifier to prevent vertical overflow
-			CanvasH.getContext("2d").drawImage(Canvas, 0, 0, Canvas.width, Canvas.height - C.HeightModifier, 0, 0, Canvas.width, Canvas.height - C.HeightModifier);
+			CanvasH.getContext("2d").drawImage(Canvas, 0, 0, Canvas.width, Canvas.height, 0, 0, Canvas.width, Canvas.height);
 			Canvas = CanvasH;
 		}
 
-		// Draw the character and applies the zoom ratio, the canvas to draw can be shrunk based on the height modifier
-		Zoom *= HeightRatio;
-		var H = Canvas.height + (((C.HeightModifier != null) && (C.HeightModifier < 0)) ? C.HeightModifier : 0);
-		MainCanvas.drawImage(Canvas, 0, 0, Canvas.width, H, X, Y - (C.HeightModifier * Zoom), Canvas.width * Zoom, H * Zoom);
-
-		// Applies a Y offset if the character is suspended
-		if (C.Pose.indexOf("Suspension") >= 0) Y += (Zoom * Canvas.height * (1 - HeightRatio) / HeightRatio);
+		// Get the height ratio and X & Y offsets based on it
+		let HeightRatio = (IsHeightResizeAllowed == null || IsHeightResizeAllowed == true) ? C.HeightRatio : 1;
+		let XOffset = CharacterAppearanceXOffset(C, HeightRatio);
+		let YOffset = CharacterAppearanceYOffset(C, HeightRatio);
+		
+		// Calculate the vertical parameters, factoring in the character's height ratio, modifiers and the excess canvas overflow
+		let YStart = CanvasUpperOverflow - YOffset / HeightRatio;
+		let SourceHeight = 1000 / HeightRatio;
+		let SourceY = IsInverted ? Canvas.height - (YStart + SourceHeight) : YStart;
+		
+		// Draw the character into a 500x1000 space
+		MainCanvas.drawImage(Canvas, 0, SourceY, Canvas.width / HeightRatio, SourceHeight, X + XOffset * Zoom, Y, 500 * Zoom, 1000 * Zoom);
 
 		// Draw the arousal meter & game images on certain conditions
-		DrawArousalMeter(C, X - Zoom * Canvas.width * (1 - HeightRatio) / 2, Y - Zoom * Canvas.height * (1 - HeightRatio), Zoom / HeightRatio);
-		OnlineGameDrawCharacter(C, X - Zoom * Canvas.width * (1 - HeightRatio) / 2, Y - Zoom * Canvas.height * (1 - HeightRatio), Zoom / HeightRatio);
+		DrawArousalMeter(C, X, Y, Zoom);
+		OnlineGameDrawCharacter(C, X, Y, Zoom);
 		if (C.HasHiddenItems) DrawImageZoomCanvas("Screens/Character/Player/HiddenItem.png", MainCanvas, 0, 0, 86, 86, X + 54 * Zoom, Y + 880 * Zoom, 70 * Zoom, 70 * Zoom);
 
 		// Draws the character focus zones if we need too
@@ -317,18 +315,18 @@ function DrawCharacter(C, X, Y, Zoom, IsHeightResizeAllowed) {
 					var Color = "#80808040";
 					if (InventoryGroupIsBlocked(C, AssetGroup[A].Name)) Color = "#88000580";
 					else if (InventoryGet(C, AssetGroup[A].Name) != null) Color = "#D5A30080";
-					DrawAssetGroupZone(C, AssetGroup[A].Zone, HeightRatio, X, Y, Color, 5);
+					DrawAssetGroupZone(C, AssetGroup[A].Zone, HeightRatio * Zoom, X + XOffset * Zoom, Y + YOffset * Zoom, Color, 5);
 				}
 
 			// Draw the focused zone in cyan
-			DrawAssetGroupZone(C, C.FocusGroup.Zone, HeightRatio, X, Y, "cyan");
+			DrawAssetGroupZone(C, C.FocusGroup.Zone, HeightRatio * Zoom, X + XOffset * Zoom, Y + YOffset * Zoom, "cyan");
 		}
 
 		// Draw the character name below herself
 		if ((C.Name != "") && ((CurrentModule == "Room") || (CurrentModule == "Online") || ((CurrentScreen == "Wardrobe") && (C.ID != 0))) && (CurrentScreen != "Private"))
 			if (!Player.IsBlind() || (Player.GameplaySettings && Player.GameplaySettings.SensDepChatLog == "SensDepLight")) {
 				MainCanvas.font = CommonGetFont(30);
-				DrawText(C.Name, X + 255 * Zoom, Y + 980 * ((C.Pose.indexOf("SuspensionHogtied") < 0) ? Zoom : Zoom / HeightRatio), (CommonIsColor(C.LabelColor)) ? C.LabelColor : "White", "Black");
+				DrawText(C.Name, X + 255 * Zoom, Y + 980 * Zoom, (CommonIsColor(C.LabelColor)) ? C.LabelColor : "White", "Black");
 				MainCanvas.font = CommonGetFont(36);
 			}
 

--- a/BondageClub/Scripts/Drawing.js
+++ b/BondageClub/Scripts/Drawing.js
@@ -337,37 +337,24 @@ function DrawCharacter(C, X, Y, Zoom, IsHeightResizeAllowed) {
  * Draws an asset group zone outline over the character
  * @param {Character} C - Character for which to draw the zone
  * @param {number[][]} Zone - Zone to be drawn
- * @param {number} HeightRatio - Height ratio of the character
+ * @param {number} Zoom - Height ratio of the character
  * @param {number} X - Position of the character on the X axis
  * @param {number} Y - Position of the character on the Y axis
  * @param {string} Color - Color of the zone outline
  * @param {number} [Thickness=3] - Thickness of the outline
+ * @param {string} FillColor - If non-empty, the color to fill the rectangle with
  * @returns {void} - Nothing
  */
-function DrawAssetGroupZone(C, Zone, HeightRatio, X, Y, Color, Thickness = 3) {
-	for (let Z = 0; Z < Zone.length; Z++)
-		if (C.Pose.indexOf("Suspension") >= 0)
-			DrawEmptyRect((HeightRatio * Zone[Z][0]) + X, (1000 - (HeightRatio * (Zone[Z][1] + Y + Zone[Z][3]))) - C.HeightModifier, (HeightRatio * Zone[Z][2]), (HeightRatio * Zone[Z][3]), Color, Thickness);
-		else
-			DrawEmptyRect((HeightRatio * Zone[Z][0]) + X, HeightRatio * (Zone[Z][1] - C.HeightModifier) + Y, (HeightRatio * Zone[Z][2]), (HeightRatio * Zone[Z][3]), Color, Thickness);
-}
+function DrawAssetGroupZone(C, Zone, Zoom, X, Y, Color, Thickness = 3, FillColor) {
+	for (let Z = 0; Z < Zone.length; Z++) {
+		let Left = X + Zone[Z][0] * Zoom;
+		let Top = C.Pose.indexOf("Suspension") >= 0 ? 1000 - (Y + (Zone[Z][1] + Zone[Z][3]) * Zoom) : Y + Zone[Z][1] * Zoom;
+		let Width = Zone[Z][2] * Zoom;
+		let Height = Zone[Z][3] * Zoom;
 
-/**
- * Draws an asset group zone background over the character
- * @param {Character} C - Character for which to draw the zone
- * @param {number[][]} Zone - Zone to be drawn
- * @param {number} HeightRatio - Height ratio of the character
- * @param {number} X - Position of the character on the X axis
- * @param {number} Y - Position of the character on the Y axis
- * @param {string} Color - Color of the zone background
- * @returns {void} - Nothing
- */
-function DrawAssetGroupZoneBackground(C, Zone, HeightRatio, X, Y, Color) {
-	for (let Z = 0; Z < Zone.length; Z++)
-		if (C.Pose.indexOf("Suspension") >= 0)
-			DrawRect((HeightRatio * Zone[Z][0]) + X, (1000 - (HeightRatio * (Zone[Z][1] + Y + Zone[Z][3]))) - C.HeightModifier, (HeightRatio * Zone[Z][2]), (HeightRatio * Zone[Z][3]), Color);
-		else
-			DrawRect((HeightRatio * Zone[Z][0]) + X, HeightRatio * (Zone[Z][1] - C.HeightModifier) + Y, (HeightRatio * Zone[Z][2]), (HeightRatio * Zone[Z][3]), Color);
+		if (FillColor != null) DrawRect(Left, Top, Width, Height, FillColor);
+		DrawEmptyRect(Left, Top, Width, Height, Color, Thickness);
+	}
 }
 
 /**

--- a/BondageClub/Scripts/GLDraw.js
+++ b/BondageClub/Scripts/GLDraw.js
@@ -22,7 +22,7 @@ window.addEventListener('load', GLDrawLoad);
 function GLDrawLoad() {
     GLDrawCanvas = document.createElement("canvas");
     GLDrawCanvas.width = 1000;
-    GLDrawCanvas.height = 1000;
+    GLDrawCanvas.height = CanvasDrawHeight;
     GLVersion = "webgl2";
     var gl = GLDrawCanvas.getContext(GLVersion);
     if (!gl) { GLVersion = "webgl"; gl = GLDrawCanvas.getContext(GLVersion); }
@@ -76,7 +76,7 @@ function GLDrawInitCharacterCanvas(canvas) {
     if (canvas == null) {
         canvas = document.createElement("canvas");
         canvas.width = 1000;
-        canvas.height = 1000;
+        canvas.height = CanvasDrawHeight;
     }
     if (canvas.GL == null) {
         canvas.GL = canvas.getContext(GLVersion);
@@ -85,7 +85,7 @@ function GLDrawInitCharacterCanvas(canvas) {
             return GLDrawInitCharacterCanvas(null);
         }
     } else {
-        GLDrawClearRect(canvas.GL, 0, 0, 1000, 1000);
+        GLDrawClearRect(canvas.GL, 0, 0, 1000, CanvasDrawHeight);
     }
     if (canvas.GL.program == null) {
         GLDrawMakeGLProgam(canvas.GL);
@@ -468,7 +468,7 @@ function GLDrawHexToRGBA(color) {
  * @returns {void} - Nothing 
  */
 function GLDrawAppearanceBuild(C) {
-    GLDrawClearRect(GLDrawCanvas.GL, 0, 0, 1000, 1000);
+    GLDrawClearRect(GLDrawCanvas.GL, 0, 0, 1000, CanvasDrawHeight);
     CommonDrawCanvasPrepare(C);
     CommonDrawAppearanceBuild(C, {
 		clearRect: (x, y, w, h) => GLDrawClearRect(GLDrawCanvas.GL, x, 1000 - y - h, w, h),


### PR DESCRIPTION
### Overview
This makes a number of changes around the code that determines a character's vertical height and position. In two key ways in particular:
- Allowing assets to be drawn in space that's opened up when the character is shorter or in a low pose, which in the current system is unsuable.
- Refactoring many of the height/position calculations for easier re-use and expansion in upcoming developments.

I have a feature nearing completion to allow suspension hogties to be set at variable heights built using this, but I'm only pushing the core system rework for now to keep it (relatively) digestible. There should be **no noticeable changes to the game** from this PR, other than a few fixes. The new stuff will all follow separately.

### Points of Interest
#### Character Canvas Size
The height of the character canvas (Canvas and CanvasBlink) will be extended vertically from 1000 pixels to have an additional 600 above and 150 below. These values were chosen on the assumption the head should always be fully on-screen, and they approximately allow the full space to become available if the character is moved to the very top or very bottom (in a compressed pose!) of their space. It's a single variable change if they prove to be too much/little.
When the character is drawn onto the main canvas, the image is cropped and scaled down if needed to the usual 500 x 1000 dimensions.
The existing asset height settings are unaffected. The top-left of a full-sized character will still be considered the (0,0) co-ordinate. To draw something above their head, a negative Top setting can now be used.
Note: The original plan was to scale down assets as they were drawn onto the character canvas instead of increasing its size, but apparent limitations in WebGL scaling and canvas smoothing resulted in a slight loss in image quality.

#### Override Height Priorities
At the moment we rely on poses for fixed heights, which results in cases like the OverTheHead pose setting a height that's misaligned with other standing poses (to see this in action go to the pose menu and switch to OverTheHead). Override settings can now be supplied by assets and properties as well. 
A priority setting will be expected to allow the code to determine which height to prefer. This removes the currently needed hardcoded check for pose pairs that don't mix well (Kneel/Hogtied and Kneel/OverTheHead).

### Fixes
The following issues have been fixed by these changes:
- The appearance screen face zoom-in works properly for hogtie & allfours
- Large tails no longer cut-off for all-fours
- X-Cross no longer cut off at the top

### Future Benefits
To help justify this, the following contributions from myself and others are dependent on this rework (at least without relying on tricky workarounds):
- Suspended hogtie in mid-air, with the height configurable by the player
- Upside-down ties with different poses (e.g. hogtie)
- Vac-cubes
- Flipping the room for players upside-down
- Arm chains up to the ceiling
- Flippers (currently cut off at the bottom)
- Over-the-head misalignment when not in the X-cross

### Testing
To make sure the final visuals were unaffected, I tested for a variety of factors side-by-side at the same time using both this branch and the master.
Including but not limited to: height-affecting assets, height-affecting poses, short characters, the always-full size setting, the Up button, rooms of all sizes, alpha masks, single-player mini-games, both the WebGL and Appearance drawing methods.
I saw no discrepencies other than a few cases differing only by pixels where it was actually more accurate/consistent in the new system.