### PR TITLE
Bugfix: Fixes alpha mask issues with the open straitdress

### DIFF
--- a/BondageClub/Assets/Female3DCG/Female3DCG.js
+++ b/BondageClub/Assets/Female3DCG/Female3DCG.js
@@ -1993,14 +1993,18 @@ var AssetFemale3DCG = [
 			{
 				Name: "StraitDressOpen", Fetish: ["Latex"], Value: 200, Difficulty: 15, SelfBondage: 8, Time: 40, RemoveTime: 30, Random: false, AllowLock: true, BuyGroup: "StraitDress", DefaultColor: ["#400000", "Default"],
 				Prerequisite: ["NotSuspended", "NotHogtied", "NotMounted", "NotKneelingSpread", "NoFeetSpreader"],
-				Hide: ["Cloth", "Shoes", "ItemBoots", "ItemNipplesPiercings", "ItemLegs", "Suit"],
-				HideItem: ["ItemFeetOrnateAnkleCuffs", "ItemFeetNylonRope", "ItemFeetHempRope", "ItemFeetLeatherBelt", "ItemFeetIrish8Cuffs", "ItemFeetDuctTape", "ItemFeetFuturisticAnkleCuffs", "ItemFeetFuturisticAnkleCuffs","ItemNipplesLactationPump"],
+				Hide: ["Cloth", "Shoes", "Socks", "ItemBoots", "ItemNipples", "ItemNipplesPiercings", "Suit", "LeftAnklet", "RightAnklet"],
 				AllowPose: ["Kneel"],
 				SetPose: ["BackElbowTouch", "LegsClosed"],
 				Effect: ["Block", "Prone"],
 				Block: ["ItemPelvis", "ItemTorso", "ItemBreast", "ItemHands", "ItemFeet", "ItemNipples", "ItemNipplesPiercings", "ItemLegs"],
 				AllowActivePose: ["Kneel"],
-				Alpha: [{Masks: [[0, 362, 500, 100], [0, 462, 210, 120], [290, 462, 210, 120], [0, 582, 500, 418]]}],
+				Alpha: [
+					{
+						Group: ["BodyLower", "ClothLower", "ItemLegs", "ItemFeet", "SuitLower", "Bra", "Panties", "Corset", "ItemTorso"],
+						Masks: [[0, 220, 500, 242], [0, 462, 210, 120], [290, 462, 210, 120], [0, 582, 500, 418]]
+					}
+				],
 				Layer: [
 					{ Name: "Latex" },
 					{ Name: "Belts" }


### PR DESCRIPTION
The alpha masks on the open straitdress were being applied to all layers, resulting in visual issues with some items (see image). This changes the masks to target specific groups, and also revises the `Hide`/`HideItem` arrays. This should remove any bad combinations, for now.

![image](https://user-images.githubusercontent.com/62729616/105169017-d5d55900-5b12-11eb-81ee-37af632f10da.png)
