### PR TITLE
Height Rework Fixes

### DIFF
--- a/BondageClub/Screens/Character/Appearance/Appearance.js
+++ b/BondageClub/Screens/Character/Appearance/Appearance.js
@@ -19,7 +19,7 @@ var CharacterAppearancePreviousEmoticon = "";
 var CharacterAppearanceMode = "";
 var CharacterAppearanceCloth = null;
 
-const CanvasUpperOverflow = 600;
+const CanvasUpperOverflow = 700;
 const CanvasLowerOverflow = 150;
 const CanvasDrawHeight = 1000 + CanvasUpperOverflow + CanvasLowerOverflow;
 

--- a/BondageClub/Screens/Character/Preference/Preference.js
+++ b/BondageClub/Screens/Character/Preference/Preference.js
@@ -908,13 +908,13 @@ function PreferenceSubscreenArousalRun() {
 		// Draws all the available character zones
 		for (let A = 0; A < AssetGroup.length; A++)
 			if ((AssetGroup[A].Zone != null) && (AssetGroup[A].Activity != null))
-				DrawAssetGroupZone(Player, AssetGroup[A].Zone, 0.9, 50, 50, "#808080FF", 3, PreferenceGetFactorColor(PreferenceGetZoneFactor(Player, AssetGroup[A].Name)));
+				DrawAssetGroupZone(Player, AssetGroup[A].Zone, 0.9, 50, 50, 1, "#808080FF", 3, PreferenceGetFactorColor(PreferenceGetZoneFactor(Player, AssetGroup[A].Name)));
 
 		// The zones can be selected and drawn on the character
 		if (Player.FocusGroup != null) {
 			DrawCheckbox(1230, 813, 64, 64, TextGet("ArousalAllowOrgasm"), PreferenceGetZoneOrgasm(Player, Player.FocusGroup.Name));
 			DrawText(TextGet("ArousalZone" + Player.FocusGroup.Name) + " - " + TextGet("ArousalConfigureErogenousZones"), 550, 745, "Black", "Gray");
-			DrawAssetGroupZone(Player, Player.FocusGroup.Zone, 0.9, 50, 50, "cyan");
+			DrawAssetGroupZone(Player, Player.FocusGroup.Zone, 0.9, 50, 50, 1, "cyan");
 			MainCanvas.textAlign = "center";
 			DrawBackNextButton(550, 813, 600, 64, TextGet("ArousalZoneLove" + PreferenceArousalZoneFactor), PreferenceGetFactorColor(PreferenceGetZoneFactor(Player, Player.FocusGroup.Name)), "", () => "", () => "");
 			Player.FocusGroup
@@ -1243,7 +1243,7 @@ function PreferenceSubscreenArousalClick() {
 		for (let A = 0; A < AssetGroup.length; A++)
 			if ((AssetGroup[A].Zone != null) && (AssetGroup[A].Activity != null))
 				for (let Z = 0; Z < AssetGroup[A].Zone.length; Z++)
-					if (DialogClickedInZone(Player, AssetGroup[A].Zone[Z], 0.9, 50, 50)) {
+					if (DialogClickedInZone(Player, AssetGroup[A].Zone[Z], 0.9, 50, 50, 1)) {
 						Player.FocusGroup = AssetGroup[A];
 						PreferenceArousalZoneFactor = PreferenceGetZoneFactor(Player, AssetGroup[A].Name);
 					}

--- a/BondageClub/Screens/Room/Shop/Shop.js
+++ b/BondageClub/Screens/Room/Shop/Shop.js
@@ -150,8 +150,7 @@ function ShopClick() {
 				for (let A = 0; A < AssetGroup.length; A++)
 					if ((AssetGroup[A].Category == "Item") && (AssetGroup[A].Zone != null))
 						for (let Z = 0; Z < AssetGroup[A].Zone.length; Z++) {
-							let YOffset = CharacterAppearanceYOffset(ShopVendor, 1);
-							if (DialogClickedInZone(ShopVendor, AssetGroup[A].Zone[Z], 1, 500, YOffset)) {
+							if (DialogClickedInZone(ShopVendor, AssetGroup[A].Zone[Z], 1, 500, 0, 1)) {
 								ShopItemOffset = 0;
 								ShopVendor.FocusGroup = AssetGroup[A];
 								ShopSelectAsset = ShopAssetFocusGroup;

--- a/BondageClub/Scripts/Dialog.js
+++ b/BondageClub/Scripts/Dialog.js
@@ -1229,12 +1229,11 @@ function DialogClick() {
 		DialogLeaveItemMenu();
 		DialogLeaveFocusItem();
 		var C = (MouseX < 500) ? Player : CurrentCharacter;
-		let X = CharacterAppearanceXOffset(C, C.HeightRatio) + (MouseX < 500 ? 0 : 500);
-		let Y = CharacterAppearanceYOffset(C, C.HeightRatio);
+		let X = MouseX < 500 ? 0 : 500;
 		for (let A = 0; A < AssetGroup.length; A++)
 			if ((AssetGroup[A].Category == "Item") && (AssetGroup[A].Zone != null))
 				for (let Z = 0; Z < AssetGroup[A].Zone.length; Z++)
-					if (DialogClickedInZone(C, AssetGroup[A].Zone[Z], C.HeightRatio, X, Y)) {
+					if (DialogClickedInZone(C, AssetGroup[A].Zone[Z], 1, X, 0, C.HeightRatio)) {
 						C.FocusGroup = AssetGroup[A];
 						DialogItemToLock = null;
 						DialogFocusItem = null;
@@ -1369,17 +1368,37 @@ function DialogClick() {
  * Returns whether the clicked co-ordinates are inside the asset zone
  * @param {Character} C - The character the click is on
  * @param {Array} Zone - The 4 part array of the rectangular asset zone on the character's body: [X, Y, Width, Height]
+ * @param {number} Zoom - The amount the character has been zoomed
  * @param {number} X - The X co-ordinate of the click
  * @param {number} Y - The Y co-ordinate of the click
- * @param {number} Zoom - The amount the character has been zoomed
+ * @param {number} HeightRatio - The displayed height ratio of the character
  * @returns {boolean} - If TRUE the click is inside the zone
  */
-function DialogClickedInZone(C, Zone, Zoom, X, Y) {
+function DialogClickedInZone(C, Zone, Zoom, X, Y, HeightRatio) {
+	let CZ = DialogGetCharacterZone(C, Zone, X, Y, Zoom, HeightRatio);
+	return MouseIn(CZ[0], CZ[1], CZ[2], CZ[3]);
+}
+
+/**
+ * Return the co-ordinates and dimensions of the asset group zone as it appears on screen
+ * @param {Character} C - The character the zone is calculated for
+ * @param {Array} Zone - The 4 part array of the rectangular asset zone: [X, Y, Width, Height]
+ * @param {number} X - The starting X co-ordinate of the character's position
+ * @param {number} Y - The starting Y co-ordinate of the character's position
+ * @param {number} Zoom - The amount the character has been zoomed
+ * @param {number} HeightRatio - The displayed height ratio of the character
+ * @returns {Array} - The 4 part array of the displayed rectangular asset zone: [X, Y, Width, Height]
+ */
+function DialogGetCharacterZone(C, Zone, X, Y, Zoom, HeightRatio) {
+	X += CharacterAppearanceXOffset(C, HeightRatio) * Zoom;
+	Y += CharacterAppearanceYOffset(C, HeightRatio) * Zoom;
+	Zoom *= HeightRatio;
+
 	let Left = X + Zone[0] * Zoom;
 	let Top = CharacterAppearsInverted(C) ? 1000 - (Y + (Zone[1] + Zone[3]) * Zoom) : Y + Zone[1] * Zoom;
 	let Width = Zone[2] * Zoom;
 	let Height = Zone[3] * Zoom;
-	return MouseIn(Left, Top, Width, Height);
+	return [Left, Top, Width, Height];
 }
 
 /**

--- a/BondageClub/Scripts/Drawing.js
+++ b/BondageClub/Scripts/Drawing.js
@@ -293,13 +293,15 @@ function DrawCharacter(C, X, Y, Zoom, IsHeightResizeAllowed) {
 		let XOffset = CharacterAppearanceXOffset(C, HeightRatio);
 		let YOffset = CharacterAppearanceYOffset(C, HeightRatio);
 		
-		// Calculate the vertical parameters, factoring in the character's height ratio, modifiers and the excess canvas overflow
-		let YStart = CanvasUpperOverflow - YOffset / HeightRatio;
-		let SourceHeight = 1000 / HeightRatio;
+		// Calculate the vertical parameters. In certain cases, cut off anything above the Y value.
+		let YCutOff = YOffset >= 0 || CurrentScreen == "ChatRoom";
+		let YStart = CanvasUpperOverflow + (YCutOff ? -YOffset / HeightRatio : 0);
+		let SourceHeight = 1000 / HeightRatio + (YCutOff ? 0 : -YOffset / HeightRatio);
 		let SourceY = IsInverted ? Canvas.height - (YStart + SourceHeight) : YStart;
-		
-		// Draw the character into a 500x1000 space
-		MainCanvas.drawImage(Canvas, 0, SourceY, Canvas.width / HeightRatio, SourceHeight, X + XOffset * Zoom, Y, 500 * Zoom, 1000 * Zoom);
+		let DestY = (IsInverted || YCutOff) ? 0 : YOffset;
+
+		// Draw the character
+		MainCanvas.drawImage(Canvas, 0, SourceY, Canvas.width / HeightRatio, SourceHeight, X + XOffset * Zoom, Y + DestY * Zoom, 500 * Zoom, (1000 - DestY) * Zoom);
 
 		// Draw the arousal meter & game images on certain conditions
 		DrawArousalMeter(C, X, Y, Zoom);

--- a/BondageClub/Scripts/Drawing.js
+++ b/BondageClub/Scripts/Drawing.js
@@ -317,11 +317,11 @@ function DrawCharacter(C, X, Y, Zoom, IsHeightResizeAllowed) {
 					var Color = "#80808040";
 					if (InventoryGroupIsBlocked(C, AssetGroup[A].Name)) Color = "#88000580";
 					else if (InventoryGet(C, AssetGroup[A].Name) != null) Color = "#D5A30080";
-					DrawAssetGroupZone(C, AssetGroup[A].Zone, HeightRatio * Zoom, X + XOffset * Zoom, Y + YOffset * Zoom, Color, 5);
+					DrawAssetGroupZone(C, AssetGroup[A].Zone, Zoom, X, Y, HeightRatio, Color, 5);
 				}
 
 			// Draw the focused zone in cyan
-			DrawAssetGroupZone(C, C.FocusGroup.Zone, HeightRatio * Zoom, X + XOffset * Zoom, Y + YOffset * Zoom, "cyan");
+			DrawAssetGroupZone(C, C.FocusGroup.Zone, Zoom, X, Y, HeightRatio, "cyan");
 		}
 
 		// Draw the character name below herself
@@ -342,20 +342,18 @@ function DrawCharacter(C, X, Y, Zoom, IsHeightResizeAllowed) {
  * @param {number} Zoom - Height ratio of the character
  * @param {number} X - Position of the character on the X axis
  * @param {number} Y - Position of the character on the Y axis
+ * @param {number} HeightRatio - The displayed height ratio of the character
  * @param {string} Color - Color of the zone outline
  * @param {number} [Thickness=3] - Thickness of the outline
  * @param {string} FillColor - If non-empty, the color to fill the rectangle with
  * @returns {void} - Nothing
  */
-function DrawAssetGroupZone(C, Zone, Zoom, X, Y, Color, Thickness = 3, FillColor) {
+function DrawAssetGroupZone(C, Zone, Zoom, X, Y, HeightRatio, Color, Thickness = 3, FillColor) {
 	for (let Z = 0; Z < Zone.length; Z++) {
-		let Left = X + Zone[Z][0] * Zoom;
-		let Top = CharacterAppearsInverted(C) ? 1000 - (Y + (Zone[Z][1] + Zone[Z][3]) * Zoom) : Y + Zone[Z][1] * Zoom;
-		let Width = Zone[Z][2] * Zoom;
-		let Height = Zone[Z][3] * Zoom;
+		let CZ = DialogGetCharacterZone(C, Zone[Z], X, Y, Zoom, HeightRatio);
 
-		if (FillColor != null) DrawRect(Left, Top, Width, Height, FillColor);
-		DrawEmptyRect(Left, Top, Width, Height, Color, Thickness);
+		if (FillColor != null) DrawRect(CZ[0], CZ[1], CZ[2], CZ[3], FillColor);
+		DrawEmptyRect(CZ[0], CZ[1], CZ[2], CZ[3], Color, Thickness);
 	}
 }
 

--- a/BondageClub/Scripts/GLDraw.js
+++ b/BondageClub/Scripts/GLDraw.js
@@ -471,8 +471,8 @@ function GLDrawAppearanceBuild(C) {
     GLDrawClearRect(GLDrawCanvas.GL, 0, 0, 1000, CanvasDrawHeight);
     CommonDrawCanvasPrepare(C);
     CommonDrawAppearanceBuild(C, {
-		clearRect: (x, y, w, h) => GLDrawClearRect(GLDrawCanvas.GL, x, 1000 - y - h, w, h),
-		clearRectBlink: (x, y, w, h) => GLDrawClearRectBlink(GLDrawCanvas.GL, x, 1000 - y - h, w, h),
+		clearRect: (x, y, w, h) => GLDrawClearRect(GLDrawCanvas.GL, x, CanvasDrawHeight - y - h, w, h),
+		clearRectBlink: (x, y, w, h) => GLDrawClearRectBlink(GLDrawCanvas.GL, x, CanvasDrawHeight - y - h, w, h),
 		drawImage: (src, x, y, alphaMasks) => GLDrawImage(src, GLDrawCanvas.GL, x, y, 0, null, null, alphaMasks),
 		drawImageBlink: (src, x, y, alphaMasks) => GLDrawImageBlink(src, GLDrawCanvas.GL, x, y, null, null, alphaMasks),
 		drawImageColorize: (src, x, y, color, fullAlpha, alphaMasks) => GLDrawImage(src, GLDrawCanvas.GL, x, y, 0, color, fullAlpha, alphaMasks),


### PR DESCRIPTION
1. In rare cases when a character is particularly tall (for example is max height, wearing tall boots and has a ponytail), a portion of the top of their head would not be displayed. This cutoff was intentional so that ceiling restraints in the lower row of a chatroom would not spill up onto the upper row. However outside of chatrooms, there are cases where there is no 'ceiling' and we'd rather always display the character in full. The DrawCharacter calculations have been enhanced to make sure it only applies this cutoff where it needs to.
2. The asset zones in the arousal preferences screen were sometimes not lining up with the character. The zone functions have been corrected and further refactored.
3. Full-body alpha masks for WebGL drawing were misaligned. Now corrected.

I've redone the full set of parellel tests: poses, character heights, chatroom sizes, all NPC rooms, private rooms, assets of all types, etc. Also the new ceiling chains. The issues have been fixed and everything else still looks good.
