### PR TITLE
Hands Missing Fix

### DIFF
--- a/BondageClub/Assets/Female3DCG/Female3DCG.js
+++ b/BondageClub/Assets/Female3DCG/Female3DCG.js
@@ -1216,7 +1216,8 @@ var AssetFemale3DCG = [
 		AllowCustomize: false,
 		AllowPose: ["TapedHands", "BackBoxTie", "BackCuffs", "BackElbowTouch", "AllFours"],
 		Asset: ["Default"],
-		InheritColor: "BodyUpper"
+		InheritColor: "BodyUpper",
+		Color: ["Default", "White", "Asian", "Black"],
 	},
 	
 	{

--- a/BondageClub/Scripts/CommonDraw.js
+++ b/BondageClub/Scripts/CommonDraw.js
@@ -168,13 +168,13 @@ function CommonDrawAppearanceBuild(C, {
 
 		// Check if we need to copy the color of another asset
 		let InheritColor = (Color == "Default" ? (Layer.InheritColor || A.InheritColor || AG.InheritColor) : null);
-		let ColorInterited = false;
+		let ColorInherited = false;
 		if (InheritColor != null) {
 			var ParentAsset = InventoryGet(C, InheritColor);
 			if (ParentAsset != null) {
 				let ParentColor = Array.isArray(ParentAsset.Color) ? ParentAsset.Color[0] : ParentAsset.Color;
 				Color = CommonDrawColorValid(ParentColor, ParentAsset.Asset.Group) ? ParentColor : "Default";
-				ColorInterited = true;
+				ColorInherited = true;
 			}
 		}
 		
@@ -230,7 +230,7 @@ function CommonDrawAppearanceBuild(C, {
 		if (Color === "Default" && A.DefaultColor) {
 			Color = Array.isArray(A.DefaultColor) ? A.DefaultColor[Layer.ColorIndex] : A.DefaultColor;
 		}
-		if (!ColorInterited && !CommonDrawColorValid(Color, AG)) {
+		if (!ColorInherited && !CommonDrawColorValid(Color, AG)) {
 			Color = "Default";
 		}
 


### PR DESCRIPTION
Adding the colour schema in for Hands, so that they pass validation and don't disappear.
While this shouldn't be necessary, since they're hidden from the player and should only need Default + InheritColor from BodyUpper, all saved wardrobe outfits created back when Hands were editable will have them saved as Color = White/Asian/Black, meaning the schema is needed.