### PR TITLE
Suspension Pose fix

### DIFF
--- a/BondageClub/Assets/Female3DCG/Female3DCG.js
+++ b/BondageClub/Assets/Female3DCG/Female3DCG.js
@@ -3810,7 +3810,6 @@ var PoseFemale3DCG = [
 	},
 	{
 		Name: "Suspension",
-		Category: "BodyFull",
 		OverrideHeight: { Height: -150, Priority: 40 },
 		Hide: []
 	},


### PR DESCRIPTION
The Suspension pose doesn't actually affect the arms or legs, as that's always determined by another pose it's paired with (e.g. LegsClosed). So it doesn't need to belong to the BodyFull category which makes it block arms/leg pose changing.