### PR TITLE
Bugfix: Fixes posture collar name orderings

### DIFF
--- a/BondageClub/Assets/Female3DCG/Female3DCG.csv
+++ b/BondageClub/Assets/Female3DCG/Female3DCG.csv
@@ -849,11 +849,11 @@ ItemNeck,PetCollar,Pet Collar
 ItemNeck,MaidCollar,Maid Collar
 ItemNeck,BordelleCollar,Bordelle Collar
 ItemNeck,LoveLeatherCollar,Lover Leather Collar
-ItemNeck,StrictPostureCollar,Strict Posture Collar
 ItemNeck,NobleCorsetCollar,Noble Corset Collar
+ItemNeck,StrictPostureCollar,Strict Posture Collar
 ItemNeck,HeartCollar,Heart Collar
-ItemNeck,LatexPostureCollar,Latex Posture Collar Gag
 ItemNeck,LeatherCorsetCollar,Leather Corset Collar Gag
+ItemNeck,LatexPostureCollar,Latex Posture Collar Gag
 ItemNeck,HighSecurityCollar,High Security Collar
 ItemNeck,OrnateCollar,Ornate Collar
 ItemNeck,SlenderSteelCollar,Slender Steel Collar


### PR DESCRIPTION
## Summary

As part of #1794, the strict posture collar and the latex posture collar got moved in `Female3DCG.js`, but their names weren't moved inside `Female3DCG.csv`, causing some of the collar names to show up incorrectly in game. This moves the names in the CSV to match their order in `Female3DCG.js`.