### PR TITLE
Fix softlock when disconnected during login

### DIFF
--- a/BondageClub/Scripts/Server.js
+++ b/BondageClub/Scripts/Server.js
@@ -68,6 +68,7 @@ function ServerSetConnected(connected, errorMessage) {
 		LoginErrorMessage = "";
 	} else {
 		LoginErrorMessage = errorMessage || "";
+		LoginSubmitted = false;
 	}
 	LoginUpdateMessage();
 }


### PR DESCRIPTION
Properly clears the `LoginSubmitted` flag on server disconnect to avoid softlock when server crashes during player's (re)login.
( Also server disconnects are properly shown instead of "Validating name and password" )