### PR TITLE
Bugfix: Prevents the bed spread eagle hemp rope type from ignoring toe ties

### DIFF
--- a/BondageClub/Screens/Inventory/ItemFeet/HempRope/HempRope.js
+++ b/BondageClub/Screens/Inventory/ItemFeet/HempRope/HempRope.js
@@ -30,7 +30,7 @@ const HempRopeFeetOptions = [
 		Name: "BedSpreadEagle",
 		BondageLevel: 1,
 		Property: { Type: "BedSpreadEagle", Effect: ["Block", "Freeze", "Prone"], Block: ["ItemLegs", "ItemBoots", "ItemDevices"], AllowActivityOn: ["ItemLegs", "ItemBoots"], SetPose: ["Spread"], Difficulty: 5 },
-		Prerequisite: ["OnBed", "NoItemLegs"]
+		Prerequisite: ["OnBed", "NoItemLegs", "LegsOpen"]
 	}
 ];
 
@@ -54,6 +54,39 @@ function InventoryItemFeetHempRopeDraw() {
 
 function InventoryItemFeetHempRopeClick() {
 	ExtendedItemClick(HempRopeFeetOptions);
+}
+
+/**
+ * Validates whether the chosen option is possible. Sets the global variable 'DialogExtendedMessage' to the appropriate
+ * error message if not.
+ * @param {Character} C - The character to check the options for
+ * @param {Option} Option - The next option to use on the character
+ * @returns {string} - Returns false and sets DialogExtendedMessage, if the chosen option is not possible.
+ */
+function InventoryItemFeetHempRopeValidate(C, Option) {
+	var Allowed = "";
+
+	// Validates some prerequisites before allowing more advanced poses
+	if (Option.Prerequisite) {
+
+		// Remove the item temporarily for prerequisite-checking - we should still be able to change type if the item
+		// is the only thing that fails the prerequisite check
+		var Rope = InventoryGet(C, C.FocusGroup.Name);
+		InventoryRemove(C, C.FocusGroup.Name);
+
+		if (!InventoryAllow(C, Option.Prerequisite, true)) {
+			Allowed = DialogText;
+		}
+
+		// Re-add the item
+		var DifficultyFactor = Rope.Difficulty - Rope.Asset.Difficulty;
+		CharacterAppearanceSetItem(C, C.FocusGroup.Name, Rope.Asset, Rope.Color, DifficultyFactor, null, false);
+		InventoryGet(C, C.FocusGroup.Name).Property = Rope.Property;
+		CharacterRefresh(C);
+		DialogFocusItem = InventoryGet(C, C.FocusGroup.Name);
+
+	}
+	return Allowed;
 }
 
 function InventoryItemFeetHempRopePublishAction(C, Option) {


### PR DESCRIPTION
## Summary

The new bed spread eagle pose for the feet hemp rope did not include a `LegsOpen` prerequisite. In order to add this I needed to add a validate function (similar to the web in the arms group), to prevent the rope from conflicting with itself.

## Steps to reproduce

1. Add a toe-binding item (e.g. hemp rope in `ItemBoots`)
2. Add hemp rope to the `ItemFeet` group
3. Select the bed spread eagle type
4. Note that the player is forced into the legs spread pose, but the toe tie is still applied