### PR TITLE
Improvement: Simple chatroom optimisations

### DIFF
--- a/BondageClub/Screens/Character/Preference/Preference.js
+++ b/BondageClub/Screens/Character/Preference/Preference.js
@@ -758,7 +758,7 @@ function PreferenceSubscreenImmersionClick() {
 			if (MouseX <= 625) PreferenceSettingsSensDepIndex = (PreferenceSettingsSensDepList.length + PreferenceSettingsSensDepIndex - 1) % PreferenceSettingsSensDepList.length;
 			else PreferenceSettingsSensDepIndex = (PreferenceSettingsSensDepIndex + 1) % PreferenceSettingsSensDepList.length;
 			Player.GameplaySettings.SensDepChatLog = PreferenceSettingsSensDepList[PreferenceSettingsSensDepIndex];
-			if (Player.GameplaySettings.SensDepChatLog == "SensDepExtreme") ChatRoomTargetMemberNumber = null;
+			if (Player.GameplaySettings.SensDepChatLog == "SensDepExtreme") ChatRoomSetTarget(null);
 		}
 
 		// Preference check boxes
@@ -768,7 +768,7 @@ function PreferenceSubscreenImmersionClick() {
 			Player.GameplaySettings.DisableAutoRemoveLogin = !Player.GameplaySettings.DisableAutoRemoveLogin;
 		if (MouseIn(500, 432, 64, 64) && (!Player.GameplaySettings.ImmersionLockSetting || (!Player.IsRestrained()))) {
 			Player.ImmersionSettings.BlockGaggedOOC = !Player.ImmersionSettings.BlockGaggedOOC;
-			if (Player.ImmersionSettings.BlockGaggedOOC) ChatRoomTargetMemberNumber = null;
+			if (Player.ImmersionSettings.BlockGaggedOOC) ChatRoomSetTarget(null);
 		}
 		if (MouseIn(500, 512, 64, 64) && (!Player.GameplaySettings.ImmersionLockSetting || (!Player.IsRestrained())))
 			Player.OnlineSharedSettings.AllowPlayerLeashing = !Player.OnlineSharedSettings.AllowPlayerLeashing;

--- a/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
+++ b/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
@@ -20,16 +20,16 @@ var ChatRoomStruggleAssistBonus = 0;
 var ChatRoomStruggleAssistTimer = 0;
 var ChatRoomSlowtimer = 0;
 var ChatRoomSlowStop = false;
-var ChatRoomLastName = ""
-var ChatRoomLastBG = ""
-var ChatRoomLastPrivate = false
-var ChatRoomLastSize = 0
-var ChatRoomLastDesc = ""
-var ChatRoomLastAdmin = []
-var ChatRoomNewRoomToUpdate = null
-
-var ChatRoomLeashList = []
-var ChatRoomLeashPlayer = null
+var ChatRoomLastName = "";
+var ChatRoomLastBG = "";
+var ChatRoomLastPrivate = false;
+var ChatRoomLastSize = 0;
+var ChatRoomLastDesc = "";
+var ChatRoomLastAdmin = [];
+var ChatRoomNewRoomToUpdate = null;
+var ChatRoomLeashList = [];
+var ChatRoomLeashPlayer = null;
+var ChatRoomTargetDirty = false;
 
 /**
  * Checks if the player can add the current character to her whitelist.
@@ -354,15 +354,16 @@ function ChatRoomOwnerInside() {
  * @returns {void} - Nothing.
  */
 function ChatRoomDrawCharacter(DoClick) {
-
 	// Intercepts the online game chat room clicks if we need to
 	if (DoClick && OnlineGameClick()) return;
 
+	// The player's current blindness level
+	const BlindLevel = Player.GetBlindLevel();
 	// The darkness factors varies with blindness level (1 is bright, 0 is pitch black)
 	var DarkFactor = 1.0;
 	
 	// The number of characters to show in the room
-	var RenderSingle = Player.GameplaySettings && (Player.GameplaySettings.SensDepChatLog == "SensDepExtreme" && Player.GameplaySettings.BlindDisableExamine) && (Player.GetBlindLevel() >= 3);
+	var RenderSingle = Player.GameplaySettings && (Player.GameplaySettings.SensDepChatLog == "SensDepExtreme" && Player.GameplaySettings.BlindDisableExamine) && (BlindLevel >= 3);
 	var CharacterCount = RenderSingle ? 1 : ChatRoomCharacter.length;
 
 	// Determine the horizontal & vertical position and zoom levels to fit all characters evenly in the room
@@ -373,14 +374,14 @@ function ChatRoomDrawCharacter(DoClick) {
 	var InvertRoom = Player.GraphicsSettings && Player.GraphicsSettings.InvertRoom && Player.IsInverted();
 	
 	// If there's more than 2 characters, we apply a zoom factor, also apply the darkness factor if the player is blindfolded
-	if (!DoClick && Player.GetBlindLevel() < 3) {
+	if (!DoClick && BlindLevel < 3) {
 
 		// Draws the zoomed background
 		DrawImageZoomCanvas("Backgrounds/" + ChatRoomData.Background + ".jpg", MainCanvas, 500 * (2 - 1 / Zoom), 0, 1000 / Zoom, 1000, 0, Y, 1000, 1000 * Zoom, InvertRoom);
 
 		// Draws a black overlay if the character is blind
-		if (Player.GetBlindLevel() == 2) DarkFactor = 0.15;
-		else if (Player.GetBlindLevel() == 1) DarkFactor = 0.3;
+		if (BlindLevel == 2) DarkFactor = 0.15;
+		else if (BlindLevel == 1) DarkFactor = 0.3;
 		if (DarkFactor < 1.0) DrawRect(0, 0, 2000, 1000, "rgba(0,0,0," + (1.0 - DarkFactor) + ")");
 
 	}
@@ -400,7 +401,7 @@ function ChatRoomDrawCharacter(DoClick) {
 		}
 		if (DoClick) {
 			if (MouseIn(CharX, CharY, 450 * Zoom, 1000 * Zoom)) {
-				if ((MouseY <= CharY + 900 * Zoom) && (Player.GameplaySettings && Player.GameplaySettings.BlindDisableExamine ? (!(Player.GetBlindLevel() >= 3) || ChatRoomCharacter[C].ID == Player.ID) : true)) {
+				if ((MouseY <= CharY + 900 * Zoom) && (Player.GameplaySettings && Player.GameplaySettings.BlindDisableExamine ? (!(BlindLevel >= 3) || ChatRoomCharacter[C].ID == Player.ID) : true)) {
 
 					// If the arousal meter is shown for that character, we can interact with it
 					if ((ChatRoomCharacter[C].ID == 0) || (Player.ArousalSettings.ShowOtherMeter == null) || Player.ArousalSettings.ShowOtherMeter)
@@ -450,10 +451,10 @@ function ChatRoomDrawCharacter(DoClick) {
 
 				} else
 					if ((!LogQuery("BlockWhisper", "OwnerRule") || (Player.Ownership == null) || (Player.Ownership.Stage != 1) || (Player.Ownership.MemberNumber == ChatRoomCharacter[C].MemberNumber) || !ChatRoomOwnerInside())
-						&& !(Player.GameplaySettings && (Player.GameplaySettings.SensDepChatLog == "SensDepExtreme") && (Player.GetBlindLevel() >= 3)))
-						ChatRoomTargetMemberNumber = ((ChatRoomTargetMemberNumber == ChatRoomCharacter[C].MemberNumber) || (ChatRoomCharacter[C].ID == 0)) ? null : ChatRoomCharacter[C].MemberNumber;
+						&& !(Player.GameplaySettings && (Player.GameplaySettings.SensDepChatLog == "SensDepExtreme") && (BlindLevel >= 3)))
+						ChatRoomSetTarget(((ChatRoomTargetMemberNumber == ChatRoomCharacter[C].MemberNumber) || (ChatRoomCharacter[C].ID == 0)) ? null : ChatRoomCharacter[C].MemberNumber);
 						
-					else if (Player.GameplaySettings && (Player.GameplaySettings.SensDepChatLog == "SensDepExtreme") && (Player.GetBlindLevel() >= 3))
+					else if (Player.GameplaySettings && (Player.GameplaySettings.SensDepChatLog == "SensDepExtreme") && (BlindLevel >= 3))
 						ChatRoomTargetMemberNumber = null
 				break;
 			}
@@ -461,7 +462,7 @@ function ChatRoomDrawCharacter(DoClick) {
 		else {
 
 			// Draw the background a second time for characters 6 to 10 (we do it here to correct clipping errors from the first part)
-			if ((C == 5) && (Player.GetBlindLevel() < 3)) {
+			if ((C == 5) && (BlindLevel < 3)) {
 				DrawImageZoomCanvas("Backgrounds/" + ChatRoomData.Background + ".jpg", MainCanvas, 0, 0, 2000, 1000, 0, 500, 1000, 500, InvertRoom);
 				if (DarkFactor < 1.0) DrawRect(0, 500, 1000, 500, "rgba(0,0,0," + (1.0 - DarkFactor) + ")");
 			}
@@ -503,22 +504,36 @@ function ChatRoomFirstTimeHelp() {
 	}
 }
 
+function ChatRoomSetTarget(MemberNumber) {
+	if (MemberNumber !== ChatRoomTargetMemberNumber) {
+		ChatRoomTargetMemberNumber = MemberNumber;
+		ChatRoomTargetDirty = true;
+	}
+}
+
 /**
  * Sets the whisper target.
  * @returns {void} - Nothing.
  */
 function ChatRoomTarget() {
+	// If the target member number hasn't changed, do nothing
+	if (!ChatRoomTargetDirty) return;
+
 	var TargetName = null;
 	if (ChatRoomTargetMemberNumber != null) {
 		for (let C = 0; C < ChatRoomCharacter.length; C++)
-			if (ChatRoomTargetMemberNumber == ChatRoomCharacter[C].MemberNumber)
+			if (ChatRoomTargetMemberNumber == ChatRoomCharacter[C].MemberNumber) {
 				TargetName = ChatRoomCharacter[C].Name;
-		if (TargetName == null) ChatRoomTargetMemberNumber = null;
+				break;
+			}
+		if (TargetName == null) ChatRoomSetTarget(null);
 	}
-	let placeholder = TextGet("PublicChat");
+	let placeholder;
 	if (ChatRoomTargetMemberNumber != null) {
 		placeholder = TextGet("WhisperTo");
 		placeholder += " " + TargetName;
+	} else {
+		placeholder = TextGet("PublicChat");
 	}
 	document.getElementById("InputChat").placeholder = placeholder;
 }
@@ -586,7 +601,7 @@ function ChatRoomRun() {
 		ChatRoomNewRoomToUpdate = null
 	}
 	 
-	var OnlyPersonBlacklisted = (ChatRoomCharacter.length > 1) ? true : false;
+	var OnlyPersonBlacklisted = ChatRoomCharacter.length > 1;
 	
 	for (let I = 0; I < ChatRoomCharacter.length; I++) {
 		if (ChatRoomCharacter[I].ID != 0 && (Player.BlackList.indexOf(ChatRoomCharacter[I].MemberNumber) < 0 || Player.FriendList.indexOf(ChatRoomCharacter[I].MemberNumber) >= 0 || Player.IsOwnedByMemberNumber(ChatRoomCharacter[I].MemberNumber))) {
@@ -1940,7 +1955,7 @@ function ChatRoomSetRule(data) {
 
 		// Whisper rules
 		if (data.Content == "OwnerRuleWhisperAllow") LogDelete("BlockWhisper", "OwnerRule");
-		if (data.Content == "OwnerRuleWhisperBlock") { LogAdd("BlockWhisper", "OwnerRule"); ChatRoomTargetMemberNumber = null; }
+		if (data.Content == "OwnerRuleWhisperBlock") { LogAdd("BlockWhisper", "OwnerRule"); ChatRoomSetTarget(null); }
 
 		// Key rules
 		if (data.Content == "OwnerRuleKeyAllow") LogDelete("BlockKey", "OwnerRule");

--- a/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
+++ b/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
@@ -641,8 +641,10 @@ function ChatRoomRun() {
 		ChatRoomSlowStop = false;
 	}
 
+	const PlayerIsSlow = Player.IsSlow();
+
 	// If the player is slow (ex: ball & chains), she can leave the room with a timer and can be blocked by others
-	if (Player.IsSlow() && ChatRoomCanLeave() && (ChatRoomSlowStop == false)) {
+	if (PlayerIsSlow && ChatRoomCanLeave() && (ChatRoomSlowStop == false)) {
 		if (ChatRoomSlowtimer == 0) DrawButton(1005, 2, 120, 60, "", "#FFFF00", "Icons/Rectangle/Exit.png", TextGet("MenuLeave"));
 		if ((CurrentTime < ChatRoomSlowtimer) && (ChatRoomSlowtimer != 0)) DrawButton(1005, 2, 120, 60, "", "White", "Icons/Rectangle/Cancel.png", TextGet("MenuCancel"));
 		if ((CurrentTime > ChatRoomSlowtimer) && (ChatRoomSlowtimer != 0)) {
@@ -656,7 +658,7 @@ function ChatRoomRun() {
 	}
 
 	// If the player is slow and was stopped from leaving by another player
-	if ((ChatRoomSlowStop == true) && Player.IsSlow()) {
+	if ((ChatRoomSlowStop == true) && PlayerIsSlow) {
 		DrawButton(1005, 2, 120, 60, "", "Pink", "Icons/Rectangle/Exit.png", TextGet("MenuLeave"));
 		if (CurrentTime > ChatRoomSlowtimer) {
 			 ChatRoomSlowtimer = 0;
@@ -665,7 +667,7 @@ function ChatRoomRun() {
 	}
 
 	// Draws the top buttons in pink if they aren't available
-	if (!Player.IsSlow() || (ChatRoomSlowtimer == 0 && !ChatRoomCanLeave())){
+	if (!PlayerIsSlow || (ChatRoomSlowtimer == 0 && !ChatRoomCanLeave())){
 		if (ChatRoomSlowtimer != 0) ChatRoomSlowtimer = 0;
 		DrawButton(1005, 2, 120, 60, "", (ChatRoomCanLeave()) ? "White" : "Pink", "Icons/Rectangle/Exit.png", TextGet("MenuLeave"));
 	}
@@ -726,8 +728,10 @@ function ChatRoomClick() {
 	// When the user chats or clicks on a character
 	if (MouseIn(0, 0, 1000, 1000)) ChatRoomDrawCharacter(true);
 
+	const PlayerIsSlow = Player.IsSlow();
+
 	// When the user leaves
-	if (MouseIn(1005, 0, 120, 62) && ChatRoomCanLeave() && !Player.IsSlow()) {
+	if (MouseIn(1005, 0, 120, 62) && ChatRoomCanLeave() && !PlayerIsSlow) {
 		ChatRoomClearAllElements();
 		ServerSend("ChatRoomLeave", "");
 		ChatRoomSetLastChatRoom("")		
@@ -738,7 +742,7 @@ function ChatRoomClick() {
 	}
 
 	// When the player is slow and attempts to leave
-	if (MouseIn(1005, 0, 120, 62) && ChatRoomCanLeave() && Player.IsSlow()) {
+	if (MouseIn(1005, 0, 120, 62) && ChatRoomCanLeave() && PlayerIsSlow) {
 
 		// If the player clicked to leave, we start a timer based on evasion level and send a chat message
 		if ((ChatRoomSlowtimer == 0) && (ChatRoomSlowStop == false)) {

--- a/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
+++ b/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
@@ -504,6 +504,11 @@ function ChatRoomFirstTimeHelp() {
 	}
 }
 
+/**
+ * Sets the current whisper target and flags a target update
+ * @param {number} MemberNumber - The target member number to set
+ * @returns {void} - Nothing
+ */
 function ChatRoomSetTarget(MemberNumber) {
 	if (MemberNumber !== ChatRoomTargetMemberNumber) {
 		ChatRoomTargetMemberNumber = MemberNumber;
@@ -512,7 +517,7 @@ function ChatRoomSetTarget(MemberNumber) {
 }
 
 /**
- * Sets the whisper target.
+ * Updates the chat input's placeholder text to reflect the current whisper target
  * @returns {void} - Nothing.
  */
 function ChatRoomTarget() {


### PR DESCRIPTION
## Summary

Last one for today! This PR makes some simple optimisations to the chatroom code to reduce the amount of work done when just idling in a chatroom. I selected the optimisations based on running a CPU profiler over the chatroom, and identifying optimisations to functions (outside of the draw functions) that took a notable amount of time. They aren't huge performance improvements, but they're a couple of simple "easy wins" to reduce the game's overhead in chatrooms, and might benefit those with slower devices.

The changes that were made are:

* Reduces duplicated use of `Player.GetGagLevel()` and `Player.IsSlow()` by calculating once and assigning to a variable
* Reduces the overhead of the `ChatRoomTarget()` function - this gets called every frame and was accounting for about 7% of CPU time when idling in a chatroom (presumably due to the text lookup and DOM manipulation). Chatroom target updates now go through a new `ChatRoomSetTarget()` function, which sets a dirty flag accordingly. The main body of `ChatRoomTarget()` then only runs if the dirty flag is set, reducing the function's CPU time when idling to < 0.1% 