### PR TITLE
Bugfix: Allows timer locks to trigger chatroom messages in other chatroom subscreens

### DIFF
--- a/BondageClub/Scripts/Timer.js
+++ b/BondageClub/Scripts/Timer.js
@@ -71,7 +71,7 @@ function TimerInventoryRemove() {
 									Character[C].Appearance[A].Property.Effect.splice(E, 1);
 
 						// If we're removing a lock and we're in a chatroom, send a chatroom message
-						if (LockName && (CurrentScreen === "ChatRoom" || CharacterAppearanceReturnRoom === "ChatRoom")) {
+						if (LockName && ServerPlayerIsInChatRoom()) {
 							var Dictionary = [
 								{Tag: "DestinationCharacterName", Text: Character[C].Name, MemberNumber: Character[C].MemberNumber},
 								{Tag: "FocusAssetGroup", AssetGroupName: Character[C].Appearance[A].Asset.Group.Name},

--- a/BondageClub/Scripts/Timer.js
+++ b/BondageClub/Scripts/Timer.js
@@ -71,7 +71,7 @@ function TimerInventoryRemove() {
 									Character[C].Appearance[A].Property.Effect.splice(E, 1);
 
 						// If we're removing a lock and we're in a chatroom, send a chatroom message
-						if (LockName && CurrentScreen === "ChatRoom") {
+						if (LockName && (CurrentScreen === "ChatRoom" || CharacterAppearanceReturnRoom === "ChatRoom")) {
 							var Dictionary = [
 								{Tag: "DestinationCharacterName", Text: Character[C].Name, MemberNumber: Character[C].MemberNumber},
 								{Tag: "FocusAssetGroup", AssetGroupName: Character[C].Appearance[A].Asset.Group.Name},


### PR DESCRIPTION
## Summary

Not strictly a bug with the current beta, but when timer locks expire, they won't trigger chatroom messages if the player is in their wardrobe, information sheet, etc. This fixes that.