### PR TITLE
Improvement: Adds retry logic to CommonGet

### DIFF
--- a/BondageClub/Scripts/Common.js
+++ b/BondageClub/Scripts/Common.js
@@ -196,8 +196,8 @@ function CommonGet(Path, Callback, RetriesLeft) {
  * retries up to a maximum of 10 times.
  * @param {string} Path - The path of the resource to request
  * @param {function} Callback - Callback to execute once the resource is received
- * @param {number} [RetriesLeft]
- * @returns {void} - How many more times to retry - after this hits zero, an error will be logged
+ * @param {number} [RetriesLeft] - How many more times to retry - after this hits zero, an error will be logged
+ * @returns {void} - Nothing
  */
 function CommonGetRetry(Path, Callback, RetriesLeft) {
 	if (typeof RetriesLeft !== "number") RetriesLeft = 10;

--- a/BondageClub/Scripts/Common.js
+++ b/BondageClub/Scripts/Common.js
@@ -196,7 +196,8 @@ function CommonGet(Path, Callback, RetriesLeft) {
  * retries up to a maximum of 10 times.
  * @param {string} Path - The path of the resource to request
  * @param {function} Callback - Callback to execute once the resource is received
- * @param {number} RetriesLeft
+ * @param {number} [RetriesLeft]
+ * @returns {void} - How many more times to retry - after this hits zero, an error will be logged
  */
 function CommonGetRetry(Path, Callback, RetriesLeft) {
 	if (typeof RetriesLeft !== "number") RetriesLeft = 10;

--- a/BondageClub/Scripts/Common.js
+++ b/BondageClub/Scripts/Common.js
@@ -172,16 +172,41 @@ function CommonReadCSV(Array, Path, Screen, File) {
 }
 
 /**
- * AJAX utility to get a file and return its content
+ * AJAX utility to get a file and return its content. By default will retry requests 10 times
  * @param {string} Path - Path of the resource to request
  * @param {function} Callback - Callback to execute once the resource is received
+ * @param {number} [RetriesLeft] - How many more times to retry if the request fails - after this hits zero, an error will be logged
  * @returns {void} - Nothing
  */
-function CommonGet(Path, Callback) {
+function CommonGet(Path, Callback, RetriesLeft) {
 	var xhr = new XMLHttpRequest();
 	xhr.open("GET", Path);
-	xhr.onreadystatechange = function () { if (this.readyState == 4) Callback.bind(this)(xhr); };
+	xhr.onloadend = function() {
+		// For non-error responses, call the callback
+		if (this.status < 400) Callback.bind(this)(xhr);
+		// Otherwise, retry
+		else CommonGetRetry(Path, Callback, RetriesLeft);
+	};
+	xhr.onerror = function() { CommonGetRetry(Path, Callback, RetriesLeft); };
 	xhr.send(null);
+}
+
+/**
+ * Retry handler for CommonGet requests. Exponentially backs off retry attempts up to a limit of 1 minute. By default,
+ * retries up to a maximum of 10 times.
+ * @param {string} Path - The path of the resource to request
+ * @param {function} Callback - Callback to execute once the resource is received
+ * @param {number} RetriesLeft
+ */
+function CommonGetRetry(Path, Callback, RetriesLeft) {
+	if (typeof RetriesLeft !== "number") RetriesLeft = 10;
+	if (RetriesLeft <= 0) {
+		console.error(`GET request to ${Path} failed - no more retries`);
+	} else {
+		const retrySeconds = Math.min(Math.pow(2, Math.max(0, 10 - RetriesLeft)), 60);
+		console.warn(`GET request to ${Path} failed - retrying in ${retrySeconds} second${retrySeconds === 1 ? "" : "s"}...`);
+		setTimeout(() => CommonGet(Path, Callback, RetriesLeft - 1), retrySeconds * 1000);
+	}
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR adds retry logic to the `CommonGet` function. Occasionally, GET requests (usually for CSVs) will fail, usually due to an intermittent error. That then results in textual errors like those below, which can only be resolved by exiting/re-entering the screen, or in some cases by refreshing the page completely. This change should prevent the vast majority of those cases. If a request succeeds first time, the current behaviour is preserved.

![image](https://user-images.githubusercontent.com/62729616/105389145-685b2280-5c0f-11eb-9e2b-fdba568d89f5.png)

![image](https://media.discordapp.net/attachments/554378725916147722/801827027031425044/20210121_085049.jpg?width=936&height=702)

## Technical Details

Retries are backed off exponentially up to a limit of 60 seconds between retries, and by default a request is retried a total of 10 times. If no successful response is received after 10 retries, the function will stop retrying.

This is the console log output and network requests for a request that has failed 10 times:

![retries-1](https://user-images.githubusercontent.com/62729616/105389513-d56eb800-5c0f-11eb-89ba-8dccd4f9dbca.png)

And this is the output for a request that succeeded after a few retries:

![retries-2](https://user-images.githubusercontent.com/62729616/105389600-e9b2b500-5c0f-11eb-97c8-676647f2b6d3.png)
