### PR TITLE
Bugfix: Fix for chess square overflow in Firefox

### DIFF
--- a/BondageClub/CSS/Chess.css
+++ b/BondageClub/CSS/Chess.css
@@ -1,0 +1,14 @@
+/* Fixes for square overflow in Firefox (overwrites default styling) */
+.row-5277c {
+  display: flex;
+}
+
+.clearfix-7da63 {
+  display: none;
+}
+
+.notation-322f9 {
+  right: 0;
+  width: auto !important;
+  padding-right: 3px;
+}

--- a/BondageClub/index.html
+++ b/BondageClub/index.html
@@ -13,6 +13,7 @@
 	<link rel="icon" type="image/png" href="Icons/Logo.png">
 	<link rel="stylesheet" href="CSS/Styles.css">
 	<link rel="stylesheet" href="CSS/chessboard-0.3.0.css">
+	<link rel="stylesheet" href="CSS/Chess.css">
 </head>
 
 <script src="Backgrounds/Backgrounds.js"></script>


### PR DESCRIPTION
## Summary

This fixes an issue where the squares of the chessboard overflow the rows at certain window widths in Firefox (see image below). This is likely due to some internal rounding error in the way Firefox calculates the widths/positions of floated elements. I've added a new `Chess.css` file, separate from the existing library file, which modifies the CSS on certain chessboard elements to make it a bit more robust. It also moves the file letterings over to the right of the squares so that they don't overlap with the rank numbers. Tested and working on Firefox, Chrome and Edge. I've not tested Safari, as I don't have a Mac, but there shouldn't be anything in the added CSS that should cause issues.

Before fix:
![](https://cdn.discordapp.com/attachments/554378725916147722/800854707739951154/ce.png)

After fix:
![image](https://user-images.githubusercontent.com/62729616/104971066-7e859a80-59e5-11eb-8aab-881c2e405ab5.png)
