### PR TITLE
Bugfix: Fixes some font issues

### DIFF
--- a/BondageClub/Screens/MiniGame/Kidnap/Kidnap.js
+++ b/BondageClub/Screens/MiniGame/Kidnap/Kidnap.js
@@ -378,7 +378,7 @@ function KidnapDrawMoveUpperHand() {
 function KidnapShowTimer() {
 	if ((KidnapMode == "SelectItem") || (KidnapMode == "SelectMove") || (KidnapMode == "UpperHand") || (KidnapMode == "ShowMove")) {
 		var Sec = Math.floor((KidnapTimer - CommonTime() + 1000) / 1000);
-		MainCanvas.font = "italic " + CommonGetFont(200) + " Narrow";
+		MainCanvas.font = "italic 300 " + CommonGetFont(200);
 		DrawText(Sec.toString(), (KidnapMode == "SelectItem") ? 500 : 1000, 500, (Sec <= 3) ? "red" : "white", "black");
 		MainCanvas.font = CommonGetFont(36);
 	}
@@ -390,7 +390,7 @@ function KidnapShowTimer() {
  * @returns {void} - Nothing
  */
 function KidnapTitle(Title) {
-	MainCanvas.font = "italic " + CommonGetFont(200) + " Narrow";
+	MainCanvas.font = "italic 300 " + CommonGetFont(200);
 	DrawText(Title, 1003, 503, "White");
 	DrawText(Title, 997, 497, "Red");
 	MainCanvas.font = CommonGetFont(36);

--- a/BondageClub/Scripts/Common.js
+++ b/BondageClub/Scripts/Common.js
@@ -442,15 +442,14 @@ function CommonDebounce(func, wait) {
  */
 function CommonMemoize(func) {
 	var memo = {};
-	var slice = Array.prototype.slice;
 
 	var memoized = function () {
 		var index = [];
 		for (var i = 0; i < arguments.length; i++) {
-			if (typeof arguments[i] === "object") {
+			if (typeof arguments[i] !== "object") {
 				index.push(JSON.stringify(arguments[i]));
 			} else {
-				index.push(slice.call(arguments[i]));
+				index.push(String(arguments[i]));
 			}
 		} // for
 		if (!(index in memo)) {

--- a/BondageClub/Scripts/Common.js
+++ b/BondageClub/Scripts/Common.js
@@ -446,7 +446,7 @@ function CommonMemoize(func) {
 	var memoized = function () {
 		var index = [];
 		for (var i = 0; i < arguments.length; i++) {
-			if (typeof arguments[i] !== "object") {
+			if (typeof arguments[i] === "object") {
 				index.push(JSON.stringify(arguments[i]));
 			} else {
 				index.push(String(arguments[i]));


### PR DESCRIPTION
## Summary

This fixes two font issues:
1. Fonts were not cached correctly when calling `CommonGetFont()` due to a bug with number arguments in `CommonMemoize`
2. The Kidnap minigame used to use the "Arial Narrow" font, which is a completely separate font, meaning `CommonGetFont()` would have " Narrow" appended to its result, which would not work. I've emulated this for generalised fonts as well as possible by changing the font weight to 300 (light) for those instances. It won't reproduce the previous look when using Arial exactly, but it will be consistent with the player's preferred font choice.