### PR TITLE
DrawCharacter on iOS fix

### DIFF
--- a/BondageClub/Scripts/Drawing.js
+++ b/BondageClub/Scripts/Drawing.js
@@ -301,7 +301,7 @@ function DrawCharacter(C, X, Y, Zoom, IsHeightResizeAllowed) {
 		let DestY = (IsInverted || YCutOff) ? 0 : YOffset;
 
 		// Draw the character
-		MainCanvas.drawImage(Canvas, 0, SourceY, Canvas.width / HeightRatio, SourceHeight, X + XOffset * Zoom, Y + DestY * Zoom, 500 * Zoom, (1000 - DestY) * Zoom);
+		MainCanvas.drawImage(Canvas, 0, SourceY, Canvas.width, SourceHeight, X + XOffset * Zoom, Y + DestY * Zoom, 500 * HeightRatio * Zoom, (1000 - DestY) * Zoom);
 
 		// Draw the arousal meter & game images on certain conditions
 		DrawArousalMeter(C, X, Y, Zoom);


### PR DESCRIPTION
A small fix to the new drawing method for how the width is calculated so that the height ratio is applied to the destination width instead of the source width. It worked fine on most browsers but on iOS using a source width greater than the canvas width failed to draw.