### PR TITLE
Beta fix: Vanishing lover/owner locks

### DIFF
--- a/BondageClub/Scripts/Server.js
+++ b/BondageClub/Scripts/Server.js
@@ -265,7 +265,7 @@ function ServerValidateProperties(C, Item, Validation) {
 	// Remove LockMemberNumber if the source is incorrect prior to all checks
 	if ((Item.Property != null) && (C.ID == 0) && (Validation != null) && (Validation.SourceMemberNumber != null)) {
 		var Lock = InventoryGetLock(Item);
-		if ((Lock != null) && (Lock.Asset != null)) {
+		if ((Lock != null) && (Lock.Property != null)) {
 			if (!Validation.FromOwner && Lock.Asset.OwnerOnly) delete Item.Property.LockMemberNumber;
 			else if (!Validation.FromLoversOrOwner && Lock.Asset.LoverOnly) delete Item.Property.LockMemberNumber;
 		}


### PR DESCRIPTION
## Summary

This took longer than I care to admit to track down. As part of #1387, the chunk of code which removes lock member numbers from invalid sources got moved from `ServerAppearanceLoadFromBundle` into `ServerValidateProperties`. In the process, part of it was mis-translated, causing an issue where any appearance bundle load from someone that was neither an owner nor a lover of the player would strip any lover or owner locks from their appearance (because `NA.Asset` is always defined).

## Steps to reproduce

Needs 3 characters:
* Character A
* Character B - owner and/or lover of Character A
* Character C - neither owner nor lover of Character A

1. Character B applies an item to Character A and owner/lover locks the item
2. Character C then applies an extended item to Character A (or anything that will trigger a `ServerAppearanceLoadFromBundle` on Character A's end)
3. Note that the lover/owner lock on the item applied by Character B has vanished