### PR TITLE
Auto-Remake rooms now remakes private, adding player as admin

### DIFF
--- a/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
+++ b/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
@@ -563,9 +563,9 @@ function ChatRoomRun() {
 	
 	// Set the admins of the new room
 	if (Player.ImmersionSettings && ChatRoomData && Player.ImmersionSettings.ReturnToChatRoomAdmin && Player.ImmersionSettings.ReturnToChatRoom && Player.LastChatRoomAdmin && ChatRoomNewRoomToUpdate) {
-		/*if (Player.LastChatRoomAdmin.indexOf(Player.MemberNumber) < 0) { // Add the player if they are not an admin
+		if (Player.LastChatRoomAdmin.indexOf(Player.MemberNumber) < 0 && Player.LastChatRoomPrivate) { // Add the player if they are not an admin
 			Player.LastChatRoomAdmin.push(Player.MemberNumber)
-		}*/
+		}
 		var UpdatedRoom = {
 			Name: Player.LastChatRoom,
 			Description: Player.LastChatRoomDesc,
@@ -575,7 +575,7 @@ function ChatRoomRun() {
 			Ban: ChatRoomData.Ban,
 			BlockCategory: ChatRoomData.BlockCategory,
 			Game: ChatRoomData.Game,
-			Private: ChatRoomData.Private,
+			Private: Player.LastChatRoomPrivate,
 			Locked: ChatRoomData.Locked
 		};
 		ServerSend("ChatRoomAdmin", { MemberNumber: Player.ID, Room: UpdatedRoom, Action: "Update" });

--- a/BondageClub/Screens/Online/ChatSearch/ChatSearch.js
+++ b/BondageClub/Screens/Online/ChatSearch/ChatSearch.js
@@ -402,18 +402,19 @@ function ChatSearchResultResponse(data) {
 				var block = []
 				var ChatRoomName = Player.LastChatRoom;
 				var ChatRoomDesc = Player.LastChatRoomDesc;
-				if (Player.LastChatRoomPrivate) {
+				/*if (Player.LastChatRoomPrivate) {
 					ChatRoomName = Player.Name + Player.MemberNumber
 					ChatRoomDesc = ""
-				} else if (roomIsFull) {
-					ChatRoomName = ChatRoomName + Player.MemberNumber
+				} else*/
+				if (roomIsFull) {
+					ChatRoomName = ChatRoomName.substring(0, Math.min(ChatRoomName.length, 16)) + Math.floor(1+Math.random() * 998); // Added 
 				}
 				if (ChatBlockItemCategory) block = ChatBlockItemCategory
 				var NewRoom = {
 					Name: ChatRoomName.trim(),
 					Description: ChatRoomDesc.trim(),
 					Background: Player.LastChatRoomBG,
-					Private: false,
+					Private: Player.LastChatRoomPrivate,
 					Space: "",
 					Game: "",
 					Admin: [Player.MemberNumber],


### PR DESCRIPTION
Due to this:
https://cdn.discordapp.com/attachments/797897462694019093/798246477809057872/unknown.png

It became pretty clear that remaking private rooms as public will lead to a lot of spam (and also players being separated!). So instead of remaking them as public, they are instead remade as private with the caveat that the remaker is now an admin. So they can change the room parameters if they want to make it public, or choose to stay private, respecting people's wishes.

This has the side effect of making players less helpless, as the admin player can always make a private room public, wait for people to join, lock the room, and then F5 (since players cannot rejoin a locked room), but this was always possible if you were the room creator in the first place. It was also possible to use an alt account to get out of a solo room this way before.

The player is not made an admin after rejoining a public room