### PR TITLE
Longer messages & bio (with bio compression)

### DIFF
--- a/BondageClub/Screens/Character/Login/Login.js
+++ b/BondageClub/Screens/Character/Login/Login.js
@@ -361,7 +361,7 @@ function LoginResponse(C) {
 			if (CommonIsNumeric(C.Money)) Player.Money = C.Money;
 			Player.Owner = ((C.Owner == null) || (C.Owner == "undefined")) ? "" : C.Owner;
 			Player.Game = C.Game;
-			Player.Description = (C.Description == null) ? "" : C.Description.substr(0, 1000);
+			Player.Description = (C.Description == null) ? "" : C.Description.substr(0, 10000);
 			Player.Creation = C.Creation;
 			Player.Wardrobe = CharacterDecompressWardrobe(C.Wardrobe);
 			WardrobeFixLength();

--- a/BondageClub/Screens/Character/Login/Login.js
+++ b/BondageClub/Screens/Character/Login/Login.js
@@ -361,6 +361,9 @@ function LoginResponse(C) {
 			if (CommonIsNumeric(C.Money)) Player.Money = C.Money;
 			Player.Owner = ((C.Owner == null) || (C.Owner == "undefined")) ? "" : C.Owner;
 			Player.Game = C.Game;
+			if (typeof C.Description === "string" && C.Description.startsWith("--compressed-")) {
+				C.Description = LZString.decompressFromUTF16(C.Description.substr(13));
+			}
 			Player.Description = (C.Description == null) ? "" : C.Description.substr(0, 10000);
 			Player.Creation = C.Creation;
 			Player.Wardrobe = CharacterDecompressWardrobe(C.Wardrobe);

--- a/BondageClub/Screens/Character/Login/Login.js
+++ b/BondageClub/Screens/Character/Login/Login.js
@@ -361,8 +361,8 @@ function LoginResponse(C) {
 			if (CommonIsNumeric(C.Money)) Player.Money = C.Money;
 			Player.Owner = ((C.Owner == null) || (C.Owner == "undefined")) ? "" : C.Owner;
 			Player.Game = C.Game;
-			if (typeof C.Description === "string" && C.Description.startsWith("--compressed-")) {
-				C.Description = LZString.decompressFromUTF16(C.Description.substr(13));
+			if (typeof C.Description === "string" && C.Description.startsWith("╬")) {
+				C.Description = LZString.decompressFromUTF16(C.Description.substr(1));
 			}
 			Player.Description = (C.Description == null) ? "" : C.Description.substr(0, 10000);
 			Player.Creation = C.Creation;

--- a/BondageClub/Screens/Character/OnlineProfile/OnlineProfile.js
+++ b/BondageClub/Screens/Character/OnlineProfile/OnlineProfile.js
@@ -48,8 +48,8 @@ function OnlineProfileExit(Save) {
     if ((InformationSheetSelection.ID == 0) && (InformationSheetSelection.Description != ElementValue("DescriptionInput").trim()) && Save) {
         InformationSheetSelection.Description = ElementValue("DescriptionInput").trim().substr(0, 10000);
         let Description = InformationSheetSelection.Description;
-        const CompressedDescription = "--compressed-" + LZString.compressToUTF16(Description)
-        if (CompressedDescription.length < Description.length || Description.startsWith("--compressed-")) {
+        const CompressedDescription = "╬" + LZString.compressToUTF16(Description)
+        if (CompressedDescription.length < Description.length || Description.startsWith("╬")) {
             Description = CompressedDescription;
         }
         ServerSend("AccountUpdate", { Description });

--- a/BondageClub/Screens/Character/OnlineProfile/OnlineProfile.js
+++ b/BondageClub/Screens/Character/OnlineProfile/OnlineProfile.js
@@ -47,7 +47,7 @@ function OnlineProfileExit(Save) {
     // If the current character is the player, we update the description
     if ((InformationSheetSelection.ID == 0) && (InformationSheetSelection.Description != ElementValue("DescriptionInput").trim()) && Save) {
         InformationSheetSelection.Description = ElementValue("DescriptionInput").trim().substr(0, 10000);
-        ServerSend("AccountUpdate", { Description: InformationSheetSelection.Description });
+        ServerSend("AccountUpdate", { Description: "--compressed-" + LZString.compressToUTF16(InformationSheetSelection.Description) });
         ChatRoomCharacterUpdate(InformationSheetSelection);
     }
     ElementRemove("DescriptionInput");

--- a/BondageClub/Screens/Character/OnlineProfile/OnlineProfile.js
+++ b/BondageClub/Screens/Character/OnlineProfile/OnlineProfile.js
@@ -9,7 +9,7 @@ function OnlineProfileLoad() {
     ElementRemove("DescriptionInput");
     ElementCreateTextArea("DescriptionInput");
     var DescriptionInput = document.getElementById("DescriptionInput");
-    DescriptionInput.setAttribute("maxlength", 1000);
+    DescriptionInput.setAttribute("maxlength", 10000);
     DescriptionInput.value = (InformationSheetSelection.Description != null) ? InformationSheetSelection.Description : "";
     if (InformationSheetSelection.ID != 0) DescriptionInput.setAttribute("readonly", "readonly");
 }
@@ -46,7 +46,7 @@ function OnlineProfileClick() {
 function OnlineProfileExit(Save) {
     // If the current character is the player, we update the description
     if ((InformationSheetSelection.ID == 0) && (InformationSheetSelection.Description != ElementValue("DescriptionInput").trim()) && Save) {
-        InformationSheetSelection.Description = ElementValue("DescriptionInput").trim().substr(0, 1000);
+        InformationSheetSelection.Description = ElementValue("DescriptionInput").trim().substr(0, 10000);
         ServerSend("AccountUpdate", { Description: InformationSheetSelection.Description });
         ChatRoomCharacterUpdate(InformationSheetSelection);
     }

--- a/BondageClub/Screens/Character/OnlineProfile/OnlineProfile.js
+++ b/BondageClub/Screens/Character/OnlineProfile/OnlineProfile.js
@@ -47,7 +47,12 @@ function OnlineProfileExit(Save) {
     // If the current character is the player, we update the description
     if ((InformationSheetSelection.ID == 0) && (InformationSheetSelection.Description != ElementValue("DescriptionInput").trim()) && Save) {
         InformationSheetSelection.Description = ElementValue("DescriptionInput").trim().substr(0, 10000);
-        ServerSend("AccountUpdate", { Description: "--compressed-" + LZString.compressToUTF16(InformationSheetSelection.Description) });
+        let Description = InformationSheetSelection.Description;
+        const CompressedDescription = "--compressed-" + LZString.compressToUTF16(Description)
+        if (CompressedDescription.length < Description.length || Description.startsWith("--compressed-")) {
+            Description = CompressedDescription;
+        }
+        ServerSend("AccountUpdate", { Description });
         ChatRoomCharacterUpdate(InformationSheetSelection);
     }
     ElementRemove("DescriptionInput");

--- a/BondageClub/Screens/Character/OnlineProfile/Text_OnlineProfile.csv
+++ b/BondageClub/Screens/Character/OnlineProfile/Text_OnlineProfile.csv
@@ -1,4 +1,4 @@
-EnterDescription,Enter your online description (1000 characters maximum)
+EnterDescription,Enter your online description (10000 characters maximum)
 ViewDescription,CharacterName's online description
 Leave,Exit profile
 LeaveSave,Accept changes

--- a/BondageClub/Screens/Character/OnlineProfile/Text_OnlineProfile_DE.txt
+++ b/BondageClub/Screens/Character/OnlineProfile/Text_OnlineProfile_DE.txt
@@ -1,4 +1,4 @@
-Enter your online description (1000 characters maximum)
-Gib deine Online-Beschreibung ein (maximal 1000 Zeichen)
+Enter your online description (10000 characters maximum)
+Gib deine Online-Beschreibung ein (maximal 10000 Zeichen)
 CharacterName's online description
 CharacterNames Online-Beschreibung

--- a/BondageClub/Screens/Character/OnlineProfile/Text_OnlineProfile_FR.txt
+++ b/BondageClub/Screens/Character/OnlineProfile/Text_OnlineProfile_FR.txt
@@ -1,5 +1,5 @@
-﻿Enter your online description (1000 characters maximum)
-Entrez votre description en ligne (1000 caractères maximum)
+﻿Enter your online description (10000 characters maximum)
+Entrez votre description en ligne (10000 caractères maximum)
 CharacterName's online description
 Description de CharacterName en ligne
 Exit profile

--- a/BondageClub/Screens/Character/OnlineProfile/Text_OnlineProfile_RU.txt
+++ b/BondageClub/Screens/Character/OnlineProfile/Text_OnlineProfile_RU.txt
@@ -1,4 +1,4 @@
-﻿Enter your online description (1000 characters maximum)
-Введите описание в Интернете (1000 максимум символов)
+﻿Enter your online description (10000 characters maximum)
+Введите описание в Интернете (10000 максимум символов)
 CharacterName's online description
 Имя персонажа Описание в интернете

--- a/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
+++ b/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
@@ -235,7 +235,7 @@ function ChatRoomCreateElement() {
 	// Creates the chat box
 	if (document.getElementById("InputChat") == null) {
 		ElementCreateTextArea("InputChat");
-		document.getElementById("InputChat").setAttribute("maxLength", 250);
+		document.getElementById("InputChat").setAttribute("maxLength", 1000);
 		document.getElementById("InputChat").setAttribute("autocomplete", "off");
 		ElementFocus("InputChat");
 	} else if (document.getElementById("InputChat").style.display == "none") ElementFocus("InputChat");

--- a/BondageClub/Scripts/Character.js
+++ b/BondageClub/Scripts/Character.js
@@ -349,8 +349,8 @@ function CharacterLoadOnline(data, SourceMemberNumber) {
 				Char = Character[C];
 
 	// Decompresses description
-	if (typeof data.Description === "string" && data.Description.startsWith("--compressed-")) {
-		data.Description = LZString.decompressFromUTF16(data.Description.substr(13));
+	if (typeof data.Description === "string" && data.Description.startsWith("╬")) {
+		data.Description = LZString.decompressFromUTF16(data.Description.substr(1));
 	}
 
 	// If the character isn't found

--- a/BondageClub/Scripts/Character.js
+++ b/BondageClub/Scripts/Character.js
@@ -348,6 +348,11 @@ function CharacterLoadOnline(data, SourceMemberNumber) {
 			if (Character[C].AccountName == "Online-" + data.ID.toString())
 				Char = Character[C];
 
+	// Decompresses description
+	if (typeof data.Description === "string" && data.Description.startsWith("--compressed-")) {
+		data.Description = LZString.decompressFromUTF16(data.Description.substr(13));
+	}
+
 	// If the character isn't found
 	if (Char == null) {
 		// We delete the duplicate character if the person relogged.
@@ -364,7 +369,6 @@ function CharacterLoadOnline(data, SourceMemberNumber) {
 		Char.Lover = (data.Lover != null) ? data.Lover : "";
 		Char.Owner = (data.Owner != null) ? data.Owner : "";
 		Char.Title = data.Title;
-		Char.Description = data.Description;
 		Char.AccountName = "Online-" + data.ID.toString();
 		Char.MemberNumber = data.MemberNumber;
 		Char.Difficulty = data.Difficulty;


### PR DESCRIPTION
Extension of #1956 by @Shiranui-Izayoi 

> Lengthened the Chat Messages to 1000 characters so 4 times the original length because honestly 250 is way to short for more detailed RP.
> 
 > Lengthed the max length of Bios to 10,000 characters as it is crazy hard to explain yourself in 1000 characters. While most likely won't use it, it is nice for those that do.
> 
> If there is a reason that it is limited like this then please let me know. But to my knowledge there is no reason for it to be like this. Since it only hurts those that want to go into more detail. Like myself.

Additionally the Bio is compressed (if it is efficient or required) on update and decompressed on character load.

**Breaking changes:**
Current version users will see beta user's description as `╬` + lots of random characters
Beta users will see current version user's description without problem
If current version user has description, that literally starts with `╬` It will be lost when they first try editing it in Beta/Next version.

Originally was prefixed with `--compressed-`, but changed to `╬` on Ben's request.