### PR TITLE
Fix: Extended item removal while viewing

### DIFF
--- a/BondageClub/Scripts/Character.js
+++ b/BondageClub/Scripts/Character.js
@@ -692,10 +692,14 @@ function CharacterRefresh(C, Push) {
 	if (Current && C.ID == Current.ID) {
 		if (DialogFocusItem && DialogFocusItem.Asset) {
 			if (!DialogFocusItem.Asset.IsLock) {
-				DialogFocusItem = C.Appearance.find(Item =>
+				let DFI = C.Appearance.find(Item =>
 					Item.Asset.Name == DialogFocusItem.Asset.Name && Item.Asset.Group.Name == DialogFocusItem.Asset.Group.Name
 				);
-				if (DialogFocusItem && DialogFocusItem.Asset.Extended && typeof window["Inventory" + DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Load"] === "function") window["Inventory" + DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Load"]();
+				if (!DFI) DialogLeaveFocusItem();
+				else {
+					DialogFocusItem = DFI;
+					if (DialogFocusItem && DialogFocusItem.Asset.Extended && typeof window["Inventory" + DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Load"] === "function") window["Inventory" + DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Load"]();
+				}
 			} else {
 				var DFSI = DialogFocusSourceItem && DialogFocusSourceItem.Asset && C.Appearance.find(Item =>
 					Item.Asset.Name == DialogFocusSourceItem.Asset.Name && Item.Asset.Group.Name == DialogFocusSourceItem.Asset.Group.Name


### PR DESCRIPTION
For extended items with custom elements created in the Load function, such as the wooden sign or custom name tag, if the item is removed while the player is viewing the item's screen these elements were still left behind. E.g. the wooden sign's text input would stay stuck on the screen.
This is because the item's exit function never gets called. Now it will be.