### PR TITLE
Bed Rope access fix

### DIFF
--- a/BondageClub/Screens/Inventory/ItemFeet/HempRope/HempRope.js
+++ b/BondageClub/Screens/Inventory/ItemFeet/HempRope/HempRope.js
@@ -29,7 +29,7 @@ const HempRopeFeetOptions = [
 	}, {
 		Name: "BedSpreadEagle",
 		BondageLevel: 1,
-		Property: { Type: "BedSpreadEagle", Effect: ["Block", "Freeze", "Prone"], Block: ["ItemLegs", "ItemBoots", "ItemDevices"], AllowActivityOn: ["ItemLegs", "ItemBoots"], SetPose: ["Spread"], Difficulty: 5 },
+		Property: { Type: "BedSpreadEagle", Effect: ["Freeze", "Prone"], Block: ["ItemLegs", "ItemBoots", "ItemDevices"], AllowActivityOn: ["ItemLegs", "ItemBoots"], SetPose: ["Spread"], Difficulty: 5 },
 		Prerequisite: ["OnBed", "NoItemLegs", "LegsOpen"],
 		SelfBlockCheck: true,
 	}


### PR DESCRIPTION
The ItemFeet ropes which tie the legs to the bed were blocking the character from interacting with anything, as if their arms were bound.