### PR TITLE
Extended Item Self-Blocking Validation

### DIFF
--- a/BondageClub/Screens/Inventory/ItemArms/Chains/Chains.js
+++ b/BondageClub/Screens/Inventory/ItemArms/Chains/Chains.js
@@ -30,19 +30,22 @@ const InventoryItemArmsChainsOptions = [
 		BondageLevel: 4,
 		Prerequisite: ["NotMounted", "NotSuspended"],
 		Property: { Type: "KneelingHogtie", Effect: ["Block", "Freeze", "Prone"], Block: ["ItemHands", "ItemLegs", "ItemFeet", "ItemBoots", "ItemDevices"], AllowActivityOn: ["ItemHands", "ItemLegs", "ItemFeet", "ItemBoots"], SetPose: ["Kneel", "BackElbowTouch"], Difficulty: 3 },
-		Expression: [{ Group: "Blush", Name: "Medium", Timer: 10 }]
+		Expression: [{ Group: "Blush", Name: "Medium", Timer: 10 }],
+		SelfBlockCheck: true,
 	}, {
 		Name: "Hogtied",
 		BondageLevel: 4,
 		Prerequisite: ["NotMounted", "NotSuspended", "CannotBeHogtiedWithAlphaHood"],
 		Property: { Type: "Hogtied", Effect: ["Block", "Freeze", "Prone"], Block: ["ItemHands", "ItemLegs", "ItemFeet", "ItemBoots", "ItemDevices"], AllowActivityOn: ["ItemHands", "ItemLegs", "ItemFeet", "ItemBoots"], SetPose: ["Hogtied"], Difficulty: 3 },
-		Expression: [{ Group: "Blush", Name: "Medium", Timer: 10 }]
+		Expression: [{ Group: "Blush", Name: "Medium", Timer: 10 }],
+		SelfBlockCheck: true,
 	}, {
 		Name: "AllFours",
 		BondageLevel: 6,
 		Prerequisite: ["NotMounted", "NotSuspended", "CannotBeHogtiedWithAlphaHood"],
 		Property: { Type: "AllFours", Effect: ["ForceKneel"], Block: ["ItemLegs", "ItemFeet", "ItemBoots", "ItemDevices"],  AllowActivityOn: ["ItemLegs", "ItemFeet", "ItemBoots"], SetPose: ["AllFours"], Difficulty: 3 },
-		Expression: [{ Group: "Blush", Name: "Medium", Timer: 10 }]
+		Expression: [{ Group: "Blush", Name: "Medium", Timer: 10 }],
+		SelfBlockCheck: true,
 	}, {
 		Name: "SuspensionHogtied",
 		BondageLevel: 8,
@@ -108,6 +111,7 @@ function InventoryItemArmsChainsNpcDialog(C, Option) {
 /**
  * Validates, if the chosen option is possible. Sets the global variable 'DialogExtendedMessage' to the appropriate error message, if not.
  * @param {Character} C - The character to validate the option for
+ * @param {ExtendedItemOption} Option - The selected option
  * @returns {string} - Returns false and sets DialogExtendedMessage, if the chosen option is not possible.
  */
 function InventoryItemArmsChainsValidate(C, Option) {
@@ -115,8 +119,8 @@ function InventoryItemArmsChainsValidate(C, Option) {
 
 	if (InventoryItemHasEffect(DialogFocusItem, "Lock", true)) {
 		Allowed = DialogFind(Player, "CantChangeWhileLocked");
-	}else if (Option.Prerequisite) {
-		if (!InventoryAllow(C, Option.Prerequisite, true)) {
+	} else if (Option.Prerequisite) {
+		if (!ExtendedItemSelfProofRequirementCheck(C, Option.Prerequisite)) {
 			Allowed = DialogText;
 		}
 	}

--- a/BondageClub/Screens/Inventory/ItemArms/HempRope/HempRope.js
+++ b/BondageClub/Screens/Inventory/ItemArms/HempRope/HempRope.js
@@ -30,7 +30,8 @@ const InventoryItemArmsHempRopeOptions = [
 		BondageLevel: 2,
 		Prerequisite: ["NotMounted", "NotSuspended", "CannotBeHogtiedWithAlphaHood"],
 		Property: { Type: "SimpleHogtie", Effect: ["Block", "Prone"], SetPose: ["Hogtied"], Difficulty: 2 },
-		Expression: [{ Group: "Blush", Name: "Medium", Timer: 5 }]
+		Expression: [{ Group: "Blush", Name: "Medium", Timer: 5 }],
+		SelfBlockCheck: true,
 	}, {
 		Name: "TightBoxtie",
 		BondageLevel: 3,
@@ -46,19 +47,22 @@ const InventoryItemArmsHempRopeOptions = [
 		BondageLevel: 4,
 		Prerequisite: ["NotMounted", "NotSuspended"],
 		Property: { Type: "KneelingHogtie", Effect: ["Block", "Freeze", "Prone"], Block: ["ItemHands", "ItemLegs", "ItemFeet", "ItemBoots", "ItemDevices"], AllowActivityOn: ["ItemHands", "ItemLegs", "ItemFeet", "ItemBoots"], SetPose: ["Kneel", "BackElbowTouch"], Difficulty: 3 },
-		Expression: [{ Group: "Blush", Name: "Medium", Timer: 10 }]
+		Expression: [{ Group: "Blush", Name: "Medium", Timer: 10 }],
+		SelfBlockCheck: true,
 	}, {
 		Name: "Hogtied",
 		BondageLevel: 4,
 		Prerequisite: ["NotMounted", "NotSuspended", "CannotBeHogtiedWithAlphaHood"],
 		Property: { Type: "Hogtied", Effect: ["Block", "Freeze", "Prone"], Block: ["ItemHands", "ItemLegs", "ItemFeet", "ItemBoots", "ItemDevices"], AllowActivityOn: ["ItemHands", "ItemLegs", "ItemFeet", "ItemBoots"], SetPose: ["Hogtied"], Difficulty: 3 },
-		Expression: [{ Group: "Blush", Name: "Medium", Timer: 10 }]
+		Expression: [{ Group: "Blush", Name: "Medium", Timer: 10 }],
+		SelfBlockCheck: true,
 	}, {
 		Name: "AllFours",
 		BondageLevel: 6,
 		Prerequisite: ["NotMounted", "NotSuspended", "CannotBeHogtiedWithAlphaHood"],
 		Property: { Type: "AllFours", Effect: ["ForceKneel"], Block: ["ItemLegs", "ItemFeet", "ItemBoots", "ItemDevices"], AllowActivityOn: ["ItemLegs", "ItemFeet", "ItemBoots"], SetPose: ["AllFours"], Difficulty: 3 },
-		Expression: [{ Group: "Blush", Name: "Medium", Timer: 10 }]
+		Expression: [{ Group: "Blush", Name: "Medium", Timer: 10 }],
+		SelfBlockCheck: true,
 	}, {
 		Name: "SuspensionHogtied",
 		BondageLevel: 8,

--- a/BondageClub/Screens/Inventory/ItemArms/Web/Web.js
+++ b/BondageClub/Screens/Inventory/ItemArms/Web/Web.js
@@ -48,6 +48,7 @@ var InventoryItemArmsWebOptions = [
 			Hide: ["Cloth", "ClothLower", "ClothAccessory", "Necklace", "Shoes", "Socks"],
 			Block: ["ItemVulva", "ItemVulvaPiercings", "ItemButt", "ItemPelvis", "ItemTorso", "ItemHands", "ItemLegs", "ItemFeet", "ItemBoots", "ItemNipples", "ItemNipplesPiercings", "ItemBreast", "ItemDevices"],
 		},
+		SelfBlockCheck: true,
 	},
 	{
 		Name: "Suspended",
@@ -90,6 +91,7 @@ var InventoryItemArmsWebOptions = [
 			Block: ["ItemVulva", "ItemVulvaPiercings", "ItemButt", "ItemPelvis", "ItemTorso", "ItemHands", "ItemLegs", "ItemFeet", "ItemBoots", "ItemNipples", "ItemNipplesPiercings", "ItemBreast", "ItemDevices"],
 			OverrideHeight: { Height: 0, Priority: 51, HeightRatioProportion: 0 },
 		},
+		SelfBlockCheck: true,
 	},
 ];
 
@@ -116,38 +118,6 @@ function InventoryItemArmsWebDraw() {
  */
 function InventoryItemArmsWebClick() {
 	ExtendedItemClick(InventoryItemArmsWebOptions);
-}
-
-/**
- * Validates, if the chosen option is possible. Sets the global variable 'DialogExtendedMessage' to the appropriate error message, if not.
- * @param {Character} C - The character to check the options for
- * @param {Option} Option - The next option to use on the character
- * @returns {string} - Returns false and sets DialogExtendedMessage, if the chosen option is not possible.
- */
-function InventoryItemArmsWebValidate(C, Option) {
-	var Allowed = "";
-
-	// Validates some prerequisites before allowing more advanced poses
-	if (Option.Prerequisite) {
-
-		// Remove the web temporarily for prerequisite-checking - we should still be able to change type if the web is the only thing that
-		// fails the prerequisite check
-		var Web = InventoryGet(C, "ItemArms");
-		InventoryRemove(C, "ItemArms");
-
-		if (!InventoryAllow(C, Option.Prerequisite, true)) {
-			Allowed = DialogText;
-		}
-
-		// Re-add the web
-		var DifficultyFactor = Web.Difficulty - Web.Asset.Difficulty;
-		CharacterAppearanceSetItem(C, "ItemArms", Web.Asset, Web.Color, DifficultyFactor, null, false);
-		InventoryGet(C, "ItemArms").Property = Web.Property;
-		CharacterRefresh(C);
-		DialogFocusItem = InventoryGet(C, C.FocusGroup.Name);
-
-	}
-	return Allowed;
 }
 
 /**

--- a/BondageClub/Screens/Inventory/ItemFeet/HempRope/HempRope.js
+++ b/BondageClub/Screens/Inventory/ItemFeet/HempRope/HempRope.js
@@ -30,7 +30,8 @@ const HempRopeFeetOptions = [
 		Name: "BedSpreadEagle",
 		BondageLevel: 1,
 		Property: { Type: "BedSpreadEagle", Effect: ["Block", "Freeze", "Prone"], Block: ["ItemLegs", "ItemBoots", "ItemDevices"], AllowActivityOn: ["ItemLegs", "ItemBoots"], SetPose: ["Spread"], Difficulty: 5 },
-		Prerequisite: ["OnBed", "NoItemLegs", "LegsOpen"]
+		Prerequisite: ["OnBed", "NoItemLegs", "LegsOpen"],
+		SelfBlockCheck: true,
 	}
 ];
 
@@ -54,39 +55,6 @@ function InventoryItemFeetHempRopeDraw() {
 
 function InventoryItemFeetHempRopeClick() {
 	ExtendedItemClick(HempRopeFeetOptions);
-}
-
-/**
- * Validates whether the chosen option is possible. Sets the global variable 'DialogExtendedMessage' to the appropriate
- * error message if not.
- * @param {Character} C - The character to check the options for
- * @param {Option} Option - The next option to use on the character
- * @returns {string} - Returns false and sets DialogExtendedMessage, if the chosen option is not possible.
- */
-function InventoryItemFeetHempRopeValidate(C, Option) {
-	var Allowed = "";
-
-	// Validates some prerequisites before allowing more advanced poses
-	if (Option.Prerequisite) {
-
-		// Remove the item temporarily for prerequisite-checking - we should still be able to change type if the item
-		// is the only thing that fails the prerequisite check
-		var Rope = InventoryGet(C, C.FocusGroup.Name);
-		InventoryRemove(C, C.FocusGroup.Name);
-
-		if (!InventoryAllow(C, Option.Prerequisite, true)) {
-			Allowed = DialogText;
-		}
-
-		// Re-add the item
-		var DifficultyFactor = Rope.Difficulty - Rope.Asset.Difficulty;
-		CharacterAppearanceSetItem(C, C.FocusGroup.Name, Rope.Asset, Rope.Color, DifficultyFactor, null, false);
-		InventoryGet(C, C.FocusGroup.Name).Property = Rope.Property;
-		CharacterRefresh(C);
-		DialogFocusItem = InventoryGet(C, C.FocusGroup.Name);
-
-	}
-	return Allowed;
 }
 
 function InventoryItemFeetHempRopePublishAction(C, Option) {


### PR DESCRIPTION
Web and hemp hope on feet both have a custom validation function to work around cases where the item is blocking itself from being changed by failing the prerequisite check of the new type.
This moves the remove-validate-reapply process into the general ExtendedItem script and adds a new property that calls it, and only to the item types that need it.

Also added the setting to hemp rope and chains for arms to fix that same issue for them.