### PR TITLE
Bugfix: Ensures an item update when the full lockdown suit's wand gets added

### DIFF
--- a/BondageClub/Screens/Inventory/ItemArms/FullLatexSuit/FullLatexSuit.js
+++ b/BondageClub/Screens/Inventory/ItemArms/FullLatexSuit/FullLatexSuit.js
@@ -62,7 +62,10 @@ function InventoryItemArmsFullLatexSuitSetType(NewType) {
 	if (NewType == null || NewType == "UnZip") DialogFocusItem.Property.Type = NewType;
 	if (NewType == null) DialogFocusItem.Property.Block = ["ItemBreast", "ItemNipples", "ItemNipplesPiercings", "ItemVulva", "ItemVulvaPiercings", "ItemButt"];
 	else if (NewType == "UnZip") DialogFocusItem.Property.Block = [];
-	if (NewType == "Wand") InventoryWear(C, "FullLatexSuitWand", "ItemVulva");
+	if (NewType == "Wand") {
+		InventoryWear(C, "FullLatexSuitWand", "ItemVulva");
+		ChatRoomCharacterItemUpdate(C, "ItemVulva");
+	}
 	CharacterRefresh(C);
 
 	// Pushes the change to the chatroom


### PR DESCRIPTION
## Summary

I'm not quite sure if this is specifically a beta problem, or when exactly this broke (probably due to a change in the behaviour of `CharacterRefresh`), but the full lockdown suit's wand was not being properly updated in chatrooms when added. This adds a `ChatRoomCharacterItemUpdate` call to ensure that it is updated properly for other players.

## Steps to reproduce

1. Character A adds a Full Lockdown Suit to Character B
2. Character A adds a wand attachment to the lockdown suit
3. Notice that the wand is not added on Character B's screen