### PR TITLE
Feature/Beta Fix: Adds a "reset to default" button to the color picker

### DIFF
--- a/BondageClub/Screens/Character/Appearance/Appearance.js
+++ b/BondageClub/Screens/Character/Appearance/Appearance.js
@@ -612,7 +612,7 @@ function AppearanceRun() {
 		// Leave the color picker if the item is gone.
 		if (!InventoryGet(CharacterAppearanceSelection, CharacterAppearanceColorPickerGroupName)) ItemColorCancelAndExit();
 		// Draw the color picker
-	    ItemColorDraw(CharacterAppearanceSelection, CharacterAppearanceColorPickerGroupName, 1300, 25, 675, 950);
+	    ItemColorDraw(CharacterAppearanceSelection, CharacterAppearanceColorPickerGroupName, 1200, 25, 775, 950, true);
 	}
 
 	// In cloth selection mode
@@ -872,7 +872,7 @@ function AppearanceClick() {
 							CharacterAppearanceColorPickerGroupName = AssetGroup[A].Name;
 							CharacterAppearanceColorPickerBackup =
 								CharacterAppearanceGetCurrentValue(C, CharacterAppearanceColorPickerGroupName, "Color");
-							ItemColorLoad(C, Item, 1300, 25, 675, 950);
+							ItemColorLoad(C, Item, 1200, 25, 775, 950, true);
 							ItemColorOnExit(() => CharacterAppearanceMode = "");
 						}
 					}
@@ -927,7 +927,7 @@ function AppearanceClick() {
 
 	// In item coloring mode
 	if (CharacterAppearanceMode == "Color") {
-		ItemColorClick(CharacterAppearanceSelection, CharacterAppearanceColorPickerGroupName, 1300, 25, 675, 950);
+		ItemColorClick(CharacterAppearanceSelection, CharacterAppearanceColorPickerGroupName, 1200, 25, 775, 950, true);
 	}
 
 	// In cloth selection mode

--- a/BondageClub/Scripts/ColorPicker.js
+++ b/BondageClub/Scripts/ColorPicker.js
@@ -11,6 +11,7 @@
 var ColorPickerX, ColorPickerY, ColorPickerWidth, ColorPickerHeight;
 var ColorPickerInitialHSV, ColorPickerLastHSV, ColorPickerHSV, ColorPickerCallback, ColorPickerSourceElement;
 var ColorPickerCSS;
+var ColorPickerIsDefault;
 
 var ColorPickerHueBarHeight = 40;
 var ColorPickerSVPanelGap = 20;
@@ -264,6 +265,7 @@ function ColorPickerDraw(X, Y, Width, Height, Src, Callback) {
         if (ColorPickerSourceElement != null) {
             var UserInputColor = ColorPickerSourceElement.value.trim().toUpperCase();
             if (CommonIsColor(UserInputColor)) {
+            	ColorPickerIsDefault = false;
                 if (!ColorPickerCSSColorEquals(UserInputColor, ColorPickerCSS)) {
                     if (ColorPickerCallback) {
                         // Fire callback due to source element changed by user interaction
@@ -272,6 +274,9 @@ function ColorPickerDraw(X, Y, Width, Height, Src, Callback) {
                     ColorPickerCSS = UserInputColor;
                     ColorPickerHSV = ColorPickerCSSToHSV(UserInputColor, ColorPickerHSV);
                 }
+            } else if (UserInputColor === "DEFAULT" && !ColorPickerIsDefault) {
+            	ColorPickerIsDefault = true;
+            	if (ColorPickerCallback) ColorPickerCallback("Default");
             }
         }
         // Use user updated HSV
@@ -305,10 +310,13 @@ function ColorPickerDraw(X, Y, Width, Height, Src, Callback) {
     Grad.addColorStop(1, "rgba(0, 0, 0, 1)");
     MainCanvas.fillStyle = Grad;
     MainCanvas.fillRect(X, SVPanelOffset, Width, SVPanelHeight);
-    
-    var CSS = ColorPickerHSVToCSS(HSV);
-    DrawCircle(X + HSV.S * Width, SVPanelOffset + (1 - HSV.V) * SVPanelHeight, 8, 16, CSS);
-    DrawCircle(X + HSV.S * Width, SVPanelOffset + (1 - HSV.V) * SVPanelHeight, 14, 4, (HSV.V > 0.8 && HSV.S < 0.2) ? "#333333" : "#FFFFFF");
+
+    if (!ColorPickerIsDefault) {
+	    var CSS = ColorPickerHSVToCSS(HSV);
+	    DrawCircle(X + HSV.S * Width, SVPanelOffset + (1 - HSV.V) * SVPanelHeight, 8, 16, CSS);
+	    DrawCircle(
+		    X + HSV.S * Width, SVPanelOffset + (1 - HSV.V) * SVPanelHeight, 14, 4, (HSV.V > 0.8 && HSV.S < 0.2) ? "#333333" : "#FFFFFF");
+    }
     // Draw Hue Picker
     DrawEmptyRect(X + HSV.H * (Width - 20), Y, 20, ColorPickerHueBarHeight, "#FFFFFF");
 

--- a/BondageClub/Scripts/Dialog.js
+++ b/BondageClub/Scripts/Dialog.js
@@ -1223,7 +1223,7 @@ function DialogClick() {
 
 
 	if (DialogColor != null && CurrentCharacter.FocusGroup && InventoryGet(CurrentCharacter, CurrentCharacter.FocusGroup.Name) && MouseIn(1300, 25, 675, 950)) {
-		return ItemColorClick(CurrentCharacter, CurrentCharacter.FocusGroup.Name, 1300, 25, 675, 950);
+		return ItemColorClick(CurrentCharacter, CurrentCharacter.FocusGroup.Name, 1200, 25, 775, 950, true);
 	}
 
 	// If the user clicked on the interaction character or herself, we check to build the item menu
@@ -1520,7 +1520,7 @@ function DialogDrawItemMenu(C) {
 	const FocusItem = InventoryGet(C, C.FocusGroup.Name);
 
 	if (DialogColor != null && FocusItem) {
-		return ItemColorDraw(C, C.FocusGroup.Name, 1300, 25, 675, 950);
+		return ItemColorDraw(C, C.FocusGroup.Name, 1200, 25, 775, 950, true);
 	}
 
 	// Gets the default text that will reset after 5 seconds
@@ -1861,7 +1861,7 @@ function DialogClickExpressionMenu() {
 			Player.FocusGroup = AssetGroupGet(Player.AssetFamily, GroupName);
 			DialogColor = "";
 			DialogExpressionColor = "";
-			ItemColorLoad(Player, Item, 1300, 25, 675, 950);
+			ItemColorLoad(Player, Item, 1200, 25, 775, 950, true);
 			ItemColorOnExit((save) => {
 				DialogColor = null;
 				DialogExpressionColor = null;


### PR DESCRIPTION
## Summary

This is something of a follow-up to #1882, as I feel that fully resetting a character's expression to reset their expression color to default doesn't fully meet the needs of players. This does two things:
* Adds support for the special "Default" keyword to the color picker - typing "Default" into the input box will reset an item (or layer) to its default color
* Adds support for a new reset button to the color picker which will reset an item (or layer) to its default color (by auto-filling the input with "Default")

Below is an image of the updated color picker with the default button:

![color-picker-default](https://user-images.githubusercontent.com/62729616/104447545-d8283800-5593-11eb-9dcc-968e28ee1782.png)
