### PR TITLE
Appearance Dynamic Menu Buttons

### DIFF
--- a/BondageClub/Screens/Character/Appearance/Text_Appearance.csv
+++ b/BondageClub/Screens/Character/Appearance/Text_Appearance.csv
@@ -15,4 +15,4 @@ Accept,Accept changes
 Wardrobe,Wardrobe
 DialogPermissionMode,Edit item permissions
 Use,Use this item
-Reset,
+Reset,Reset character

--- a/BondageClub/Screens/Character/Appearance/Text_Appearance.csv
+++ b/BondageClub/Screens/Character/Appearance/Text_Appearance.csv
@@ -13,4 +13,6 @@ Prev,Previous
 Cancel,Cancel changes
 Accept,Accept changes
 Wardrobe,Wardrobe
-DressManually,Dress manually
+DialogPermissionMode,Edit item permissions
+Use,Use this item
+Reset,


### PR DESCRIPTION
This refactors the appearance/clothing code so that the row of buttons at the top are built dynamically, similar to the menu buttons in the inventory items screen.
This will mean better use of space, make it easier to add new buttons, and reduces the work in the Run function.
The behaviour is all the same as before except in the Wardrobe and Permissions subscreens, which now use the green tick/accept button to jump back one screen instead of having unique "dress manually" and "reset" exit buttons, to make them more consistent with the rest of the appearance subscreens.