### PR TITLE
Bugfix: Removes an unneeded console.log call

### DIFF
--- a/BondageClub/Screens/Character/ItemColor/ItemColor.js
+++ b/BondageClub/Screens/Character/ItemColor/ItemColor.js
@@ -212,7 +212,6 @@ function ItemColorDrawDefault(x, y) {
  * @const {function(): void}
  */
 const ItemColorOnPickerChange = CommonDebounce((color) => {
-	console.log(color);
 	const newColors = ItemColorState.colors.slice();
 	ItemColorPickerIndices.forEach(i => newColors[i] = color);
 	ItemColorItem.Color = newColors;


### PR DESCRIPTION
I just noticed that I'd left in a `console.log` statement that I was using to debug the recent color picker change which is no longer necessary.