### PR TITLE
Bugfix: Fixes the layer names for the Futuristic arm cuffs

### DIFF
--- a/BondageClub/Assets/Female3DCG/LayerNames.csv
+++ b/BondageClub/Assets/Female3DCG/LayerNames.csv
@@ -111,8 +111,6 @@ ItemLegsFuturisticLegCuffsCuffs,Cuffs
 ItemLegsFuturisticLegCuffsDisplay,Display
 ItemLegsCeilingShacklesChain,Chain
 ItemLegsCeilingShacklesCuffs,Cuffs
-ItemLegsFuturisticCuffsCuffs,Cuffs
-ItemLegsFuturisticCuffsDisplay,Display
 ItemLegsOrnateLegCuffsGems,Gems
 ItemLegsLegBinderLatex,Binder
 ItemLegsLegBinderBelts,Belts
@@ -200,6 +198,8 @@ ItemArmsFuturisticArmbinderBand,Band
 ItemArmsFuturisticArmbinderStraps,Straps
 ItemArmsMedicalBedRestraintsBase,Bed Straps
 ItemArmsMedicalBedRestraintsStraps,Cuffs
+ItemArmsFuturisticCuffsCuffs,Cuffs
+ItemArmsFuturisticCuffsDisplay,Display
 ItemHandsFuturisticMittensBody,Body
 ItemHandsFuturisticMittensMesh,Mesh
 ItemHandsFuturisticMittensDisplay,Display


### PR DESCRIPTION
Fixes missing layer names for Futuristic Cuffs in `ItemArms`. Also removes 2 unused layer name entries.