### PR TITLE
Bugfix: Adds type definitions for the new asset properties

### DIFF
--- a/BondageClub/Tools/Node/AssetCheck_Types.js
+++ b/BondageClub/Tools/Node/AssetCheck_Types.js
@@ -31,7 +31,8 @@ const AssetGroupType = {
 	FullAlpha: "Maybe Boolean",
 	Blink: "Maybe Boolean",
 	InheritColor: "Maybe String",
-	FreezeActivePose: "Maybe [String]"
+	FreezeActivePose: "Maybe [String]",
+
 };
 
 const AssetType = {
@@ -56,6 +57,8 @@ const AssetType = {
 	Require: "[String]",
 	SetPose: "[String]",
 	AllowPose: "[String]",
+	HideForPose: "[String]",
+	OverrideAllowPose: "[String]",
 	AllowActivePose: "[String]",
 	WhitelistActivePose: "[String]",
 	Value: "Number",


### PR DESCRIPTION
This adds asset property definitions to the asset type check script for the new asset properties that were added as part of #1936 (I was going to update that PR, but it got merged before I could).