### PR TITLE
Optimise DialogFind for Player + error message

### DIFF
--- a/BondageClub/Backgrounds/Backgrounds.js
+++ b/BondageClub/Backgrounds/Backgrounds.js
@@ -198,7 +198,7 @@ function BackgroundsGenerateList(BackgroundTagList) {
 		for (let T = 0; T < BackgroundsList[B].Tag.length; T++)
 			if (BackgroundTagList.indexOf(BackgroundsList[B].Tag[T]) >= 0) {
 				List.push(BackgroundsList[B].Name);
-				var Desc = DialogFind(Player, BackgroundsList[B].Name);
+				var Desc = GetPlayerDialog(BackgroundsList[B].Name);
 				BackgroundSelectionAll.push({ Name: BackgroundsList[B].Name, Description: Desc, Low: Desc.toLowerCase() });
 				break;
 			}

--- a/BondageClub/Backgrounds/Backgrounds.js
+++ b/BondageClub/Backgrounds/Backgrounds.js
@@ -198,7 +198,7 @@ function BackgroundsGenerateList(BackgroundTagList) {
 		for (let T = 0; T < BackgroundsList[B].Tag.length; T++)
 			if (BackgroundTagList.indexOf(BackgroundsList[B].Tag[T]) >= 0) {
 				List.push(BackgroundsList[B].Name);
-				var Desc = GetPlayerDialog(BackgroundsList[B].Name);
+				var Desc = DialogFindPlayer(BackgroundsList[B].Name);
 				BackgroundSelectionAll.push({ Name: BackgroundsList[B].Name, Description: Desc, Low: Desc.toLowerCase() });
 				break;
 			}

--- a/BondageClub/Screens/Character/BackgroundSelection/BackgroundSelection.js
+++ b/BondageClub/Screens/Character/BackgroundSelection/BackgroundSelection.js
@@ -50,7 +50,7 @@ function BackGroundSelectionSort(a, b) {
  */
 function BackgroundSelectionLoad() {
 	BackgroundSelectionSelect = BackgroundSelectionList[BackgroundSelectionIndex];
-	BackgroundSelectionSelectName = GetPlayerDialog(BackgroundSelectionSelect);
+	BackgroundSelectionSelectName = DialogFindPlayer(BackgroundSelectionSelect);
 	BackgroundSelectionOffset = Math.floor(BackgroundSelectionIndex / BackgroundSelectionSize) * BackgroundSelectionSize;
 	BackgroundSelectionBackground = BackgroundSelectionList[BackgroundSelectionIndex] || "Introduction";
 	BackgroundSelectionView = BackgroundSelectionAll.slice(0).sort(BackGroundSelectionSort);
@@ -168,7 +168,7 @@ function BackgroundSelectionClick() {
 			if (BackgroundSelectionIndex >= BackgroundSelectionView.length) BackgroundSelectionIndex = 0;
 			if (BackgroundSelectionIndex < 0) BackgroundSelectionIndex = BackgroundSelectionView.length - 1;
 			BackgroundSelectionSelect = BackgroundSelectionView[BackgroundSelectionIndex].Name;
-			BackgroundSelectionSelectName = GetPlayerDialog(BackgroundSelectionSelect);
+			BackgroundSelectionSelectName = DialogFindPlayer(BackgroundSelectionSelect);
 			BackgroundSelectionBackground = BackgroundSelectionSelect;
 		}
 		X += 450 + 35;

--- a/BondageClub/Screens/Character/BackgroundSelection/BackgroundSelection.js
+++ b/BondageClub/Screens/Character/BackgroundSelection/BackgroundSelection.js
@@ -50,7 +50,7 @@ function BackGroundSelectionSort(a, b) {
  */
 function BackgroundSelectionLoad() {
 	BackgroundSelectionSelect = BackgroundSelectionList[BackgroundSelectionIndex];
-	BackgroundSelectionSelectName = DialogFind(Player, BackgroundSelectionSelect);
+	BackgroundSelectionSelectName = GetPlayerDialog(BackgroundSelectionSelect);
 	BackgroundSelectionOffset = Math.floor(BackgroundSelectionIndex / BackgroundSelectionSize) * BackgroundSelectionSize;
 	BackgroundSelectionBackground = BackgroundSelectionList[BackgroundSelectionIndex] || "Introduction";
 	BackgroundSelectionView = BackgroundSelectionAll.slice(0).sort(BackGroundSelectionSort);
@@ -168,7 +168,7 @@ function BackgroundSelectionClick() {
 			if (BackgroundSelectionIndex >= BackgroundSelectionView.length) BackgroundSelectionIndex = 0;
 			if (BackgroundSelectionIndex < 0) BackgroundSelectionIndex = BackgroundSelectionView.length - 1;
 			BackgroundSelectionSelect = BackgroundSelectionView[BackgroundSelectionIndex].Name;
-			BackgroundSelectionSelectName = DialogFind(Player, BackgroundSelectionSelect);
+			BackgroundSelectionSelectName = GetPlayerDialog(BackgroundSelectionSelect);
 			BackgroundSelectionBackground = BackgroundSelectionSelect;
 		}
 		X += 450 + 35;

--- a/BondageClub/Screens/Character/FriendList/FriendList.js
+++ b/BondageClub/Screens/Character/FriendList/FriendList.js
@@ -93,13 +93,13 @@ function FriendListLoadFriendList(data) {
 	FriendListNextCheck = CurrentTime + 30000;
 
 	// Loads the header caption
-	const BeepCaption = GetPlayerDialog("Beep");
-	const DeleteCaption = GetPlayerDialog("Delete");
-	const ConfirmDeleteCaption = GetPlayerDialog("ConfirmDelete");
-	const PrivateRoomCaption = GetPlayerDialog("PrivateRoom");
-	const SentCaption = GetPlayerDialog("SentBeep");
-	const ReceivedCaption = GetPlayerDialog("ReceivedBeep");
-	const SpaceAsylumCaption = GetPlayerDialog("ChatRoomSpaceAsylum");
+	const BeepCaption = DialogFindPlayer("Beep");
+	const DeleteCaption = DialogFindPlayer("Delete");
+	const ConfirmDeleteCaption = DialogFindPlayer("ConfirmDelete");
+	const PrivateRoomCaption = DialogFindPlayer("PrivateRoom");
+	const SentCaption = DialogFindPlayer("SentBeep");
+	const ReceivedCaption = DialogFindPlayer("ReceivedBeep");
+	const SpaceAsylumCaption = DialogFindPlayer("ChatRoomSpaceAsylum");
 	const FriendTypeCaption = {
 		Owner: TextGet("TypeOwner"),
 		Lover: TextGet("TypeLover"),

--- a/BondageClub/Screens/Character/FriendList/FriendList.js
+++ b/BondageClub/Screens/Character/FriendList/FriendList.js
@@ -93,13 +93,13 @@ function FriendListLoadFriendList(data) {
 	FriendListNextCheck = CurrentTime + 30000;
 
 	// Loads the header caption
-	const BeepCaption = DialogFind(Player, "Beep");
-	const DeleteCaption = DialogFind(Player, "Delete");
-	const ConfirmDeleteCaption = DialogFind(Player, "ConfirmDelete");
-	const PrivateRoomCaption = DialogFind(Player, "PrivateRoom");
-	const SentCaption = DialogFind(Player, "SentBeep");
-	const ReceivedCaption = DialogFind(Player, "ReceivedBeep");
-	const SpaceAsylumCaption = DialogFind(Player, "ChatRoomSpaceAsylum");
+	const BeepCaption = GetPlayerDialog("Beep");
+	const DeleteCaption = GetPlayerDialog("Delete");
+	const ConfirmDeleteCaption = GetPlayerDialog("ConfirmDelete");
+	const PrivateRoomCaption = GetPlayerDialog("PrivateRoom");
+	const SentCaption = GetPlayerDialog("SentBeep");
+	const ReceivedCaption = GetPlayerDialog("ReceivedBeep");
+	const SpaceAsylumCaption = GetPlayerDialog("ChatRoomSpaceAsylum");
 	const FriendTypeCaption = {
 		Owner: TextGet("TypeOwner"),
 		Lover: TextGet("TypeLover"),

--- a/BondageClub/Screens/Inventory/HairAccessory3/Halo/Halo.js
+++ b/BondageClub/Screens/Inventory/HairAccessory3/Halo/Halo.js
@@ -62,7 +62,7 @@ function InventoryHairAccessory3HaloDraw() {
 	ElementPosition(InventoryHairAccessory3HaloBrightnessInputId, 1725, 430, 400);
 	MainCanvas.textAlign = "center";
 
-	DrawTextFit(DialogFind(Player, "InventoryHairAccessory3HaloType"), 1500, 530, 800, "#fff", "#000");
+	DrawTextFit(GetPlayerDialog("InventoryHairAccessory3HaloType"), 1500, 530, 800, "#fff", "#000");
 
 	InventoryHairAccessory3HaloOptions.forEach((option, i) => {
 		const x = ExtendedXY[InventoryHairAccessory3HaloOptions.length][i][0];
@@ -71,7 +71,7 @@ function InventoryHairAccessory3HaloDraw() {
 
 		DrawButton(x, y, 225, 275, "", isSelected ? "#888" : "#fff", null, null, isSelected);
 		DrawImage("Screens/Inventory/" + asset.DynamicGroupName + "/" + asset.Name + "/" + option.Name + ".png", x + 2, y);
-		DrawTextFit(DialogFind(Player, "InventoryHairAccessory3HaloType" + option.Name), x + 112, y + 250, 225, "#000");
+		DrawTextFit(GetPlayerDialog("InventoryHairAccessory3HaloType" + option.Name), x + 112, y + 250, 225, "#000");
 	});
 }
 

--- a/BondageClub/Screens/Inventory/HairAccessory3/Halo/Halo.js
+++ b/BondageClub/Screens/Inventory/HairAccessory3/Halo/Halo.js
@@ -62,7 +62,7 @@ function InventoryHairAccessory3HaloDraw() {
 	ElementPosition(InventoryHairAccessory3HaloBrightnessInputId, 1725, 430, 400);
 	MainCanvas.textAlign = "center";
 
-	DrawTextFit(GetPlayerDialog("InventoryHairAccessory3HaloType"), 1500, 530, 800, "#fff", "#000");
+	DrawTextFit(DialogFindPlayer("InventoryHairAccessory3HaloType"), 1500, 530, 800, "#fff", "#000");
 
 	InventoryHairAccessory3HaloOptions.forEach((option, i) => {
 		const x = ExtendedXY[InventoryHairAccessory3HaloOptions.length][i][0];
@@ -71,7 +71,7 @@ function InventoryHairAccessory3HaloDraw() {
 
 		DrawButton(x, y, 225, 275, "", isSelected ? "#888" : "#fff", null, null, isSelected);
 		DrawImage("Screens/Inventory/" + asset.DynamicGroupName + "/" + asset.Name + "/" + option.Name + ".png", x + 2, y);
-		DrawTextFit(GetPlayerDialog("InventoryHairAccessory3HaloType" + option.Name), x + 112, y + 250, 225, "#000");
+		DrawTextFit(DialogFindPlayer("InventoryHairAccessory3HaloType" + option.Name), x + 112, y + 250, 225, "#000");
 	});
 }
 

--- a/BondageClub/Screens/Inventory/ItemArms/Chains/Chains.js
+++ b/BondageClub/Screens/Inventory/ItemArms/Chains/Chains.js
@@ -118,7 +118,7 @@ function InventoryItemArmsChainsValidate(C, Option) {
 	var Allowed = "";
 
 	if (InventoryItemHasEffect(DialogFocusItem, "Lock", true)) {
-		Allowed = DialogFind(Player, "CantChangeWhileLocked");
+		Allowed = GetPlayerDialog("CantChangeWhileLocked");
 	} else if (Option.Prerequisite) {
 		if (!ExtendedItemSelfProofRequirementCheck(C, Option.Prerequisite)) {
 			Allowed = DialogText;

--- a/BondageClub/Screens/Inventory/ItemArms/Chains/Chains.js
+++ b/BondageClub/Screens/Inventory/ItemArms/Chains/Chains.js
@@ -118,7 +118,7 @@ function InventoryItemArmsChainsValidate(C, Option) {
 	var Allowed = "";
 
 	if (InventoryItemHasEffect(DialogFocusItem, "Lock", true)) {
-		Allowed = GetPlayerDialog("CantChangeWhileLocked");
+		Allowed = DialogFindPlayer("CantChangeWhileLocked");
 	} else if (Option.Prerequisite) {
 		if (!ExtendedItemSelfProofRequirementCheck(C, Option.Prerequisite)) {
 			Allowed = DialogText;

--- a/BondageClub/Screens/Inventory/ItemArms/FullLatexSuit/FullLatexSuit.js
+++ b/BondageClub/Screens/Inventory/ItemArms/FullLatexSuit/FullLatexSuit.js
@@ -17,17 +17,17 @@ function InventoryItemArmsFullLatexSuitDraw() {
 	// Draw the item image and top controls
 	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
 	DrawRect(1387, 125, 225, 275, "white");
-	DrawText(DialogFind(Player, "SelectSuitType"), 1500, 50, "white", "gray");
+	DrawText(GetPlayerDialog("SelectSuitType"), 1500, 50, "white", "gray");
 	DrawImageResize("Assets/" + DialogFocusItem.Asset.Group.Family + "/" + DialogFocusItem.Asset.Group.Name + "/Preview/" + DialogFocusItem.Asset.Name + ".png", 1389, 127, 221, 221);
 	DrawTextFit(DialogFocusItem.Asset.Description, 1500, 375, 221, "black");
 
 	// Draw the suits options
 	DrawButton(1150, 440, 225, 225, "", (DialogFocusItem.Property.Type == null || DialogFocusItem.Property.Type == "Latex") ? "#888888" : "White");
 	DrawImage("Screens/Inventory/" + DialogFocusItem.Asset.Group.Name + "/" + DialogFocusItem.Asset.Name + "/Latex.png", 1150, 439);
-	DrawText(DialogFind(Player, "FullLatexSuitTypeZipped"), 1263, 425, "white", "gray");
+	DrawText(GetPlayerDialog("FullLatexSuitTypeZipped"), 1263, 425, "white", "gray");
 	DrawButton(1600, 440, 225, 225, "", ((DialogFocusItem.Property.Type != null) && (DialogFocusItem.Property.Type == "UnZip")) ? "#888888" : "White");
 	DrawImage("Screens/Inventory/" + DialogFocusItem.Asset.Group.Name + "/" + DialogFocusItem.Asset.Name + "/UnZip.png", 1600, 439);
-	DrawText(DialogFind(Player, "FullLatexSuitTypeUnZip"), 1713, 425, "white", "gray");
+	DrawText(GetPlayerDialog("FullLatexSuitTypeUnZip"), 1713, 425, "white", "gray");
 	if (InventoryGet(C, "ItemVulvaPiercings") == null ||
 		!InventoryGet(C, "ItemVulvaPiercings").Asset ||
 		!InventoryGet(C, "ItemVulvaPiercings").Asset.Effect ||
@@ -35,9 +35,9 @@ function InventoryItemArmsFullLatexSuitDraw() {
 		if (InventoryGet(((Player.FocusGroup != null) ? Player : CurrentCharacter), "ItemVulva") == null) {
 			DrawButton(1375, 750, 225, 225, "", (InventoryGet(C, "ItemVulva") == null) ? "White" : "White");
 			DrawImage("Screens/Inventory/" + DialogFocusItem.Asset.Group.Name + "/" + DialogFocusItem.Asset.Name + "/Wand.png", 1375, 749);
-			DrawText(DialogFind(Player, "FullLatexSuitTypeWand"), 1488, 725, "white", "gray");
+			DrawText(GetPlayerDialog("FullLatexSuitTypeWand"), 1488, 725, "white", "gray");
 		} else
-			DrawText(DialogFind(Player, "CheckVulvaForWand"), 1500, 690, "white", "gray");
+			DrawText(GetPlayerDialog("CheckVulvaForWand"), 1500, 690, "white", "gray");
 
 }
 

--- a/BondageClub/Screens/Inventory/ItemArms/FullLatexSuit/FullLatexSuit.js
+++ b/BondageClub/Screens/Inventory/ItemArms/FullLatexSuit/FullLatexSuit.js
@@ -17,17 +17,17 @@ function InventoryItemArmsFullLatexSuitDraw() {
 	// Draw the item image and top controls
 	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
 	DrawRect(1387, 125, 225, 275, "white");
-	DrawText(GetPlayerDialog("SelectSuitType"), 1500, 50, "white", "gray");
+	DrawText(DialogFindPlayer("SelectSuitType"), 1500, 50, "white", "gray");
 	DrawImageResize("Assets/" + DialogFocusItem.Asset.Group.Family + "/" + DialogFocusItem.Asset.Group.Name + "/Preview/" + DialogFocusItem.Asset.Name + ".png", 1389, 127, 221, 221);
 	DrawTextFit(DialogFocusItem.Asset.Description, 1500, 375, 221, "black");
 
 	// Draw the suits options
 	DrawButton(1150, 440, 225, 225, "", (DialogFocusItem.Property.Type == null || DialogFocusItem.Property.Type == "Latex") ? "#888888" : "White");
 	DrawImage("Screens/Inventory/" + DialogFocusItem.Asset.Group.Name + "/" + DialogFocusItem.Asset.Name + "/Latex.png", 1150, 439);
-	DrawText(GetPlayerDialog("FullLatexSuitTypeZipped"), 1263, 425, "white", "gray");
+	DrawText(DialogFindPlayer("FullLatexSuitTypeZipped"), 1263, 425, "white", "gray");
 	DrawButton(1600, 440, 225, 225, "", ((DialogFocusItem.Property.Type != null) && (DialogFocusItem.Property.Type == "UnZip")) ? "#888888" : "White");
 	DrawImage("Screens/Inventory/" + DialogFocusItem.Asset.Group.Name + "/" + DialogFocusItem.Asset.Name + "/UnZip.png", 1600, 439);
-	DrawText(GetPlayerDialog("FullLatexSuitTypeUnZip"), 1713, 425, "white", "gray");
+	DrawText(DialogFindPlayer("FullLatexSuitTypeUnZip"), 1713, 425, "white", "gray");
 	if (InventoryGet(C, "ItemVulvaPiercings") == null ||
 		!InventoryGet(C, "ItemVulvaPiercings").Asset ||
 		!InventoryGet(C, "ItemVulvaPiercings").Asset.Effect ||
@@ -35,9 +35,9 @@ function InventoryItemArmsFullLatexSuitDraw() {
 		if (InventoryGet(((Player.FocusGroup != null) ? Player : CurrentCharacter), "ItemVulva") == null) {
 			DrawButton(1375, 750, 225, 225, "", (InventoryGet(C, "ItemVulva") == null) ? "White" : "White");
 			DrawImage("Screens/Inventory/" + DialogFocusItem.Asset.Group.Name + "/" + DialogFocusItem.Asset.Name + "/Wand.png", 1375, 749);
-			DrawText(GetPlayerDialog("FullLatexSuitTypeWand"), 1488, 725, "white", "gray");
+			DrawText(DialogFindPlayer("FullLatexSuitTypeWand"), 1488, 725, "white", "gray");
 		} else
-			DrawText(GetPlayerDialog("CheckVulvaForWand"), 1500, 690, "white", "gray");
+			DrawText(DialogFindPlayer("CheckVulvaForWand"), 1500, 690, "white", "gray");
 
 }
 

--- a/BondageClub/Screens/Inventory/ItemArms/HighSecurityStraitJacket/HighSecurityStraitJacket.js
+++ b/BondageClub/Screens/Inventory/ItemArms/HighSecurityStraitJacket/HighSecurityStraitJacket.js
@@ -99,7 +99,7 @@ function InventoryItemArmsHighSecurityStraitJacketLoad() {
 		CharacterRefresh(C);
 		ChatRoomCharacterItemUpdate(C, DialogFocusItem.Asset.Group.Name);
 	}
-	DialogExtendedMessage = DialogFind(Player, "ItemArmsHighSecurityStraitJacketSelectBase");
+	DialogExtendedMessage = GetPlayerDialog("ItemArmsHighSecurityStraitJacketSelectBase");
 }
 
 function InventoryItemArmsHighSecurityStraitJacketCall(functionMap) {
@@ -117,7 +117,7 @@ function InventoryItemArmsHighSecurityStraitJacketClick() {
 
 function InventoryItemArmsHighSecurityStraitJacketPageTransition(newPage) {
 	InventoryItemArmsHighSecurityStraitJacketPage = newPage;
-	DialogExtendedMessage = DialogFind(Player, "ItemArmsHighSecurityStraitJacketSelect" + newPage);
+	DialogExtendedMessage = GetPlayerDialog("ItemArmsHighSecurityStraitJacketSelect" + newPage);
 }
 
 function InventoryItemArmsHighSecurityStraitJacketDrawCommon(buttonDefinitions) {
@@ -133,7 +133,7 @@ function InventoryItemArmsHighSecurityStraitJacketDrawCommon(buttonDefinitions) 
 		var y = 450 + (Math.floor(i / 2) * 300);
 		DrawButton(x, y, 225, 225, "", buttonDefinition[2] || "#fff");
 		DrawImage(buttonDefinition[0], x, y);
-		DrawText(DialogFind(Player, buttonDefinition[1]), x + 113, y - 20, "#fff", "#808080");
+		DrawText(GetPlayerDialog(buttonDefinition[1]), x + 113, y - 20, "#fff", "#808080");
 	});
 }
 
@@ -238,13 +238,13 @@ function InventoryItemArmsHighSecurityStraitJacketSetType(option) {
 
 	// Lock check - cannot change type if you can't unlock the item
 	if (DialogFocusItem.Property.LockedBy && !DialogCanUnlock(C, DialogFocusItem)) {
-		DialogExtendedMessage = DialogFind(Player, "CantChangeWhileLocked");
+		DialogExtendedMessage = GetPlayerDialog("CantChangeWhileLocked");
 		return;
 	}
 
 	// Self bondage requirement check
 	if (option.SelfBondage && C.ID === 0 && SkillGetLevelReal(C, "SelfBondage") < option.SelfBondage) {
-		DialogExtendedMessage = DialogFind(Player, "RequireSelfBondage" + option.SelfBondage);
+		DialogExtendedMessage = GetPlayerDialog("RequireSelfBondage" + option.SelfBondage);
 		return;
 	}
 

--- a/BondageClub/Screens/Inventory/ItemArms/HighSecurityStraitJacket/HighSecurityStraitJacket.js
+++ b/BondageClub/Screens/Inventory/ItemArms/HighSecurityStraitJacket/HighSecurityStraitJacket.js
@@ -99,7 +99,7 @@ function InventoryItemArmsHighSecurityStraitJacketLoad() {
 		CharacterRefresh(C);
 		ChatRoomCharacterItemUpdate(C, DialogFocusItem.Asset.Group.Name);
 	}
-	DialogExtendedMessage = GetPlayerDialog("ItemArmsHighSecurityStraitJacketSelectBase");
+	DialogExtendedMessage = DialogFindPlayer("ItemArmsHighSecurityStraitJacketSelectBase");
 }
 
 function InventoryItemArmsHighSecurityStraitJacketCall(functionMap) {
@@ -117,7 +117,7 @@ function InventoryItemArmsHighSecurityStraitJacketClick() {
 
 function InventoryItemArmsHighSecurityStraitJacketPageTransition(newPage) {
 	InventoryItemArmsHighSecurityStraitJacketPage = newPage;
-	DialogExtendedMessage = GetPlayerDialog("ItemArmsHighSecurityStraitJacketSelect" + newPage);
+	DialogExtendedMessage = DialogFindPlayer("ItemArmsHighSecurityStraitJacketSelect" + newPage);
 }
 
 function InventoryItemArmsHighSecurityStraitJacketDrawCommon(buttonDefinitions) {
@@ -133,7 +133,7 @@ function InventoryItemArmsHighSecurityStraitJacketDrawCommon(buttonDefinitions) 
 		var y = 450 + (Math.floor(i / 2) * 300);
 		DrawButton(x, y, 225, 225, "", buttonDefinition[2] || "#fff");
 		DrawImage(buttonDefinition[0], x, y);
-		DrawText(GetPlayerDialog(buttonDefinition[1]), x + 113, y - 20, "#fff", "#808080");
+		DrawText(DialogFindPlayer(buttonDefinition[1]), x + 113, y - 20, "#fff", "#808080");
 	});
 }
 
@@ -238,13 +238,13 @@ function InventoryItemArmsHighSecurityStraitJacketSetType(option) {
 
 	// Lock check - cannot change type if you can't unlock the item
 	if (DialogFocusItem.Property.LockedBy && !DialogCanUnlock(C, DialogFocusItem)) {
-		DialogExtendedMessage = GetPlayerDialog("CantChangeWhileLocked");
+		DialogExtendedMessage = DialogFindPlayer("CantChangeWhileLocked");
 		return;
 	}
 
 	// Self bondage requirement check
 	if (option.SelfBondage && C.ID === 0 && SkillGetLevelReal(C, "SelfBondage") < option.SelfBondage) {
-		DialogExtendedMessage = GetPlayerDialog("RequireSelfBondage" + option.SelfBondage);
+		DialogExtendedMessage = DialogFindPlayer("RequireSelfBondage" + option.SelfBondage);
 		return;
 	}
 

--- a/BondageClub/Screens/Inventory/ItemArms/PrisonLockdownSuit/PrisonLockdownSuit.js
+++ b/BondageClub/Screens/Inventory/ItemArms/PrisonLockdownSuit/PrisonLockdownSuit.js
@@ -45,7 +45,7 @@ function InventoryItemArmsPrisonLockdownSuitLoad() {
 
 function InventoryItemArmsPrisonLockdownSuitSetPage(Page) {
 	InventoryItemArmsPrisonLockdownSuitPage = Page;
-	DialogExtendedMessage = GetPlayerDialog("ItemArmsPrisonLockdownSuitSelect" + Page);
+	DialogExtendedMessage = DialogFindPlayer("ItemArmsPrisonLockdownSuitSelect" + Page);
 }
 
 function InventoryItemArmsPrisonLockdownSuitDraw() {
@@ -63,11 +63,11 @@ function InventoryItemArmsPrisonLockdownSuitDrawBase() {
 
 	DrawButton(1175, 550, 225, 225, "", "white");
 	DrawImage("Screens/Inventory/" + A.Group.Name + "/" + A.Name + "/" + (DialogFocusItem.Property.Type || "Free") + ".png", 1175, 550);
-	DrawText(GetPlayerDialog("ItemArmsPrisonLockdownSuitStraps"), 1288, 800, "white", "gray");
+	DrawText(DialogFindPlayer("ItemArmsPrisonLockdownSuitStraps"), 1288, 800, "white", "gray");
 
 	DrawButton(1600, 550, 225, 225, "", "white");
 	DrawImage("Screens/Inventory/" + A.Group.Name + "/" + A.Name + "/Shock.png", 1600, 550);
-	DrawText(GetPlayerDialog("ItemArmsPrisonLockdownSuitShock"), 1713, 800, "white", "gray");
+	DrawText(DialogFindPlayer("ItemArmsPrisonLockdownSuitShock"), 1713, 800, "white", "gray");
 }
 
 function InventoryItemArmsPrisonLockdownSuitDrawStraps() {

--- a/BondageClub/Screens/Inventory/ItemArms/PrisonLockdownSuit/PrisonLockdownSuit.js
+++ b/BondageClub/Screens/Inventory/ItemArms/PrisonLockdownSuit/PrisonLockdownSuit.js
@@ -45,7 +45,7 @@ function InventoryItemArmsPrisonLockdownSuitLoad() {
 
 function InventoryItemArmsPrisonLockdownSuitSetPage(Page) {
 	InventoryItemArmsPrisonLockdownSuitPage = Page;
-	DialogExtendedMessage = DialogFind(Player, "ItemArmsPrisonLockdownSuitSelect" + Page);
+	DialogExtendedMessage = GetPlayerDialog("ItemArmsPrisonLockdownSuitSelect" + Page);
 }
 
 function InventoryItemArmsPrisonLockdownSuitDraw() {
@@ -63,11 +63,11 @@ function InventoryItemArmsPrisonLockdownSuitDrawBase() {
 
 	DrawButton(1175, 550, 225, 225, "", "white");
 	DrawImage("Screens/Inventory/" + A.Group.Name + "/" + A.Name + "/" + (DialogFocusItem.Property.Type || "Free") + ".png", 1175, 550);
-	DrawText(DialogFind(Player, "ItemArmsPrisonLockdownSuitStraps"), 1288, 800, "white", "gray");
+	DrawText(GetPlayerDialog("ItemArmsPrisonLockdownSuitStraps"), 1288, 800, "white", "gray");
 
 	DrawButton(1600, 550, 225, 225, "", "white");
 	DrawImage("Screens/Inventory/" + A.Group.Name + "/" + A.Name + "/Shock.png", 1600, 550);
-	DrawText(DialogFind(Player, "ItemArmsPrisonLockdownSuitShock"), 1713, 800, "white", "gray");
+	DrawText(GetPlayerDialog("ItemArmsPrisonLockdownSuitShock"), 1713, 800, "white", "gray");
 }
 
 function InventoryItemArmsPrisonLockdownSuitDrawStraps() {

--- a/BondageClub/Screens/Inventory/ItemArms/SturdyLeatherBelts/SturdyLeatherBelts.js
+++ b/BondageClub/Screens/Inventory/ItemArms/SturdyLeatherBelts/SturdyLeatherBelts.js
@@ -55,9 +55,9 @@ function InventoryItemArmsSturdyLeatherBeltsClick() {
 function InventoryItemArmsSturdyLeatherBeltsValidate(C) {
 	var Allowed = "";
 	if (DialogFocusItem.Property.LockedBy && !DialogCanUnlock(C, DialogFocusItem)) {
-		Allowed = GetPlayerDialog("CantChangeWhileLocked");
+		Allowed = DialogFindPlayer("CantChangeWhileLocked");
 	} else if (InventoryGet(C, "Cloth") != null) {
-		Allowed = GetPlayerDialog("RemoveClothesForItem");
+		Allowed = DialogFindPlayer("RemoveClothesForItem");
 	}
 	return Allowed;
 }

--- a/BondageClub/Screens/Inventory/ItemArms/SturdyLeatherBelts/SturdyLeatherBelts.js
+++ b/BondageClub/Screens/Inventory/ItemArms/SturdyLeatherBelts/SturdyLeatherBelts.js
@@ -55,9 +55,9 @@ function InventoryItemArmsSturdyLeatherBeltsClick() {
 function InventoryItemArmsSturdyLeatherBeltsValidate(C) {
 	var Allowed = "";
 	if (DialogFocusItem.Property.LockedBy && !DialogCanUnlock(C, DialogFocusItem)) {
-		Allowed = DialogFind(Player, "CantChangeWhileLocked");
+		Allowed = GetPlayerDialog("CantChangeWhileLocked");
 	} else if (InventoryGet(C, "Cloth") != null) {
-		Allowed = DialogFind(Player, "RemoveClothesForItem");
+		Allowed = GetPlayerDialog("RemoveClothesForItem");
 	}
 	return Allowed;
 }

--- a/BondageClub/Screens/Inventory/ItemArms/TightJacket/TightJacket.js
+++ b/BondageClub/Screens/Inventory/ItemArms/TightJacket/TightJacket.js
@@ -68,7 +68,7 @@ function InventoryItemArmsTightJacketClick() {
 function InventoryItemArmsTightJacketValidate(C) {
 	var Allowed = "";
 	if (DialogFocusItem.Property.LockedBy && !DialogCanUnlock(C, DialogFocusItem)) {
-		Allowed = DialogFind(Player, "CantChangeWhileLocked");
+		Allowed = GetPlayerDialog("CantChangeWhileLocked");
 	}
 	return Allowed;
 }

--- a/BondageClub/Screens/Inventory/ItemArms/TightJacket/TightJacket.js
+++ b/BondageClub/Screens/Inventory/ItemArms/TightJacket/TightJacket.js
@@ -68,7 +68,7 @@ function InventoryItemArmsTightJacketClick() {
 function InventoryItemArmsTightJacketValidate(C) {
 	var Allowed = "";
 	if (DialogFocusItem.Property.LockedBy && !DialogCanUnlock(C, DialogFocusItem)) {
-		Allowed = GetPlayerDialog("CantChangeWhileLocked");
+		Allowed = DialogFindPlayer("CantChangeWhileLocked");
 	}
 	return Allowed;
 }

--- a/BondageClub/Screens/Inventory/ItemArms/TightJacketCrotch/TightJacketCrotch.js
+++ b/BondageClub/Screens/Inventory/ItemArms/TightJacketCrotch/TightJacketCrotch.js
@@ -68,7 +68,7 @@ function InventoryItemArmsTightJacketCrotchClick() {
 function InventoryItemArmsTightJacketCrotchValidate(C) {
 	var Allowed = "";
 	if (InventoryItemHasEffect(DialogFocusItem, "Lock", true) && !DialogCanUnlock(C, DialogFocusItem)) {
-		Allowed = GetPlayerDialog("CantChangeWhileLocked");
+		Allowed = DialogFindPlayer("CantChangeWhileLocked");
 	}
 	return Allowed;
 }

--- a/BondageClub/Screens/Inventory/ItemArms/TightJacketCrotch/TightJacketCrotch.js
+++ b/BondageClub/Screens/Inventory/ItemArms/TightJacketCrotch/TightJacketCrotch.js
@@ -68,7 +68,7 @@ function InventoryItemArmsTightJacketCrotchClick() {
 function InventoryItemArmsTightJacketCrotchValidate(C) {
 	var Allowed = "";
 	if (InventoryItemHasEffect(DialogFocusItem, "Lock", true) && !DialogCanUnlock(C, DialogFocusItem)) {
-		Allowed = DialogFind(Player, "CantChangeWhileLocked");
+		Allowed = GetPlayerDialog("CantChangeWhileLocked");
 	}
 	return Allowed;
 }

--- a/BondageClub/Screens/Inventory/ItemArms/Web/Web.js
+++ b/BondageClub/Screens/Inventory/ItemArms/Web/Web.js
@@ -131,7 +131,7 @@ function InventoryItemArmsWebPublishAction(C, Option, PreviousOption) {
 	var NewIndex = InventoryItemArmsWebOptions.indexOf(Option);
 	var PreviousIndex = InventoryItemArmsWebOptions.indexOf(PreviousOption);
 	var msg = "ArmsWebSet" + Option.Name;
-	var ActionDialog = GetPlayerDialog(NewIndex > PreviousIndex ? "tightens" : "loosens");
+	var ActionDialog = DialogFindPlayer(NewIndex > PreviousIndex ? "tightens" : "loosens");
 	var Dictionary = [
 		{ Tag: "SourceCharacter", Text: Player.Name, MemberNumber: Player.MemberNumber },
 		{ Tag: "TargetCharacter", Text: C.Name, MemberNumber: C.MemberNumber },

--- a/BondageClub/Screens/Inventory/ItemArms/Web/Web.js
+++ b/BondageClub/Screens/Inventory/ItemArms/Web/Web.js
@@ -131,7 +131,7 @@ function InventoryItemArmsWebPublishAction(C, Option, PreviousOption) {
 	var NewIndex = InventoryItemArmsWebOptions.indexOf(Option);
 	var PreviousIndex = InventoryItemArmsWebOptions.indexOf(PreviousOption);
 	var msg = "ArmsWebSet" + Option.Name;
-	var ActionDialog = DialogFind(Player, NewIndex > PreviousIndex ? "tightens" : "loosens", "ItemArms");
+	var ActionDialog = GetPlayerDialog(NewIndex > PreviousIndex ? "tightens" : "loosens");
 	var Dictionary = [
 		{ Tag: "SourceCharacter", Text: Player.Name, MemberNumber: Player.MemberNumber },
 		{ Tag: "TargetCharacter", Text: C.Name, MemberNumber: C.MemberNumber },

--- a/BondageClub/Screens/Inventory/ItemBreast/FuturisticBra/FuturisticBra.js
+++ b/BondageClub/Screens/Inventory/ItemBreast/FuturisticBra/FuturisticBra.js
@@ -74,30 +74,30 @@ function InventoryItemBreastFuturisticBraDraw() {
 	var current_temp = update.temp
 		
 	
-	DrawText(GetPlayerDialog("FuturisticBraPlayerDesc") + " " + C.MemberNumber, 1500, 600, "White", "Gray");
-	DrawText(GetPlayerDialog("FuturisticBraPlayerHeartRate") + " " + current_bpm + " " + GetPlayerDialog("FuturisticBraPlayerHeartRateBPM"), 1500, 680, "White", "Gray");
-	DrawText(GetPlayerDialog("FuturisticBraPlayerTemp") + " " + current_temp + GetPlayerDialog("FuturisticBraPlayerTempC"), 1500, 730, "White", "Gray");
-	DrawText(GetPlayerDialog("FuturisticBraPlayerBreathing") + " " + GetPlayerDialog("FuturisticBraPlayerBreathing" + current_breathing), 1500, 780, "White", "Gray");
-	DrawText(GetPlayerDialog("FuturisticBraPlayerTracking"), 1500, 830, "White", "Gray");
+	DrawText(DialogFindPlayer("FuturisticBraPlayerDesc") + " " + C.MemberNumber, 1500, 600, "White", "Gray");
+	DrawText(DialogFindPlayer("FuturisticBraPlayerHeartRate") + " " + current_bpm + " " + DialogFindPlayer("FuturisticBraPlayerHeartRateBPM"), 1500, 680, "White", "Gray");
+	DrawText(DialogFindPlayer("FuturisticBraPlayerTemp") + " " + current_temp + DialogFindPlayer("FuturisticBraPlayerTempC"), 1500, 730, "White", "Gray");
+	DrawText(DialogFindPlayer("FuturisticBraPlayerBreathing") + " " + DialogFindPlayer("FuturisticBraPlayerBreathing" + current_breathing), 1500, 780, "White", "Gray");
+	DrawText(DialogFindPlayer("FuturisticBraPlayerTracking"), 1500, 830, "White", "Gray");
 	
 	// If the player can modify 
 	if (InventoryItemMouthFuturisticPanelGagValidate(C) == "") {
 		if (DialogFocusItem.Property.Type == "Solid") {
-			DrawButton(1250, 900, 200, 64, GetPlayerDialog("FuturisticBraPlayerShow"), "White", "");
+			DrawButton(1250, 900, 200, 64, DialogFindPlayer("FuturisticBraPlayerShow"), "White", "");
 		} else {
-			DrawButton(1550, 900, 200, 64, GetPlayerDialog("FuturisticBraPlayerSolid"), "White", "");
+			DrawButton(1550, 900, 200, 64, DialogFindPlayer("FuturisticBraPlayerSolid"), "White", "");
 		}
 	}
 	
 	
 	/*
-	DrawText(GetPlayerDialog("Intensity" + DialogFocusItem.Property.Intensity.toString()).replace("Item", DialogFocusItem.Asset.Description), 1500, 600, "White", "Gray");
-	if (DialogFocusItem.Property.Intensity > 0) DrawButton(1200, 650, 200, 55, GetPlayerDialog("Low"), "White");
-	if (DialogFocusItem.Property.Intensity < 1 || DialogFocusItem.Property.Intensity > 1) DrawButton(1550, 650, 200, 55, GetPlayerDialog("Medium"), "White");
-	if (DialogFocusItem.Property.Intensity < 2) DrawButton(1375, 710, 200, 55, GetPlayerDialog("High"), "White");
+	DrawText(DialogFindPlayer("Intensity" + DialogFocusItem.Property.Intensity.toString()).replace("Item", DialogFocusItem.Asset.Description), 1500, 600, "White", "Gray");
+	if (DialogFocusItem.Property.Intensity > 0) DrawButton(1200, 650, 200, 55, DialogFindPlayer("Low"), "White");
+	if (DialogFocusItem.Property.Intensity < 1 || DialogFocusItem.Property.Intensity > 1) DrawButton(1550, 650, 200, 55, DialogFindPlayer("Medium"), "White");
+	if (DialogFocusItem.Property.Intensity < 2) DrawButton(1375, 710, 200, 55, DialogFindPlayer("High"), "White");
 	if (CurrentScreen == "ChatRoom") DrawButton(1325, 800, 64, 64, "", "White", DialogFocusItem.Property.ShowText ? "Icons/Checked.png" : "");
-	if (CurrentScreen == "ChatRoom") DrawText(GetPlayerDialog("ShockCollarShowChat"), 1570, 833, "White", "Gray");
-	DrawButton(1375, 900, 200, 55, GetPlayerDialog("TriggerShock"), "White");*/
+	if (CurrentScreen == "ChatRoom") DrawText(DialogFindPlayer("ShockCollarShowChat"), 1570, 833, "White", "Gray");
+	DrawButton(1375, 900, 200, 55, DialogFindPlayer("TriggerShock"), "White");*/
 }
 
 // Catches the item extension clicks

--- a/BondageClub/Screens/Inventory/ItemBreast/FuturisticBra/FuturisticBra.js
+++ b/BondageClub/Screens/Inventory/ItemBreast/FuturisticBra/FuturisticBra.js
@@ -74,30 +74,30 @@ function InventoryItemBreastFuturisticBraDraw() {
 	var current_temp = update.temp
 		
 	
-	DrawText(DialogFind(Player, "FuturisticBraPlayerDesc") + " " + C.MemberNumber, 1500, 600, "White", "Gray");
-	DrawText(DialogFind(Player, "FuturisticBraPlayerHeartRate") + " " + current_bpm + " " + DialogFind(Player, "FuturisticBraPlayerHeartRateBPM"), 1500, 680, "White", "Gray");
-	DrawText(DialogFind(Player, "FuturisticBraPlayerTemp") + " " + current_temp + DialogFind(Player, "FuturisticBraPlayerTempC"), 1500, 730, "White", "Gray");
-	DrawText(DialogFind(Player, "FuturisticBraPlayerBreathing") + " " + DialogFind(Player, "FuturisticBraPlayerBreathing" + current_breathing), 1500, 780, "White", "Gray");
-	DrawText(DialogFind(Player, "FuturisticBraPlayerTracking"), 1500, 830, "White", "Gray");
+	DrawText(GetPlayerDialog("FuturisticBraPlayerDesc") + " " + C.MemberNumber, 1500, 600, "White", "Gray");
+	DrawText(GetPlayerDialog("FuturisticBraPlayerHeartRate") + " " + current_bpm + " " + GetPlayerDialog("FuturisticBraPlayerHeartRateBPM"), 1500, 680, "White", "Gray");
+	DrawText(GetPlayerDialog("FuturisticBraPlayerTemp") + " " + current_temp + GetPlayerDialog("FuturisticBraPlayerTempC"), 1500, 730, "White", "Gray");
+	DrawText(GetPlayerDialog("FuturisticBraPlayerBreathing") + " " + GetPlayerDialog("FuturisticBraPlayerBreathing" + current_breathing), 1500, 780, "White", "Gray");
+	DrawText(GetPlayerDialog("FuturisticBraPlayerTracking"), 1500, 830, "White", "Gray");
 	
 	// If the player can modify 
 	if (InventoryItemMouthFuturisticPanelGagValidate(C) == "") {
 		if (DialogFocusItem.Property.Type == "Solid") {
-			DrawButton(1250, 900, 200, 64, DialogFind(Player, "FuturisticBraPlayerShow"), "White", "");
+			DrawButton(1250, 900, 200, 64, GetPlayerDialog("FuturisticBraPlayerShow"), "White", "");
 		} else {
-			DrawButton(1550, 900, 200, 64, DialogFind(Player, "FuturisticBraPlayerSolid"), "White", "");
+			DrawButton(1550, 900, 200, 64, GetPlayerDialog("FuturisticBraPlayerSolid"), "White", "");
 		}
 	}
 	
 	
 	/*
-	DrawText(DialogFind(Player, "Intensity" + DialogFocusItem.Property.Intensity.toString()).replace("Item", DialogFocusItem.Asset.Description), 1500, 600, "White", "Gray");
-	if (DialogFocusItem.Property.Intensity > 0) DrawButton(1200, 650, 200, 55, DialogFind(Player, "Low"), "White");
-	if (DialogFocusItem.Property.Intensity < 1 || DialogFocusItem.Property.Intensity > 1) DrawButton(1550, 650, 200, 55, DialogFind(Player, "Medium"), "White");
-	if (DialogFocusItem.Property.Intensity < 2) DrawButton(1375, 710, 200, 55, DialogFind(Player, "High"), "White");
+	DrawText(GetPlayerDialog("Intensity" + DialogFocusItem.Property.Intensity.toString()).replace("Item", DialogFocusItem.Asset.Description), 1500, 600, "White", "Gray");
+	if (DialogFocusItem.Property.Intensity > 0) DrawButton(1200, 650, 200, 55, GetPlayerDialog("Low"), "White");
+	if (DialogFocusItem.Property.Intensity < 1 || DialogFocusItem.Property.Intensity > 1) DrawButton(1550, 650, 200, 55, GetPlayerDialog("Medium"), "White");
+	if (DialogFocusItem.Property.Intensity < 2) DrawButton(1375, 710, 200, 55, GetPlayerDialog("High"), "White");
 	if (CurrentScreen == "ChatRoom") DrawButton(1325, 800, 64, 64, "", "White", DialogFocusItem.Property.ShowText ? "Icons/Checked.png" : "");
-	if (CurrentScreen == "ChatRoom") DrawText(DialogFind(Player, "ShockCollarShowChat"), 1570, 833, "White", "Gray");
-	DrawButton(1375, 900, 200, 55, DialogFind(Player, "TriggerShock"), "White");*/
+	if (CurrentScreen == "ChatRoom") DrawText(GetPlayerDialog("ShockCollarShowChat"), 1570, 833, "White", "Gray");
+	DrawButton(1375, 900, 200, 55, GetPlayerDialog("TriggerShock"), "White");*/
 }
 
 // Catches the item extension clicks

--- a/BondageClub/Screens/Inventory/ItemButt/AnalBeads2/AnalBeads2.js
+++ b/BondageClub/Screens/Inventory/ItemButt/AnalBeads2/AnalBeads2.js
@@ -18,11 +18,11 @@ function InventoryItemButtAnalBeads2Draw() {
 	DrawRect(1387, 225, 225, 275, "white");
 	DrawImageResize("Assets/" + DialogFocusItem.Asset.Group.Family + "/" + DialogFocusItem.Asset.Group.Name + "/Preview/" + DialogFocusItem.Asset.Name + ".png", 1389, 227, 221, 221);
 	DrawTextFit(DialogFocusItem.Asset.Description, 1500, 475, 221, "black");
-	DrawText(GetPlayerDialog("BeadsCount") + DialogFocusItem.Property.InsertedBeads.toString(), 1500, 600, "White", "Gray");
-	if (DialogFocusItem.Property.InsertedBeads > 1) DrawButton(1200, 700, 250, 65, GetPlayerDialog("RemoveBead"), "White");
-	if (DialogFocusItem.Property.InsertedBeads < 5) DrawButton(1550, 700, 250, 65, GetPlayerDialog("InsertBead"), "White");
-	if (DialogFocusItem.Property.InsertedBeads < 5) DrawButton(1550, 800, 250, 65, GetPlayerDialog("MaximumBeads"), "White");
-	if (DialogFocusItem.Property.InsertedBeads > 1) DrawButton(1200, 800, 250, 65, GetPlayerDialog("MinimumBeads"), "White");
+	DrawText(DialogFindPlayer("BeadsCount") + DialogFocusItem.Property.InsertedBeads.toString(), 1500, 600, "White", "Gray");
+	if (DialogFocusItem.Property.InsertedBeads > 1) DrawButton(1200, 700, 250, 65, DialogFindPlayer("RemoveBead"), "White");
+	if (DialogFocusItem.Property.InsertedBeads < 5) DrawButton(1550, 700, 250, 65, DialogFindPlayer("InsertBead"), "White");
+	if (DialogFocusItem.Property.InsertedBeads < 5) DrawButton(1550, 800, 250, 65, DialogFindPlayer("MaximumBeads"), "White");
+	if (DialogFocusItem.Property.InsertedBeads > 1) DrawButton(1200, 800, 250, 65, DialogFindPlayer("MinimumBeads"), "White");
 }
 
 // Catches the item extension clicks

--- a/BondageClub/Screens/Inventory/ItemButt/AnalBeads2/AnalBeads2.js
+++ b/BondageClub/Screens/Inventory/ItemButt/AnalBeads2/AnalBeads2.js
@@ -18,11 +18,11 @@ function InventoryItemButtAnalBeads2Draw() {
 	DrawRect(1387, 225, 225, 275, "white");
 	DrawImageResize("Assets/" + DialogFocusItem.Asset.Group.Family + "/" + DialogFocusItem.Asset.Group.Name + "/Preview/" + DialogFocusItem.Asset.Name + ".png", 1389, 227, 221, 221);
 	DrawTextFit(DialogFocusItem.Asset.Description, 1500, 475, 221, "black");
-	DrawText(DialogFind(Player, "BeadsCount") + DialogFocusItem.Property.InsertedBeads.toString(), 1500, 600, "White", "Gray");
-	if (DialogFocusItem.Property.InsertedBeads > 1) DrawButton(1200, 700, 250, 65, DialogFind(Player, "RemoveBead"), "White");
-	if (DialogFocusItem.Property.InsertedBeads < 5) DrawButton(1550, 700, 250, 65, DialogFind(Player, "InsertBead"), "White");
-	if (DialogFocusItem.Property.InsertedBeads < 5) DrawButton(1550, 800, 250, 65, DialogFind(Player, "MaximumBeads"), "White");
-	if (DialogFocusItem.Property.InsertedBeads > 1) DrawButton(1200, 800, 250, 65, DialogFind(Player, "MinimumBeads"), "White");
+	DrawText(GetPlayerDialog("BeadsCount") + DialogFocusItem.Property.InsertedBeads.toString(), 1500, 600, "White", "Gray");
+	if (DialogFocusItem.Property.InsertedBeads > 1) DrawButton(1200, 700, 250, 65, GetPlayerDialog("RemoveBead"), "White");
+	if (DialogFocusItem.Property.InsertedBeads < 5) DrawButton(1550, 700, 250, 65, GetPlayerDialog("InsertBead"), "White");
+	if (DialogFocusItem.Property.InsertedBeads < 5) DrawButton(1550, 800, 250, 65, GetPlayerDialog("MaximumBeads"), "White");
+	if (DialogFocusItem.Property.InsertedBeads > 1) DrawButton(1200, 800, 250, 65, GetPlayerDialog("MinimumBeads"), "White");
 }
 
 // Catches the item extension clicks

--- a/BondageClub/Screens/Inventory/ItemButt/ButtPlugLock/ButtPlugLock.js
+++ b/BondageClub/Screens/Inventory/ItemButt/ButtPlugLock/ButtPlugLock.js
@@ -29,16 +29,16 @@ function InventoryItemButtButtPlugLockDraw() {
 	var ChainShortPrerequisites = InventoryItemButtButtPlugLockChainShortPrerequesites(C);
 
 	// Draw the possible poses
-	DrawText(DialogFind(Player, InventoryItemButtButtPlugLockMessage), 1500, 500, "white", "gray");
+	DrawText(GetPlayerDialog(InventoryItemButtButtPlugLockMessage), 1500, 500, "white", "gray");
 	DrawButton(1000, 550, 225, 225, "", ((DialogFocusItem.Property == null) || (DialogFocusItem.Property.Type == null)) ? "#888888" : "White");
 	DrawImage("Screens/Inventory/" + DialogFocusItem.Asset.Group.Name + "/" + DialogFocusItem.Asset.Name + "/Base.png", 1000, 550);
-	DrawText(DialogFind(Player, "ButtPlugLockPoseBase"), 1125, 800, "white", "gray");
+	DrawText(GetPlayerDialog("ButtPlugLockPoseBase"), 1125, 800, "white", "gray");
 	DrawButton(1250, 550, 225, 225, "", ((DialogFocusItem.Property != null) && (DialogFocusItem.Property.Type == "ChainShort") || !ChainShortPrerequisites) ? "#888888" : "White");
 	DrawImage("Screens/Inventory/" + DialogFocusItem.Asset.Group.Name + "/" + DialogFocusItem.Asset.Name + "/ChainShort.png", 1250, 550);
-	DrawText(DialogFind(Player, "ButtPlugLockPoseChainShort"), 1375, 800, "white", "gray");
+	DrawText(GetPlayerDialog("ButtPlugLockPoseChainShort"), 1375, 800, "white", "gray");
 	DrawButton(1500, 550, 225, 225, "", ((DialogFocusItem.Property.Restrain != null) && (DialogFocusItem.Property.Restrain == "ChainLong") || C.Pose.indexOf("Suspension") >= 0) ? "#888888" : "White");
 	DrawImage("Screens/Inventory/" + DialogFocusItem.Asset.Group.Name + "/" + DialogFocusItem.Asset.Name + "/ChainLong.png", 1500, 550);
-	DrawText(DialogFind(Player, "ButtPlugLockPoseChainLong"), 1625, 800, "white", "gray");
+	DrawText(GetPlayerDialog("ButtPlugLockPoseChainLong"), 1625, 800, "white", "gray");
 }
 
 // Catches the item extension clicks

--- a/BondageClub/Screens/Inventory/ItemButt/ButtPlugLock/ButtPlugLock.js
+++ b/BondageClub/Screens/Inventory/ItemButt/ButtPlugLock/ButtPlugLock.js
@@ -29,16 +29,16 @@ function InventoryItemButtButtPlugLockDraw() {
 	var ChainShortPrerequisites = InventoryItemButtButtPlugLockChainShortPrerequesites(C);
 
 	// Draw the possible poses
-	DrawText(GetPlayerDialog(InventoryItemButtButtPlugLockMessage), 1500, 500, "white", "gray");
+	DrawText(DialogFindPlayer(InventoryItemButtButtPlugLockMessage), 1500, 500, "white", "gray");
 	DrawButton(1000, 550, 225, 225, "", ((DialogFocusItem.Property == null) || (DialogFocusItem.Property.Type == null)) ? "#888888" : "White");
 	DrawImage("Screens/Inventory/" + DialogFocusItem.Asset.Group.Name + "/" + DialogFocusItem.Asset.Name + "/Base.png", 1000, 550);
-	DrawText(GetPlayerDialog("ButtPlugLockPoseBase"), 1125, 800, "white", "gray");
+	DrawText(DialogFindPlayer("ButtPlugLockPoseBase"), 1125, 800, "white", "gray");
 	DrawButton(1250, 550, 225, 225, "", ((DialogFocusItem.Property != null) && (DialogFocusItem.Property.Type == "ChainShort") || !ChainShortPrerequisites) ? "#888888" : "White");
 	DrawImage("Screens/Inventory/" + DialogFocusItem.Asset.Group.Name + "/" + DialogFocusItem.Asset.Name + "/ChainShort.png", 1250, 550);
-	DrawText(GetPlayerDialog("ButtPlugLockPoseChainShort"), 1375, 800, "white", "gray");
+	DrawText(DialogFindPlayer("ButtPlugLockPoseChainShort"), 1375, 800, "white", "gray");
 	DrawButton(1500, 550, 225, 225, "", ((DialogFocusItem.Property.Restrain != null) && (DialogFocusItem.Property.Restrain == "ChainLong") || C.Pose.indexOf("Suspension") >= 0) ? "#888888" : "White");
 	DrawImage("Screens/Inventory/" + DialogFocusItem.Asset.Group.Name + "/" + DialogFocusItem.Asset.Name + "/ChainLong.png", 1500, 550);
-	DrawText(GetPlayerDialog("ButtPlugLockPoseChainLong"), 1625, 800, "white", "gray");
+	DrawText(DialogFindPlayer("ButtPlugLockPoseChainLong"), 1625, 800, "white", "gray");
 }
 
 // Catches the item extension clicks

--- a/BondageClub/Screens/Inventory/ItemButt/InflVibeButtPlug/InflVibeButtPlug.js
+++ b/BondageClub/Screens/Inventory/ItemButt/InflVibeButtPlug/InflVibeButtPlug.js
@@ -15,24 +15,24 @@ function InventoryItemButtInflVibeButtPlugDraw() {
 		DrawImageResize("Assets/" + DialogFocusItem.Asset.Group.Family + "/" + DialogFocusItem.Asset.Group.Name + "/Preview/" + DialogFocusItem.Asset.Name + ".png", 1389 + Math.floor(Math.random() * 3) - 1, 227 + Math.floor(Math.random() * 3) - 1, 221, 221);
 	else DrawImageResize("Assets/" + DialogFocusItem.Asset.Group.Family + "/" + DialogFocusItem.Asset.Group.Name + "/Preview/" + DialogFocusItem.Asset.Name + ".png", 1389, 227, 221, 221);
 	DrawTextFit(DialogFocusItem.Asset.Description, 1500, 475, 221, "black");
-	DrawText(GetPlayerDialog("InflateLevel" + DialogFocusItem.Property.InflateLevel.toString()), 1500, 750, "White", "Gray");
-	if (DialogFocusItem.Property.InflateLevel > 0) DrawButton(1200, 775, 200, 55, GetPlayerDialog("Empty"), "White");
-	if (DialogFocusItem.Property.InflateLevel < 1) DrawButton(1550, 775, 200, 55, GetPlayerDialog("Light"), "White");
-	if (DialogFocusItem.Property.InflateLevel > 1) DrawButton(1550, 775, 200, 55, GetPlayerDialog("Light"), "White");
-	if (DialogFocusItem.Property.InflateLevel < 2) DrawButton(1200, 835, 200, 55, GetPlayerDialog("Inflated"), "White");
-	if (DialogFocusItem.Property.InflateLevel > 2) DrawButton(1200, 835, 200, 55, GetPlayerDialog("Inflated"), "White");
-	if (DialogFocusItem.Property.InflateLevel < 3) DrawButton(1550, 835, 200, 55, GetPlayerDialog("Bloated"), "White");
-	if (DialogFocusItem.Property.InflateLevel > 3) DrawButton(1550, 835, 200, 55, GetPlayerDialog("Bloated"), "White");
-	if (DialogFocusItem.Property.InflateLevel < 4) DrawButton(1375, 895, 200, 55, GetPlayerDialog("Maximum"), "White");
-	DrawText(GetPlayerDialog("Intensity" + DialogFocusItem.Property.Intensity.toString()), 1500, 525, "White", "Gray");
-	if (DialogFocusItem.Property.Intensity > -1) DrawButton(1200, 550, 200, 55, GetPlayerDialog("TurnOff"), "White");
-	if (DialogFocusItem.Property.Intensity < 0) DrawButton(1550, 550, 200, 55, GetPlayerDialog("Low"), "White");
-	if (DialogFocusItem.Property.Intensity > 0) DrawButton(1550, 550, 200, 55, GetPlayerDialog("Low"), "White");
-	if (DialogFocusItem.Property.Intensity < 1) DrawButton(1200, 610, 200, 55, GetPlayerDialog("Medium"), "White");
-	if (DialogFocusItem.Property.Intensity > 1) DrawButton(1200, 610, 200, 55, GetPlayerDialog("Medium"), "White");
-	if (DialogFocusItem.Property.Intensity < 2) DrawButton(1550, 610, 200, 55, GetPlayerDialog("High"), "White");
-	if (DialogFocusItem.Property.Intensity > 2) DrawButton(1550, 610, 200, 55, GetPlayerDialog("High"), "White");
-	if (DialogFocusItem.Property.Intensity < 3) DrawButton(1375, 670, 200, 55, GetPlayerDialog("Maximum"), "White");
+	DrawText(DialogFindPlayer("InflateLevel" + DialogFocusItem.Property.InflateLevel.toString()), 1500, 750, "White", "Gray");
+	if (DialogFocusItem.Property.InflateLevel > 0) DrawButton(1200, 775, 200, 55, DialogFindPlayer("Empty"), "White");
+	if (DialogFocusItem.Property.InflateLevel < 1) DrawButton(1550, 775, 200, 55, DialogFindPlayer("Light"), "White");
+	if (DialogFocusItem.Property.InflateLevel > 1) DrawButton(1550, 775, 200, 55, DialogFindPlayer("Light"), "White");
+	if (DialogFocusItem.Property.InflateLevel < 2) DrawButton(1200, 835, 200, 55, DialogFindPlayer("Inflated"), "White");
+	if (DialogFocusItem.Property.InflateLevel > 2) DrawButton(1200, 835, 200, 55, DialogFindPlayer("Inflated"), "White");
+	if (DialogFocusItem.Property.InflateLevel < 3) DrawButton(1550, 835, 200, 55, DialogFindPlayer("Bloated"), "White");
+	if (DialogFocusItem.Property.InflateLevel > 3) DrawButton(1550, 835, 200, 55, DialogFindPlayer("Bloated"), "White");
+	if (DialogFocusItem.Property.InflateLevel < 4) DrawButton(1375, 895, 200, 55, DialogFindPlayer("Maximum"), "White");
+	DrawText(DialogFindPlayer("Intensity" + DialogFocusItem.Property.Intensity.toString()), 1500, 525, "White", "Gray");
+	if (DialogFocusItem.Property.Intensity > -1) DrawButton(1200, 550, 200, 55, DialogFindPlayer("TurnOff"), "White");
+	if (DialogFocusItem.Property.Intensity < 0) DrawButton(1550, 550, 200, 55, DialogFindPlayer("Low"), "White");
+	if (DialogFocusItem.Property.Intensity > 0) DrawButton(1550, 550, 200, 55, DialogFindPlayer("Low"), "White");
+	if (DialogFocusItem.Property.Intensity < 1) DrawButton(1200, 610, 200, 55, DialogFindPlayer("Medium"), "White");
+	if (DialogFocusItem.Property.Intensity > 1) DrawButton(1200, 610, 200, 55, DialogFindPlayer("Medium"), "White");
+	if (DialogFocusItem.Property.Intensity < 2) DrawButton(1550, 610, 200, 55, DialogFindPlayer("High"), "White");
+	if (DialogFocusItem.Property.Intensity > 2) DrawButton(1550, 610, 200, 55, DialogFindPlayer("High"), "White");
+	if (DialogFocusItem.Property.Intensity < 3) DrawButton(1375, 670, 200, 55, DialogFindPlayer("Maximum"), "White");
 }
 
 // Catches the item extension clicks

--- a/BondageClub/Screens/Inventory/ItemButt/InflVibeButtPlug/InflVibeButtPlug.js
+++ b/BondageClub/Screens/Inventory/ItemButt/InflVibeButtPlug/InflVibeButtPlug.js
@@ -15,24 +15,24 @@ function InventoryItemButtInflVibeButtPlugDraw() {
 		DrawImageResize("Assets/" + DialogFocusItem.Asset.Group.Family + "/" + DialogFocusItem.Asset.Group.Name + "/Preview/" + DialogFocusItem.Asset.Name + ".png", 1389 + Math.floor(Math.random() * 3) - 1, 227 + Math.floor(Math.random() * 3) - 1, 221, 221);
 	else DrawImageResize("Assets/" + DialogFocusItem.Asset.Group.Family + "/" + DialogFocusItem.Asset.Group.Name + "/Preview/" + DialogFocusItem.Asset.Name + ".png", 1389, 227, 221, 221);
 	DrawTextFit(DialogFocusItem.Asset.Description, 1500, 475, 221, "black");
-	DrawText(DialogFind(Player, "InflateLevel" + DialogFocusItem.Property.InflateLevel.toString()), 1500, 750, "White", "Gray");
-	if (DialogFocusItem.Property.InflateLevel > 0) DrawButton(1200, 775, 200, 55, DialogFind(Player, "Empty"), "White");
-	if (DialogFocusItem.Property.InflateLevel < 1) DrawButton(1550, 775, 200, 55, DialogFind(Player, "Light"), "White");
-	if (DialogFocusItem.Property.InflateLevel > 1) DrawButton(1550, 775, 200, 55, DialogFind(Player, "Light"), "White");
-	if (DialogFocusItem.Property.InflateLevel < 2) DrawButton(1200, 835, 200, 55, DialogFind(Player, "Inflated"), "White");
-	if (DialogFocusItem.Property.InflateLevel > 2) DrawButton(1200, 835, 200, 55, DialogFind(Player, "Inflated"), "White");
-	if (DialogFocusItem.Property.InflateLevel < 3) DrawButton(1550, 835, 200, 55, DialogFind(Player, "Bloated"), "White");
-	if (DialogFocusItem.Property.InflateLevel > 3) DrawButton(1550, 835, 200, 55, DialogFind(Player, "Bloated"), "White");
-	if (DialogFocusItem.Property.InflateLevel < 4) DrawButton(1375, 895, 200, 55, DialogFind(Player, "Maximum"), "White");
-	DrawText(DialogFind(Player, "Intensity" + DialogFocusItem.Property.Intensity.toString()), 1500, 525, "White", "Gray");
-	if (DialogFocusItem.Property.Intensity > -1) DrawButton(1200, 550, 200, 55, DialogFind(Player, "TurnOff"), "White");
-	if (DialogFocusItem.Property.Intensity < 0) DrawButton(1550, 550, 200, 55, DialogFind(Player, "Low"), "White");
-	if (DialogFocusItem.Property.Intensity > 0) DrawButton(1550, 550, 200, 55, DialogFind(Player, "Low"), "White");
-	if (DialogFocusItem.Property.Intensity < 1) DrawButton(1200, 610, 200, 55, DialogFind(Player, "Medium"), "White");
-	if (DialogFocusItem.Property.Intensity > 1) DrawButton(1200, 610, 200, 55, DialogFind(Player, "Medium"), "White");
-	if (DialogFocusItem.Property.Intensity < 2) DrawButton(1550, 610, 200, 55, DialogFind(Player, "High"), "White");
-	if (DialogFocusItem.Property.Intensity > 2) DrawButton(1550, 610, 200, 55, DialogFind(Player, "High"), "White");
-	if (DialogFocusItem.Property.Intensity < 3) DrawButton(1375, 670, 200, 55, DialogFind(Player, "Maximum"), "White");
+	DrawText(GetPlayerDialog("InflateLevel" + DialogFocusItem.Property.InflateLevel.toString()), 1500, 750, "White", "Gray");
+	if (DialogFocusItem.Property.InflateLevel > 0) DrawButton(1200, 775, 200, 55, GetPlayerDialog("Empty"), "White");
+	if (DialogFocusItem.Property.InflateLevel < 1) DrawButton(1550, 775, 200, 55, GetPlayerDialog("Light"), "White");
+	if (DialogFocusItem.Property.InflateLevel > 1) DrawButton(1550, 775, 200, 55, GetPlayerDialog("Light"), "White");
+	if (DialogFocusItem.Property.InflateLevel < 2) DrawButton(1200, 835, 200, 55, GetPlayerDialog("Inflated"), "White");
+	if (DialogFocusItem.Property.InflateLevel > 2) DrawButton(1200, 835, 200, 55, GetPlayerDialog("Inflated"), "White");
+	if (DialogFocusItem.Property.InflateLevel < 3) DrawButton(1550, 835, 200, 55, GetPlayerDialog("Bloated"), "White");
+	if (DialogFocusItem.Property.InflateLevel > 3) DrawButton(1550, 835, 200, 55, GetPlayerDialog("Bloated"), "White");
+	if (DialogFocusItem.Property.InflateLevel < 4) DrawButton(1375, 895, 200, 55, GetPlayerDialog("Maximum"), "White");
+	DrawText(GetPlayerDialog("Intensity" + DialogFocusItem.Property.Intensity.toString()), 1500, 525, "White", "Gray");
+	if (DialogFocusItem.Property.Intensity > -1) DrawButton(1200, 550, 200, 55, GetPlayerDialog("TurnOff"), "White");
+	if (DialogFocusItem.Property.Intensity < 0) DrawButton(1550, 550, 200, 55, GetPlayerDialog("Low"), "White");
+	if (DialogFocusItem.Property.Intensity > 0) DrawButton(1550, 550, 200, 55, GetPlayerDialog("Low"), "White");
+	if (DialogFocusItem.Property.Intensity < 1) DrawButton(1200, 610, 200, 55, GetPlayerDialog("Medium"), "White");
+	if (DialogFocusItem.Property.Intensity > 1) DrawButton(1200, 610, 200, 55, GetPlayerDialog("Medium"), "White");
+	if (DialogFocusItem.Property.Intensity < 2) DrawButton(1550, 610, 200, 55, GetPlayerDialog("High"), "White");
+	if (DialogFocusItem.Property.Intensity > 2) DrawButton(1550, 610, 200, 55, GetPlayerDialog("High"), "White");
+	if (DialogFocusItem.Property.Intensity < 3) DrawButton(1375, 670, 200, 55, GetPlayerDialog("Maximum"), "White");
 }
 
 // Catches the item extension clicks

--- a/BondageClub/Screens/Inventory/ItemDevices/Coffin/Coffin.js
+++ b/BondageClub/Screens/Inventory/ItemDevices/Coffin/Coffin.js
@@ -54,7 +54,7 @@ function InventoryItemDevicesCoffinValidate(C) {
 	var Allowed = "";
 
 	if (DialogFocusItem.Property.LockedBy && !DialogCanUnlock(C, DialogFocusItem)) {
-		Allowed = DialogFind(Player, "CantChangeWhileLocked");
+		Allowed = GetPlayerDialog("CantChangeWhileLocked");
 	}
 
 	return Allowed;

--- a/BondageClub/Screens/Inventory/ItemDevices/Coffin/Coffin.js
+++ b/BondageClub/Screens/Inventory/ItemDevices/Coffin/Coffin.js
@@ -54,7 +54,7 @@ function InventoryItemDevicesCoffinValidate(C) {
 	var Allowed = "";
 
 	if (DialogFocusItem.Property.LockedBy && !DialogCanUnlock(C, DialogFocusItem)) {
-		Allowed = GetPlayerDialog("CantChangeWhileLocked");
+		Allowed = DialogFindPlayer("CantChangeWhileLocked");
 	}
 
 	return Allowed;

--- a/BondageClub/Screens/Inventory/ItemDevices/CryoCapsule/CryoCapsule.js
+++ b/BondageClub/Screens/Inventory/ItemDevices/CryoCapsule/CryoCapsule.js
@@ -54,7 +54,7 @@ function InventoryItemDevicesCryoCapsuleValidate(C) {
 	var Allowed = "";
 
 	if (DialogFocusItem.Property.LockedBy && !DialogCanUnlock(C, DialogFocusItem)) {
-		Allowed = DialogFind(Player, "CantChangeWhileLocked");
+		Allowed = GetPlayerDialog("CantChangeWhileLocked");
 	}
 
 	return Allowed;

--- a/BondageClub/Screens/Inventory/ItemDevices/CryoCapsule/CryoCapsule.js
+++ b/BondageClub/Screens/Inventory/ItemDevices/CryoCapsule/CryoCapsule.js
@@ -54,7 +54,7 @@ function InventoryItemDevicesCryoCapsuleValidate(C) {
 	var Allowed = "";
 
 	if (DialogFocusItem.Property.LockedBy && !DialogCanUnlock(C, DialogFocusItem)) {
-		Allowed = GetPlayerDialog("CantChangeWhileLocked");
+		Allowed = DialogFindPlayer("CantChangeWhileLocked");
 	}
 
 	return Allowed;

--- a/BondageClub/Screens/Inventory/ItemDevices/Sybian/Sybian.js
+++ b/BondageClub/Screens/Inventory/ItemDevices/Sybian/Sybian.js
@@ -12,15 +12,15 @@ function InventoryItemDevicesSybianDraw() {
 		DrawImageResize("Assets/" + DialogFocusItem.Asset.Group.Family + "/" + DialogFocusItem.Asset.Group.Name + "/Preview/" + DialogFocusItem.Asset.Name + ".png", 1389 + Math.floor(Math.random() * 3) - 1, 227 + Math.floor(Math.random() * 3) - 1, 221, 221);
 	else DrawImageResize("Assets/" + DialogFocusItem.Asset.Group.Family + "/" + DialogFocusItem.Asset.Group.Name + "/Preview/" + DialogFocusItem.Asset.Name + ".png", 1389, 227, 221, 221);
 	DrawTextFit(DialogFocusItem.Asset.Description, 1500, 475, 221, "black");
-	DrawText(DialogFind(Player, "Intensity" + DialogFocusItem.Property.Intensity.toString()).replace("Item", DialogFocusItem.Asset.Description), 1500, 600, "White", "Gray");
-	if (DialogFocusItem.Property.Intensity > -1) DrawButton(1200, 650, 200, 55, DialogFind(Player, "TurnOff"), "White");
-	if (DialogFocusItem.Property.Intensity < 0) DrawButton(1550, 650, 200, 55, DialogFind(Player, "Low"), "White");
-	if (DialogFocusItem.Property.Intensity > 0) DrawButton(1550, 650, 200, 55, DialogFind(Player, "Low"), "White");
-	if (DialogFocusItem.Property.Intensity < 1) DrawButton(1200, 710, 200, 55, DialogFind(Player, "Medium"), "White");
-	if (DialogFocusItem.Property.Intensity > 1) DrawButton(1200, 710, 200, 55, DialogFind(Player, "Medium"), "White");
-	if (DialogFocusItem.Property.Intensity < 2) DrawButton(1550, 710, 200, 55, DialogFind(Player, "High"), "White");
-	if (DialogFocusItem.Property.Intensity > 2) DrawButton(1550, 710, 200, 55, DialogFind(Player, "High"), "White");
-	if (DialogFocusItem.Property.Intensity < 3) DrawButton(1375, 770, 200, 55, DialogFind(Player, "Maximum"), "White");
+	DrawText(GetPlayerDialog("Intensity" + DialogFocusItem.Property.Intensity.toString()).replace("Item", DialogFocusItem.Asset.Description), 1500, 600, "White", "Gray");
+	if (DialogFocusItem.Property.Intensity > -1) DrawButton(1200, 650, 200, 55, GetPlayerDialog("TurnOff"), "White");
+	if (DialogFocusItem.Property.Intensity < 0) DrawButton(1550, 650, 200, 55, GetPlayerDialog("Low"), "White");
+	if (DialogFocusItem.Property.Intensity > 0) DrawButton(1550, 650, 200, 55, GetPlayerDialog("Low"), "White");
+	if (DialogFocusItem.Property.Intensity < 1) DrawButton(1200, 710, 200, 55, GetPlayerDialog("Medium"), "White");
+	if (DialogFocusItem.Property.Intensity > 1) DrawButton(1200, 710, 200, 55, GetPlayerDialog("Medium"), "White");
+	if (DialogFocusItem.Property.Intensity < 2) DrawButton(1550, 710, 200, 55, GetPlayerDialog("High"), "White");
+	if (DialogFocusItem.Property.Intensity > 2) DrawButton(1550, 710, 200, 55, GetPlayerDialog("High"), "White");
+	if (DialogFocusItem.Property.Intensity < 3) DrawButton(1375, 770, 200, 55, GetPlayerDialog("Maximum"), "White");
 }
 
 // Catches the item extension clicks

--- a/BondageClub/Screens/Inventory/ItemDevices/Sybian/Sybian.js
+++ b/BondageClub/Screens/Inventory/ItemDevices/Sybian/Sybian.js
@@ -12,15 +12,15 @@ function InventoryItemDevicesSybianDraw() {
 		DrawImageResize("Assets/" + DialogFocusItem.Asset.Group.Family + "/" + DialogFocusItem.Asset.Group.Name + "/Preview/" + DialogFocusItem.Asset.Name + ".png", 1389 + Math.floor(Math.random() * 3) - 1, 227 + Math.floor(Math.random() * 3) - 1, 221, 221);
 	else DrawImageResize("Assets/" + DialogFocusItem.Asset.Group.Family + "/" + DialogFocusItem.Asset.Group.Name + "/Preview/" + DialogFocusItem.Asset.Name + ".png", 1389, 227, 221, 221);
 	DrawTextFit(DialogFocusItem.Asset.Description, 1500, 475, 221, "black");
-	DrawText(GetPlayerDialog("Intensity" + DialogFocusItem.Property.Intensity.toString()).replace("Item", DialogFocusItem.Asset.Description), 1500, 600, "White", "Gray");
-	if (DialogFocusItem.Property.Intensity > -1) DrawButton(1200, 650, 200, 55, GetPlayerDialog("TurnOff"), "White");
-	if (DialogFocusItem.Property.Intensity < 0) DrawButton(1550, 650, 200, 55, GetPlayerDialog("Low"), "White");
-	if (DialogFocusItem.Property.Intensity > 0) DrawButton(1550, 650, 200, 55, GetPlayerDialog("Low"), "White");
-	if (DialogFocusItem.Property.Intensity < 1) DrawButton(1200, 710, 200, 55, GetPlayerDialog("Medium"), "White");
-	if (DialogFocusItem.Property.Intensity > 1) DrawButton(1200, 710, 200, 55, GetPlayerDialog("Medium"), "White");
-	if (DialogFocusItem.Property.Intensity < 2) DrawButton(1550, 710, 200, 55, GetPlayerDialog("High"), "White");
-	if (DialogFocusItem.Property.Intensity > 2) DrawButton(1550, 710, 200, 55, GetPlayerDialog("High"), "White");
-	if (DialogFocusItem.Property.Intensity < 3) DrawButton(1375, 770, 200, 55, GetPlayerDialog("Maximum"), "White");
+	DrawText(DialogFindPlayer("Intensity" + DialogFocusItem.Property.Intensity.toString()).replace("Item", DialogFocusItem.Asset.Description), 1500, 600, "White", "Gray");
+	if (DialogFocusItem.Property.Intensity > -1) DrawButton(1200, 650, 200, 55, DialogFindPlayer("TurnOff"), "White");
+	if (DialogFocusItem.Property.Intensity < 0) DrawButton(1550, 650, 200, 55, DialogFindPlayer("Low"), "White");
+	if (DialogFocusItem.Property.Intensity > 0) DrawButton(1550, 650, 200, 55, DialogFindPlayer("Low"), "White");
+	if (DialogFocusItem.Property.Intensity < 1) DrawButton(1200, 710, 200, 55, DialogFindPlayer("Medium"), "White");
+	if (DialogFocusItem.Property.Intensity > 1) DrawButton(1200, 710, 200, 55, DialogFindPlayer("Medium"), "White");
+	if (DialogFocusItem.Property.Intensity < 2) DrawButton(1550, 710, 200, 55, DialogFindPlayer("High"), "White");
+	if (DialogFocusItem.Property.Intensity > 2) DrawButton(1550, 710, 200, 55, DialogFindPlayer("High"), "White");
+	if (DialogFocusItem.Property.Intensity < 3) DrawButton(1375, 770, 200, 55, DialogFindPlayer("Maximum"), "White");
 }
 
 // Catches the item extension clicks

--- a/BondageClub/Screens/Inventory/ItemDevices/WoodenBox/WoodenBox.js
+++ b/BondageClub/Screens/Inventory/ItemDevices/WoodenBox/WoodenBox.js
@@ -62,10 +62,10 @@ function InventoryItemDevicesWoodenBoxDraw() {
 	DrawTextFit(DialogFocusItem.Asset.Description, 1500, 375, 221, "black");
 
 	MainCanvas.textAlign = "right";
-	DrawTextFit(GetPlayerDialog("WoodenBoxOpacityLabel"), 1475, 500, 400, "#fff", "#000");
+	DrawTextFit(DialogFindPlayer("WoodenBoxOpacityLabel"), 1475, 500, 400, "#fff", "#000");
 	ElementPosition(InventoryItemDevicesWoodenBoxOpacityInputId, 1725, 500, 400);
 
-	DrawTextFit(GetPlayerDialog("WoodenBoxTextLabel"), 1475, 580, 400, "#fff", "#000");
+	DrawTextFit(DialogFindPlayer("WoodenBoxTextLabel"), 1475, 580, 400, "#fff", "#000");
 	ElementPosition(InventoryItemDevicesWoodenBoxTextInputId, 1725, 580, 400);
 	MainCanvas.textAlign = "center";
 }

--- a/BondageClub/Screens/Inventory/ItemDevices/WoodenBox/WoodenBox.js
+++ b/BondageClub/Screens/Inventory/ItemDevices/WoodenBox/WoodenBox.js
@@ -62,10 +62,10 @@ function InventoryItemDevicesWoodenBoxDraw() {
 	DrawTextFit(DialogFocusItem.Asset.Description, 1500, 375, 221, "black");
 
 	MainCanvas.textAlign = "right";
-	DrawTextFit(DialogFind(Player, "WoodenBoxOpacityLabel"), 1475, 500, 400, "#fff", "#000");
+	DrawTextFit(GetPlayerDialog("WoodenBoxOpacityLabel"), 1475, 500, 400, "#fff", "#000");
 	ElementPosition(InventoryItemDevicesWoodenBoxOpacityInputId, 1725, 500, 400);
 
-	DrawTextFit(DialogFind(Player, "WoodenBoxTextLabel"), 1475, 580, 400, "#fff", "#000");
+	DrawTextFit(GetPlayerDialog("WoodenBoxTextLabel"), 1475, 580, 400, "#fff", "#000");
 	ElementPosition(InventoryItemDevicesWoodenBoxTextInputId, 1725, 580, 400);
 	MainCanvas.textAlign = "center";
 }

--- a/BondageClub/Screens/Inventory/ItemFeet/Chains/Chains.js
+++ b/BondageClub/Screens/Inventory/ItemFeet/Chains/Chains.js
@@ -84,7 +84,7 @@ function InventoryItemFeetChainsValidate(C, Option) {
 	if (Option.Prerequisite != null && !InventoryAllow(C, Option.Prerequisite, true)) {
 		Allowed = DialogText;
 	} else if (InventoryItemHasEffect(DialogFocusItem, "Lock", true)) {
-		Allowed = GetPlayerDialog("CantChangeWhileLocked");
+		Allowed = DialogFindPlayer("CantChangeWhileLocked");
 	}
 
 	return Allowed;

--- a/BondageClub/Screens/Inventory/ItemFeet/Chains/Chains.js
+++ b/BondageClub/Screens/Inventory/ItemFeet/Chains/Chains.js
@@ -84,7 +84,7 @@ function InventoryItemFeetChainsValidate(C, Option) {
 	if (Option.Prerequisite != null && !InventoryAllow(C, Option.Prerequisite, true)) {
 		Allowed = DialogText;
 	} else if (InventoryItemHasEffect(DialogFocusItem, "Lock", true)) {
-		Allowed = DialogFind(Player, "CantChangeWhileLocked");
+		Allowed = GetPlayerDialog("CantChangeWhileLocked");
 	}
 
 	return Allowed;

--- a/BondageClub/Screens/Inventory/ItemFeet/SpreaderVibratingDildoBar/SpreaderVibratingDildoBar.js
+++ b/BondageClub/Screens/Inventory/ItemFeet/SpreaderVibratingDildoBar/SpreaderVibratingDildoBar.js
@@ -13,15 +13,15 @@ function InventoryItemFeetSpreaderVibratingDildoBarDraw() {
 		DrawImageResize("Assets/" + DialogFocusItem.Asset.Group.Family + "/" + DialogFocusItem.Asset.Group.Name + "/Preview/" + DialogFocusItem.Asset.Name + ".png", 1389 + Math.floor(Math.random() * 3) - 1, 227 + Math.floor(Math.random() * 3) - 1, 221, 221);
 	else DrawImageResize("Assets/" + DialogFocusItem.Asset.Group.Family + "/" + DialogFocusItem.Asset.Group.Name + "/Preview/" + DialogFocusItem.Asset.Name + ".png", 1389, 227, 221, 221);
 	DrawTextFit(DialogFocusItem.Asset.Description, 1500, 475, 221, "black");
-	DrawText(DialogFind(Player, "Intensity" + DialogFocusItem.Property.Intensity.toString()).replace("Item", DialogFocusItem.Asset.Description), 1500, 600, "White", "Gray");
-	if (DialogFocusItem.Property.Intensity > -1) DrawButton(1200, 650, 200, 55, DialogFind(Player, "TurnOff"), "White");
-	if (DialogFocusItem.Property.Intensity < 0) DrawButton(1550, 650, 200, 55, DialogFind(Player, "Low"), "White");
-	if (DialogFocusItem.Property.Intensity > 0) DrawButton(1550, 650, 200, 55, DialogFind(Player, "Low"), "White");
-	if (DialogFocusItem.Property.Intensity < 1) DrawButton(1200, 710, 200, 55, DialogFind(Player, "Medium"), "White");
-	if (DialogFocusItem.Property.Intensity > 1) DrawButton(1200, 710, 200, 55, DialogFind(Player, "Medium"), "White");
-	if (DialogFocusItem.Property.Intensity < 2) DrawButton(1550, 710, 200, 55, DialogFind(Player, "High"), "White");
-	if (DialogFocusItem.Property.Intensity > 2) DrawButton(1550, 710, 200, 55, DialogFind(Player, "High"), "White");
-	if (DialogFocusItem.Property.Intensity < 3) DrawButton(1375, 770, 200, 55, DialogFind(Player, "Maximum"), "White");
+	DrawText(GetPlayerDialog("Intensity" + DialogFocusItem.Property.Intensity.toString()).replace("Item", DialogFocusItem.Asset.Description), 1500, 600, "White", "Gray");
+	if (DialogFocusItem.Property.Intensity > -1) DrawButton(1200, 650, 200, 55, GetPlayerDialog("TurnOff"), "White");
+	if (DialogFocusItem.Property.Intensity < 0) DrawButton(1550, 650, 200, 55, GetPlayerDialog("Low"), "White");
+	if (DialogFocusItem.Property.Intensity > 0) DrawButton(1550, 650, 200, 55, GetPlayerDialog("Low"), "White");
+	if (DialogFocusItem.Property.Intensity < 1) DrawButton(1200, 710, 200, 55, GetPlayerDialog("Medium"), "White");
+	if (DialogFocusItem.Property.Intensity > 1) DrawButton(1200, 710, 200, 55, GetPlayerDialog("Medium"), "White");
+	if (DialogFocusItem.Property.Intensity < 2) DrawButton(1550, 710, 200, 55, GetPlayerDialog("High"), "White");
+	if (DialogFocusItem.Property.Intensity > 2) DrawButton(1550, 710, 200, 55, GetPlayerDialog("High"), "White");
+	if (DialogFocusItem.Property.Intensity < 3) DrawButton(1375, 770, 200, 55, GetPlayerDialog("Maximum"), "White");
 }
 
 // Catches the item extension clicks

--- a/BondageClub/Screens/Inventory/ItemFeet/SpreaderVibratingDildoBar/SpreaderVibratingDildoBar.js
+++ b/BondageClub/Screens/Inventory/ItemFeet/SpreaderVibratingDildoBar/SpreaderVibratingDildoBar.js
@@ -13,15 +13,15 @@ function InventoryItemFeetSpreaderVibratingDildoBarDraw() {
 		DrawImageResize("Assets/" + DialogFocusItem.Asset.Group.Family + "/" + DialogFocusItem.Asset.Group.Name + "/Preview/" + DialogFocusItem.Asset.Name + ".png", 1389 + Math.floor(Math.random() * 3) - 1, 227 + Math.floor(Math.random() * 3) - 1, 221, 221);
 	else DrawImageResize("Assets/" + DialogFocusItem.Asset.Group.Family + "/" + DialogFocusItem.Asset.Group.Name + "/Preview/" + DialogFocusItem.Asset.Name + ".png", 1389, 227, 221, 221);
 	DrawTextFit(DialogFocusItem.Asset.Description, 1500, 475, 221, "black");
-	DrawText(GetPlayerDialog("Intensity" + DialogFocusItem.Property.Intensity.toString()).replace("Item", DialogFocusItem.Asset.Description), 1500, 600, "White", "Gray");
-	if (DialogFocusItem.Property.Intensity > -1) DrawButton(1200, 650, 200, 55, GetPlayerDialog("TurnOff"), "White");
-	if (DialogFocusItem.Property.Intensity < 0) DrawButton(1550, 650, 200, 55, GetPlayerDialog("Low"), "White");
-	if (DialogFocusItem.Property.Intensity > 0) DrawButton(1550, 650, 200, 55, GetPlayerDialog("Low"), "White");
-	if (DialogFocusItem.Property.Intensity < 1) DrawButton(1200, 710, 200, 55, GetPlayerDialog("Medium"), "White");
-	if (DialogFocusItem.Property.Intensity > 1) DrawButton(1200, 710, 200, 55, GetPlayerDialog("Medium"), "White");
-	if (DialogFocusItem.Property.Intensity < 2) DrawButton(1550, 710, 200, 55, GetPlayerDialog("High"), "White");
-	if (DialogFocusItem.Property.Intensity > 2) DrawButton(1550, 710, 200, 55, GetPlayerDialog("High"), "White");
-	if (DialogFocusItem.Property.Intensity < 3) DrawButton(1375, 770, 200, 55, GetPlayerDialog("Maximum"), "White");
+	DrawText(DialogFindPlayer("Intensity" + DialogFocusItem.Property.Intensity.toString()).replace("Item", DialogFocusItem.Asset.Description), 1500, 600, "White", "Gray");
+	if (DialogFocusItem.Property.Intensity > -1) DrawButton(1200, 650, 200, 55, DialogFindPlayer("TurnOff"), "White");
+	if (DialogFocusItem.Property.Intensity < 0) DrawButton(1550, 650, 200, 55, DialogFindPlayer("Low"), "White");
+	if (DialogFocusItem.Property.Intensity > 0) DrawButton(1550, 650, 200, 55, DialogFindPlayer("Low"), "White");
+	if (DialogFocusItem.Property.Intensity < 1) DrawButton(1200, 710, 200, 55, DialogFindPlayer("Medium"), "White");
+	if (DialogFocusItem.Property.Intensity > 1) DrawButton(1200, 710, 200, 55, DialogFindPlayer("Medium"), "White");
+	if (DialogFocusItem.Property.Intensity < 2) DrawButton(1550, 710, 200, 55, DialogFindPlayer("High"), "White");
+	if (DialogFocusItem.Property.Intensity > 2) DrawButton(1550, 710, 200, 55, DialogFindPlayer("High"), "White");
+	if (DialogFocusItem.Property.Intensity < 3) DrawButton(1375, 770, 200, 55, DialogFindPlayer("Maximum"), "White");
 }
 
 // Catches the item extension clicks

--- a/BondageClub/Screens/Inventory/ItemFeet/SturdyLeatherBelts/SturdyLeatherBelts.js
+++ b/BondageClub/Screens/Inventory/ItemFeet/SturdyLeatherBelts/SturdyLeatherBelts.js
@@ -56,9 +56,9 @@ function InventoryItemFeetSturdyLeatherBeltsValidate(C) {
 	var Allowed = "";
 
 	if (DialogFocusItem.Property.LockedBy && !DialogCanUnlock(C, DialogFocusItem)) {
-		Allowed = DialogFind(Player, "CantChangeWhileLocked");
+		Allowed = GetPlayerDialog("CantChangeWhileLocked");
 	} else if (InventoryGet(C, "ClothLower") != null) {
-		Allowed = DialogFind(Player, "RemoveClothesForItem");
+		Allowed = GetPlayerDialog("RemoveClothesForItem");
 	}
 
 	return Allowed;

--- a/BondageClub/Screens/Inventory/ItemFeet/SturdyLeatherBelts/SturdyLeatherBelts.js
+++ b/BondageClub/Screens/Inventory/ItemFeet/SturdyLeatherBelts/SturdyLeatherBelts.js
@@ -56,9 +56,9 @@ function InventoryItemFeetSturdyLeatherBeltsValidate(C) {
 	var Allowed = "";
 
 	if (DialogFocusItem.Property.LockedBy && !DialogCanUnlock(C, DialogFocusItem)) {
-		Allowed = GetPlayerDialog("CantChangeWhileLocked");
+		Allowed = DialogFindPlayer("CantChangeWhileLocked");
 	} else if (InventoryGet(C, "ClothLower") != null) {
-		Allowed = GetPlayerDialog("RemoveClothesForItem");
+		Allowed = DialogFindPlayer("RemoveClothesForItem");
 	}
 
 	return Allowed;

--- a/BondageClub/Screens/Inventory/ItemHands/PaddedMittens/PaddedMittens.js
+++ b/BondageClub/Screens/Inventory/ItemHands/PaddedMittens/PaddedMittens.js
@@ -16,13 +16,13 @@ function InventoryItemHandsPaddedMittensDraw() {
 	DrawTextFit(DialogFocusItem.Asset.Description, 1500, 375, 221, "black");
 
 	// Draw the possible options
-	DrawText(GetPlayerDialog("SelectFeature"), 1500, 500, "white", "gray");
+	DrawText(DialogFindPlayer("SelectFeature"), 1500, 500, "white", "gray");
 	DrawButton(1250, 550, 225, 225, "", "White");
 	DrawImage("Screens/Inventory/" + DialogFocusItem.Asset.Group.Name + "/" + DialogFocusItem.Asset.Name + "/AdultBabyHarness.png", 1250, 550);
-	DrawText(GetPlayerDialog("mittenstoharness"), 1375, 800, "white", "gray");
+	DrawText(DialogFindPlayer("mittenstoharness"), 1375, 800, "white", "gray");
 
 	// Draw the message if present
-	if (InventoryItemHandsPaddedMittensMsg != null) DrawTextWrap(GetPlayerDialog(InventoryItemHandsPaddedMittensMsg), 1100, 850, 800, 160, "White");
+	if (InventoryItemHandsPaddedMittensMsg != null) DrawTextWrap(DialogFindPlayer(InventoryItemHandsPaddedMittensMsg), 1100, 850, 800, 160, "White");
 
 }
 

--- a/BondageClub/Screens/Inventory/ItemHands/PaddedMittens/PaddedMittens.js
+++ b/BondageClub/Screens/Inventory/ItemHands/PaddedMittens/PaddedMittens.js
@@ -16,13 +16,13 @@ function InventoryItemHandsPaddedMittensDraw() {
 	DrawTextFit(DialogFocusItem.Asset.Description, 1500, 375, 221, "black");
 
 	// Draw the possible options
-	DrawText(DialogFind(Player, "SelectFeature"), 1500, 500, "white", "gray");
+	DrawText(GetPlayerDialog("SelectFeature"), 1500, 500, "white", "gray");
 	DrawButton(1250, 550, 225, 225, "", "White");
 	DrawImage("Screens/Inventory/" + DialogFocusItem.Asset.Group.Name + "/" + DialogFocusItem.Asset.Name + "/AdultBabyHarness.png", 1250, 550);
-	DrawText(DialogFind(Player, "mittenstoharness"), 1375, 800, "white", "gray");
+	DrawText(GetPlayerDialog("mittenstoharness"), 1375, 800, "white", "gray");
 
 	// Draw the message if present
-	if (InventoryItemHandsPaddedMittensMsg != null) DrawTextWrap(DialogFind(Player, InventoryItemHandsPaddedMittensMsg), 1100, 850, 800, 160, "White");
+	if (InventoryItemHandsPaddedMittensMsg != null) DrawTextWrap(GetPlayerDialog(InventoryItemHandsPaddedMittensMsg), 1100, 850, 800, 160, "White");
 
 }
 

--- a/BondageClub/Screens/Inventory/ItemHands/PawMittens/PawMittens.js
+++ b/BondageClub/Screens/Inventory/ItemHands/PawMittens/PawMittens.js
@@ -16,13 +16,13 @@ function InventoryItemHandsPawMittensDraw() {
 	DrawTextFit(DialogFocusItem.Asset.Description, 1500, 375, 221, "black");
 
 	// Draw the possible options
-	DrawText(DialogFind(Player, "SelectFeature"), 1500, 500, "white", "gray");
+	DrawText(GetPlayerDialog("SelectFeature"), 1500, 500, "white", "gray");
 	DrawButton(1250, 550, 225, 225, "", "White");
 	DrawImage("Screens/Inventory/" + DialogFocusItem.Asset.Group.Name + "/" + DialogFocusItem.Asset.Name + "/AdultBabyHarness.png", 1250, 550);
-	DrawText(DialogFind(Player, "mittenstoharness"), 1375, 800, "white", "gray");
+	DrawText(GetPlayerDialog("mittenstoharness"), 1375, 800, "white", "gray");
 
 	// Draw the message if present
-	if (InventoryItemHandsPawMittensMsg != null) DrawTextWrap(DialogFind(Player, InventoryItemHandsPawMittensMsg), 1100, 850, 800, 160, "White");
+	if (InventoryItemHandsPawMittensMsg != null) DrawTextWrap(GetPlayerDialog(InventoryItemHandsPawMittensMsg), 1100, 850, 800, 160, "White");
 
 }
 

--- a/BondageClub/Screens/Inventory/ItemHands/PawMittens/PawMittens.js
+++ b/BondageClub/Screens/Inventory/ItemHands/PawMittens/PawMittens.js
@@ -16,13 +16,13 @@ function InventoryItemHandsPawMittensDraw() {
 	DrawTextFit(DialogFocusItem.Asset.Description, 1500, 375, 221, "black");
 
 	// Draw the possible options
-	DrawText(GetPlayerDialog("SelectFeature"), 1500, 500, "white", "gray");
+	DrawText(DialogFindPlayer("SelectFeature"), 1500, 500, "white", "gray");
 	DrawButton(1250, 550, 225, 225, "", "White");
 	DrawImage("Screens/Inventory/" + DialogFocusItem.Asset.Group.Name + "/" + DialogFocusItem.Asset.Name + "/AdultBabyHarness.png", 1250, 550);
-	DrawText(GetPlayerDialog("mittenstoharness"), 1375, 800, "white", "gray");
+	DrawText(DialogFindPlayer("mittenstoharness"), 1375, 800, "white", "gray");
 
 	// Draw the message if present
-	if (InventoryItemHandsPawMittensMsg != null) DrawTextWrap(GetPlayerDialog(InventoryItemHandsPawMittensMsg), 1100, 850, 800, 160, "White");
+	if (InventoryItemHandsPawMittensMsg != null) DrawTextWrap(DialogFindPlayer(InventoryItemHandsPawMittensMsg), 1100, 850, 800, 160, "White");
 
 }
 

--- a/BondageClub/Screens/Inventory/ItemHood/CanvasHood/CanvasHood.js
+++ b/BondageClub/Screens/Inventory/ItemHood/CanvasHood/CanvasHood.js
@@ -37,9 +37,9 @@ function InventoryItemHoodCanvasHoodDraw() {
 	DrawTextFit(DialogFocusItem.Asset.Description, 1500, 375, 221, "black");
 
 	const updateAllowed = InventoryItemHoodCanvasHoodAllowedChars.test(InventoryItemHoodCanvasHoodGetText());
-	DrawTextFit(DialogFind(Player, "CanvasHoodLabel"), 1505, 620, 350, "#fff", "#000");
+	DrawTextFit(GetPlayerDialog("CanvasHoodLabel"), 1505, 620, 350, "#fff", "#000");
 	ElementPosition(InventoryItemHoodCanvasHoodInputId, 1505, 680, 350);
-	DrawButton(1330, 731, 340, 64, DialogFind(Player, "SaveText"), updateAllowed ? "White" : "#888", "");
+	DrawButton(1330, 731, 340, 64, GetPlayerDialog("SaveText"), updateAllowed ? "White" : "#888", "");
 }
 
 /**

--- a/BondageClub/Screens/Inventory/ItemHood/CanvasHood/CanvasHood.js
+++ b/BondageClub/Screens/Inventory/ItemHood/CanvasHood/CanvasHood.js
@@ -37,9 +37,9 @@ function InventoryItemHoodCanvasHoodDraw() {
 	DrawTextFit(DialogFocusItem.Asset.Description, 1500, 375, 221, "black");
 
 	const updateAllowed = InventoryItemHoodCanvasHoodAllowedChars.test(InventoryItemHoodCanvasHoodGetText());
-	DrawTextFit(GetPlayerDialog("CanvasHoodLabel"), 1505, 620, 350, "#fff", "#000");
+	DrawTextFit(DialogFindPlayer("CanvasHoodLabel"), 1505, 620, 350, "#fff", "#000");
 	ElementPosition(InventoryItemHoodCanvasHoodInputId, 1505, 680, 350);
-	DrawButton(1330, 731, 340, 64, GetPlayerDialog("SaveText"), updateAllowed ? "White" : "#888", "");
+	DrawButton(1330, 731, 340, 64, DialogFindPlayer("SaveText"), updateAllowed ? "White" : "#888", "");
 }
 
 /**

--- a/BondageClub/Screens/Inventory/ItemHood/OldGasMask/OldGasMask.js
+++ b/BondageClub/Screens/Inventory/ItemHood/OldGasMask/OldGasMask.js
@@ -29,17 +29,17 @@ function InventoryItemHoodOldGasMaskDraw() {
 	var lensesTube2IsBlocked = InventoryIsPermissionBlocked(C, "OldGasMaskLensesTube2", "ItemHoodAddon") || !InventoryCheckLimitedPermission(C, lensesTube2);
 	var lensesRebreatherIsBlocked = InventoryIsPermissionBlocked(C, "OldGasMaskLensesRebreather", "ItemHoodAddon") || !InventoryCheckLimitedPermission(C, lensesRebreather);
 
-	DrawButton(1250, 520, 200, 55, GetPlayerDialog("OldGasMaskLenses"), itemBlocked || lensesIsBlocked ? "#888" : "White");
-	DrawButton(1550, 520, 200, 55, GetPlayerDialog("OldGasMaskTubeA"), itemBlocked || tube1IsBlocked ? "#888" : "White");
-	DrawButton(1250, 600, 200, 55, GetPlayerDialog("OldGasMaskRebreather"), itemBlocked || rebreatherIsBlocked ? "#888" : "White");
-	DrawButton(1550, 600, 200, 55, GetPlayerDialog("OldGasMaskTubeB"), itemBlocked || tube2IsBlocked ? "#888" : "White");
-	DrawButton(1250, 680, 200, 55, GetPlayerDialog("OldGasMaskLensesTube1"), itemBlocked || lensesTube1IsBlocked ? "#888" : "White");
-	DrawButton(1550, 680, 200, 55, GetPlayerDialog("OldGasMaskLensesTube2"), itemBlocked || lensesTube2IsBlocked ? "#888" : "White");
-	DrawButton(1250, 760, 200, 55, GetPlayerDialog("OldGasMaskLensesRebreather"), itemBlocked || lensesRebreatherIsBlocked ? "#888" : "White");
+	DrawButton(1250, 520, 200, 55, DialogFindPlayer("OldGasMaskLenses"), itemBlocked || lensesIsBlocked ? "#888" : "White");
+	DrawButton(1550, 520, 200, 55, DialogFindPlayer("OldGasMaskTubeA"), itemBlocked || tube1IsBlocked ? "#888" : "White");
+	DrawButton(1250, 600, 200, 55, DialogFindPlayer("OldGasMaskRebreather"), itemBlocked || rebreatherIsBlocked ? "#888" : "White");
+	DrawButton(1550, 600, 200, 55, DialogFindPlayer("OldGasMaskTubeB"), itemBlocked || tube2IsBlocked ? "#888" : "White");
+	DrawButton(1250, 680, 200, 55, DialogFindPlayer("OldGasMaskLensesTube1"), itemBlocked || lensesTube1IsBlocked ? "#888" : "White");
+	DrawButton(1550, 680, 200, 55, DialogFindPlayer("OldGasMaskLensesTube2"), itemBlocked || lensesTube2IsBlocked ? "#888" : "White");
+	DrawButton(1250, 760, 200, 55, DialogFindPlayer("OldGasMaskLensesRebreather"), itemBlocked || lensesRebreatherIsBlocked ? "#888" : "White");
 
 	// Draw the message if the player is wearing an addon
 	if (tube1IsBlocked || tube2IsBlocked || lensesIsBlocked || rebreatherIsBlocked || lensesTube1IsBlocked || lensesTube2IsBlocked || lensesRebreatherIsBlocked) { 
-		DrawTextWrap(GetPlayerDialog("ItemAddonsSomeWrongPermissions"), 1100, 850, 800, 160, "White");
+		DrawTextWrap(DialogFindPlayer("ItemAddonsSomeWrongPermissions"), 1100, 850, 800, 160, "White");
 	}
 }
 

--- a/BondageClub/Screens/Inventory/ItemHood/OldGasMask/OldGasMask.js
+++ b/BondageClub/Screens/Inventory/ItemHood/OldGasMask/OldGasMask.js
@@ -29,17 +29,17 @@ function InventoryItemHoodOldGasMaskDraw() {
 	var lensesTube2IsBlocked = InventoryIsPermissionBlocked(C, "OldGasMaskLensesTube2", "ItemHoodAddon") || !InventoryCheckLimitedPermission(C, lensesTube2);
 	var lensesRebreatherIsBlocked = InventoryIsPermissionBlocked(C, "OldGasMaskLensesRebreather", "ItemHoodAddon") || !InventoryCheckLimitedPermission(C, lensesRebreather);
 
-	DrawButton(1250, 520, 200, 55, DialogFind(Player, "OldGasMaskLenses"), itemBlocked || lensesIsBlocked ? "#888" : "White");
-	DrawButton(1550, 520, 200, 55, DialogFind(Player, "OldGasMaskTubeA"), itemBlocked || tube1IsBlocked ? "#888" : "White");
-	DrawButton(1250, 600, 200, 55, DialogFind(Player, "OldGasMaskRebreather"), itemBlocked || rebreatherIsBlocked ? "#888" : "White");
-	DrawButton(1550, 600, 200, 55, DialogFind(Player, "OldGasMaskTubeB"), itemBlocked || tube2IsBlocked ? "#888" : "White");
-	DrawButton(1250, 680, 200, 55, DialogFind(Player, "OldGasMaskLensesTube1"), itemBlocked || lensesTube1IsBlocked ? "#888" : "White");
-	DrawButton(1550, 680, 200, 55, DialogFind(Player, "OldGasMaskLensesTube2"), itemBlocked || lensesTube2IsBlocked ? "#888" : "White");
-	DrawButton(1250, 760, 200, 55, DialogFind(Player, "OldGasMaskLensesRebreather"), itemBlocked || lensesRebreatherIsBlocked ? "#888" : "White");
+	DrawButton(1250, 520, 200, 55, GetPlayerDialog("OldGasMaskLenses"), itemBlocked || lensesIsBlocked ? "#888" : "White");
+	DrawButton(1550, 520, 200, 55, GetPlayerDialog("OldGasMaskTubeA"), itemBlocked || tube1IsBlocked ? "#888" : "White");
+	DrawButton(1250, 600, 200, 55, GetPlayerDialog("OldGasMaskRebreather"), itemBlocked || rebreatherIsBlocked ? "#888" : "White");
+	DrawButton(1550, 600, 200, 55, GetPlayerDialog("OldGasMaskTubeB"), itemBlocked || tube2IsBlocked ? "#888" : "White");
+	DrawButton(1250, 680, 200, 55, GetPlayerDialog("OldGasMaskLensesTube1"), itemBlocked || lensesTube1IsBlocked ? "#888" : "White");
+	DrawButton(1550, 680, 200, 55, GetPlayerDialog("OldGasMaskLensesTube2"), itemBlocked || lensesTube2IsBlocked ? "#888" : "White");
+	DrawButton(1250, 760, 200, 55, GetPlayerDialog("OldGasMaskLensesRebreather"), itemBlocked || lensesRebreatherIsBlocked ? "#888" : "White");
 
 	// Draw the message if the player is wearing an addon
 	if (tube1IsBlocked || tube2IsBlocked || lensesIsBlocked || rebreatherIsBlocked || lensesTube1IsBlocked || lensesTube2IsBlocked || lensesRebreatherIsBlocked) { 
-		DrawTextWrap(DialogFind(Player, "ItemAddonsSomeWrongPermissions"), 1100, 850, 800, 160, "White");
+		DrawTextWrap(GetPlayerDialog("ItemAddonsSomeWrongPermissions"), 1100, 850, 800, 160, "White");
 	}
 }
 

--- a/BondageClub/Screens/Inventory/ItemLegs/Chains/Chains.js
+++ b/BondageClub/Screens/Inventory/ItemLegs/Chains/Chains.js
@@ -72,7 +72,7 @@ function InventoryItemLegsChainsNpcDialog(C, Option) {
 function InventoryItemLegsChainsValidate(C) {
 	var Allowed = "";
 	if (DialogFocusItem.Property.LockedBy && !DialogCanUnlock(C, DialogFocusItem)) {
-		Allowed = DialogFind(Player, "CantChangeWhileLocked");
+		Allowed = GetPlayerDialog("CantChangeWhileLocked");
 	}
 	return Allowed;
 }

--- a/BondageClub/Screens/Inventory/ItemLegs/Chains/Chains.js
+++ b/BondageClub/Screens/Inventory/ItemLegs/Chains/Chains.js
@@ -72,7 +72,7 @@ function InventoryItemLegsChainsNpcDialog(C, Option) {
 function InventoryItemLegsChainsValidate(C) {
 	var Allowed = "";
 	if (DialogFocusItem.Property.LockedBy && !DialogCanUnlock(C, DialogFocusItem)) {
-		Allowed = GetPlayerDialog("CantChangeWhileLocked");
+		Allowed = DialogFindPlayer("CantChangeWhileLocked");
 	}
 	return Allowed;
 }

--- a/BondageClub/Screens/Inventory/ItemLegs/DuctTape/DuctTape.js
+++ b/BondageClub/Screens/Inventory/ItemLegs/DuctTape/DuctTape.js
@@ -78,7 +78,7 @@ function InventoryItemLegsDuctTapeValidate(C, Option) {
 	var Allowed = "";
 
 	if (Option.Property.Type != null && InventoryGet(C, "ClothLower")) {
-		Allowed = DialogFind(Player, "RemoveClothesForItem", "ItemLegs");
+		Allowed = GetPlayerDialog("RemoveClothesForItem");
 	}
 	return Allowed;
 }

--- a/BondageClub/Screens/Inventory/ItemLegs/DuctTape/DuctTape.js
+++ b/BondageClub/Screens/Inventory/ItemLegs/DuctTape/DuctTape.js
@@ -78,7 +78,7 @@ function InventoryItemLegsDuctTapeValidate(C, Option) {
 	var Allowed = "";
 
 	if (Option.Property.Type != null && InventoryGet(C, "ClothLower")) {
-		Allowed = GetPlayerDialog("RemoveClothesForItem");
+		Allowed = DialogFindPlayer("RemoveClothesForItem");
 	}
 	return Allowed;
 }

--- a/BondageClub/Screens/Inventory/ItemLegs/FuturisticLegCuffs/FuturisticLegCuffs.js
+++ b/BondageClub/Screens/Inventory/ItemLegs/FuturisticLegCuffs/FuturisticLegCuffs.js
@@ -23,13 +23,13 @@ function InventoryItemLegsFuturisticLegCuffsDraw() {
 		DrawTextFit(DialogFocusItem.Asset.Description, 1500, 375, 221, "black");
 
 		// Draw the possible poses
-		DrawText(GetPlayerDialog("SelectBondagePosition"), 1500, 500, "white", "gray");
+		DrawText(DialogFindPlayer("SelectBondagePosition"), 1500, 500, "white", "gray");
 		DrawButton(1250, 550, 225, 225, "", (DialogFocusItem.Property.Restrain == null) ? "#888888" : "White");
 		DrawImage("Screens/Inventory/" + DialogFocusItem.Asset.Group.Name + "/" + DialogFocusItem.Asset.Name + "/None.png", 1250, 550);
-		DrawText(GetPlayerDialog("LeatherLegCuffsPoseNone"), 1365, 800, "white", "gray");
+		DrawText(DialogFindPlayer("LeatherLegCuffsPoseNone"), 1365, 800, "white", "gray");
 		DrawButton(1500, 550, 225, 225, "", ((DialogFocusItem.Property.Restrain != null) && (DialogFocusItem.Property.Restrain == "Closed")) ? "#888888" : "Closed");
 		DrawImage("Screens/Inventory/" + DialogFocusItem.Asset.Group.Name + "/" + DialogFocusItem.Asset.Name + "/Closed.png", 1500, 550);
-		DrawText(GetPlayerDialog("LeatherLegCuffsPoseClosed"), 1610, 800, "white", "gray");
+		DrawText(DialogFindPlayer("LeatherLegCuffsPoseClosed"), 1610, 800, "white", "gray");
 	}
 }
 

--- a/BondageClub/Screens/Inventory/ItemLegs/FuturisticLegCuffs/FuturisticLegCuffs.js
+++ b/BondageClub/Screens/Inventory/ItemLegs/FuturisticLegCuffs/FuturisticLegCuffs.js
@@ -23,13 +23,13 @@ function InventoryItemLegsFuturisticLegCuffsDraw() {
 		DrawTextFit(DialogFocusItem.Asset.Description, 1500, 375, 221, "black");
 
 		// Draw the possible poses
-		DrawText(DialogFind(Player, "SelectBondagePosition"), 1500, 500, "white", "gray");
+		DrawText(GetPlayerDialog("SelectBondagePosition"), 1500, 500, "white", "gray");
 		DrawButton(1250, 550, 225, 225, "", (DialogFocusItem.Property.Restrain == null) ? "#888888" : "White");
 		DrawImage("Screens/Inventory/" + DialogFocusItem.Asset.Group.Name + "/" + DialogFocusItem.Asset.Name + "/None.png", 1250, 550);
-		DrawText(DialogFind(Player, "LeatherLegCuffsPoseNone"), 1365, 800, "white", "gray");
+		DrawText(GetPlayerDialog("LeatherLegCuffsPoseNone"), 1365, 800, "white", "gray");
 		DrawButton(1500, 550, 225, 225, "", ((DialogFocusItem.Property.Restrain != null) && (DialogFocusItem.Property.Restrain == "Closed")) ? "#888888" : "Closed");
 		DrawImage("Screens/Inventory/" + DialogFocusItem.Asset.Group.Name + "/" + DialogFocusItem.Asset.Name + "/Closed.png", 1500, 550);
-		DrawText(DialogFind(Player, "LeatherLegCuffsPoseClosed"), 1610, 800, "white", "gray");
+		DrawText(GetPlayerDialog("LeatherLegCuffsPoseClosed"), 1610, 800, "white", "gray");
 	}
 }
 

--- a/BondageClub/Screens/Inventory/ItemLegs/LeatherLegCuffs/LeatherLegCuffs.js
+++ b/BondageClub/Screens/Inventory/ItemLegs/LeatherLegCuffs/LeatherLegCuffs.js
@@ -15,13 +15,13 @@ function InventoryItemLegsLeatherLegCuffsDraw() {
 	DrawTextFit(DialogFocusItem.Asset.Description, 1500, 375, 221, "black");
 
 	// Draw the possible poses
-	DrawText(DialogFind(Player, "SelectBondagePosition"), 1500, 500, "white", "gray");
+	DrawText(GetPlayerDialog("SelectBondagePosition"), 1500, 500, "white", "gray");
 	DrawButton(1250, 550, 225, 225, "", (DialogFocusItem.Property.Restrain == null) ? "#888888" : "White");
 	DrawImage("Screens/Inventory/" + DialogFocusItem.Asset.Group.Name + "/" + DialogFocusItem.Asset.Name + "/None.png", 1250, 550);
-	DrawText(DialogFind(Player, "LeatherLegCuffsPoseNone"), 1365, 800, "white", "gray");
+	DrawText(GetPlayerDialog("LeatherLegCuffsPoseNone"), 1365, 800, "white", "gray");
 	DrawButton(1500, 550, 225, 225, "", ((DialogFocusItem.Property.Restrain != null) && (DialogFocusItem.Property.Restrain == "Closed")) ? "#888888" : "Closed");
 	DrawImage("Screens/Inventory/" + DialogFocusItem.Asset.Group.Name + "/" + DialogFocusItem.Asset.Name + "/Closed.png", 1500, 550);
-	DrawText(DialogFind(Player, "LeatherLegCuffsPoseClosed"), 1610, 800, "white", "gray");
+	DrawText(GetPlayerDialog("LeatherLegCuffsPoseClosed"), 1610, 800, "white", "gray");
 }
 
 // Catches the item extension clicks

--- a/BondageClub/Screens/Inventory/ItemLegs/LeatherLegCuffs/LeatherLegCuffs.js
+++ b/BondageClub/Screens/Inventory/ItemLegs/LeatherLegCuffs/LeatherLegCuffs.js
@@ -15,13 +15,13 @@ function InventoryItemLegsLeatherLegCuffsDraw() {
 	DrawTextFit(DialogFocusItem.Asset.Description, 1500, 375, 221, "black");
 
 	// Draw the possible poses
-	DrawText(GetPlayerDialog("SelectBondagePosition"), 1500, 500, "white", "gray");
+	DrawText(DialogFindPlayer("SelectBondagePosition"), 1500, 500, "white", "gray");
 	DrawButton(1250, 550, 225, 225, "", (DialogFocusItem.Property.Restrain == null) ? "#888888" : "White");
 	DrawImage("Screens/Inventory/" + DialogFocusItem.Asset.Group.Name + "/" + DialogFocusItem.Asset.Name + "/None.png", 1250, 550);
-	DrawText(GetPlayerDialog("LeatherLegCuffsPoseNone"), 1365, 800, "white", "gray");
+	DrawText(DialogFindPlayer("LeatherLegCuffsPoseNone"), 1365, 800, "white", "gray");
 	DrawButton(1500, 550, 225, 225, "", ((DialogFocusItem.Property.Restrain != null) && (DialogFocusItem.Property.Restrain == "Closed")) ? "#888888" : "Closed");
 	DrawImage("Screens/Inventory/" + DialogFocusItem.Asset.Group.Name + "/" + DialogFocusItem.Asset.Name + "/Closed.png", 1500, 550);
-	DrawText(GetPlayerDialog("LeatherLegCuffsPoseClosed"), 1610, 800, "white", "gray");
+	DrawText(DialogFindPlayer("LeatherLegCuffsPoseClosed"), 1610, 800, "white", "gray");
 }
 
 // Catches the item extension clicks

--- a/BondageClub/Screens/Inventory/ItemLegs/OrnateLegCuffs/OrnateLegCuffs.js
+++ b/BondageClub/Screens/Inventory/ItemLegs/OrnateLegCuffs/OrnateLegCuffs.js
@@ -15,13 +15,13 @@ function InventoryItemLegsOrnateLegCuffsDraw() {
 	DrawTextFit(DialogFocusItem.Asset.Description, 1500, 375, 221, "black");
 
 	// Draw the possible poses
-	DrawText(DialogFind(Player, "SelectBondagePosition"), 1500, 500, "white", "gray");
+	DrawText(GetPlayerDialog("SelectBondagePosition"), 1500, 500, "white", "gray");
 	DrawButton(1250, 550, 225, 225, "", (DialogFocusItem.Property.Restrain == null) ? "#888888" : "White");
 	DrawImage("Screens/Inventory/" + DialogFocusItem.Asset.Group.Name + "/" + DialogFocusItem.Asset.Name + "/None.png", 1250, 550);
-	DrawText(DialogFind(Player, "OrnateLegCuffsPoseNone"), 1365, 800, "white", "gray");
+	DrawText(GetPlayerDialog("OrnateLegCuffsPoseNone"), 1365, 800, "white", "gray");
 	DrawButton(1500, 550, 225, 225, "", ((DialogFocusItem.Property.Restrain != null) && (DialogFocusItem.Property.Restrain == "Closed")) ? "#888888" : "Closed");
 	DrawImage("Screens/Inventory/" + DialogFocusItem.Asset.Group.Name + "/" + DialogFocusItem.Asset.Name + "/Closed.png", 1500, 550);
-	DrawText(DialogFind(Player, "OrnateLegCuffsPoseClosed"), 1610, 800, "white", "gray");
+	DrawText(GetPlayerDialog("OrnateLegCuffsPoseClosed"), 1610, 800, "white", "gray");
 }
 
 // Catches the item extension clicks

--- a/BondageClub/Screens/Inventory/ItemLegs/OrnateLegCuffs/OrnateLegCuffs.js
+++ b/BondageClub/Screens/Inventory/ItemLegs/OrnateLegCuffs/OrnateLegCuffs.js
@@ -15,13 +15,13 @@ function InventoryItemLegsOrnateLegCuffsDraw() {
 	DrawTextFit(DialogFocusItem.Asset.Description, 1500, 375, 221, "black");
 
 	// Draw the possible poses
-	DrawText(GetPlayerDialog("SelectBondagePosition"), 1500, 500, "white", "gray");
+	DrawText(DialogFindPlayer("SelectBondagePosition"), 1500, 500, "white", "gray");
 	DrawButton(1250, 550, 225, 225, "", (DialogFocusItem.Property.Restrain == null) ? "#888888" : "White");
 	DrawImage("Screens/Inventory/" + DialogFocusItem.Asset.Group.Name + "/" + DialogFocusItem.Asset.Name + "/None.png", 1250, 550);
-	DrawText(GetPlayerDialog("OrnateLegCuffsPoseNone"), 1365, 800, "white", "gray");
+	DrawText(DialogFindPlayer("OrnateLegCuffsPoseNone"), 1365, 800, "white", "gray");
 	DrawButton(1500, 550, 225, 225, "", ((DialogFocusItem.Property.Restrain != null) && (DialogFocusItem.Property.Restrain == "Closed")) ? "#888888" : "Closed");
 	DrawImage("Screens/Inventory/" + DialogFocusItem.Asset.Group.Name + "/" + DialogFocusItem.Asset.Name + "/Closed.png", 1500, 550);
-	DrawText(GetPlayerDialog("OrnateLegCuffsPoseClosed"), 1610, 800, "white", "gray");
+	DrawText(DialogFindPlayer("OrnateLegCuffsPoseClosed"), 1610, 800, "white", "gray");
 }
 
 // Catches the item extension clicks

--- a/BondageClub/Screens/Inventory/ItemLegs/SturdyLeatherBelts/SturdyLeatherBelts.js
+++ b/BondageClub/Screens/Inventory/ItemLegs/SturdyLeatherBelts/SturdyLeatherBelts.js
@@ -50,9 +50,9 @@ function InventoryItemLegsSturdyLeatherBeltsValidate(C) {
 	var Allowed = "";
 
 	if (InventoryItemHasEffect(DialogFocusItem, "Lock", true) && !DialogCanUnlock(C, DialogFocusItem)) {
-		Allowed = DialogFind(Player, "CantChangeWhileLocked");
+		Allowed = GetPlayerDialog("CantChangeWhileLocked");
 	} else if (InventoryGet(C, "ClothLower") != null) {
-		Allowed = DialogFind(Player, "RemoveClothesForItem");
+		Allowed = GetPlayerDialog("RemoveClothesForItem");
 	}
 
 	return Allowed;

--- a/BondageClub/Screens/Inventory/ItemLegs/SturdyLeatherBelts/SturdyLeatherBelts.js
+++ b/BondageClub/Screens/Inventory/ItemLegs/SturdyLeatherBelts/SturdyLeatherBelts.js
@@ -50,9 +50,9 @@ function InventoryItemLegsSturdyLeatherBeltsValidate(C) {
 	var Allowed = "";
 
 	if (InventoryItemHasEffect(DialogFocusItem, "Lock", true) && !DialogCanUnlock(C, DialogFocusItem)) {
-		Allowed = GetPlayerDialog("CantChangeWhileLocked");
+		Allowed = DialogFindPlayer("CantChangeWhileLocked");
 	} else if (InventoryGet(C, "ClothLower") != null) {
-		Allowed = GetPlayerDialog("RemoveClothesForItem");
+		Allowed = DialogFindPlayer("RemoveClothesForItem");
 	}
 
 	return Allowed;

--- a/BondageClub/Screens/Inventory/ItemMisc/CombinationPadlock/CombinationPadlock.js
+++ b/BondageClub/Screens/Inventory/ItemMisc/CombinationPadlock/CombinationPadlock.js
@@ -22,24 +22,24 @@ function InventoryItemMiscCombinationPadlockDraw() {
 	DrawRect(1387, 225, 225, 275, "white");
 	DrawImageResize("Assets/" + DialogFocusItem.Asset.Group.Family + "/" + DialogFocusItem.Asset.Group.Name + "/Preview/" + DialogFocusItem.Asset.Name + ".png", 1389, 227, 221, 221);
 	DrawTextFit(DialogFocusItem.Asset.Description, 1500, 475, 221, "black");
-	DrawText(GetPlayerDialog(DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Intro"), 1500, 600, "white", "gray");
+	DrawText(DialogFindPlayer(DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Intro"), 1500, 600, "white", "gray");
 	if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property != null) && (DialogFocusSourceItem.Property.LockMemberNumber != null))
-		DrawText(GetPlayerDialog("LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 700, "white", "gray");
+		DrawText(DialogFindPlayer("LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 700, "white", "gray");
 
 	if (InventoryGroupIsBlocked(C, C.FocusGroup.Name)) {
 		// If the zone is blocked, just display some text informing the player that they can't access the lock
-		DrawText(GetPlayerDialog("LockZoneBlocked"), 1500, 800, "white", "gray");
+		DrawText(DialogFindPlayer("LockZoneBlocked"), 1500, 800, "white", "gray");
 	} else {
 		// Otherwise, draw the combination inputs
 		MainCanvas.textAlign = "right";
-		DrawText(GetPlayerDialog("CombinationOld"), 1400, 803, "white", "gray");
-		DrawText(GetPlayerDialog("CombinationNew"), 1400, 883, "white", "gray");
+		DrawText(DialogFindPlayer("CombinationOld"), 1400, 803, "white", "gray");
+		DrawText(DialogFindPlayer("CombinationNew"), 1400, 883, "white", "gray");
 		MainCanvas.textAlign = "center";
 		ElementPosition("CombinationNumber", 1500, 800, 125);
 		ElementPosition("NewCombinationNumber", 1500, 880, 125);
-		DrawButton(1600, 771, 350, 64, GetPlayerDialog("CombinationEnter"), "White", "");
-		DrawButton(1600, 851, 350, 64, GetPlayerDialog("CombinationChange"), "White", "");
-		if (PreferenceMessage != "") DrawText(GetPlayerDialog(PreferenceMessage), 1500, 963, "Red", "Black");
+		DrawButton(1600, 771, 350, 64, DialogFindPlayer("CombinationEnter"), "White", "");
+		DrawButton(1600, 851, 350, 64, DialogFindPlayer("CombinationChange"), "White", "");
+		if (PreferenceMessage != "") DrawText(DialogFindPlayer(PreferenceMessage), 1500, 963, "Red", "Black");
 	}
 }
 

--- a/BondageClub/Screens/Inventory/ItemMisc/CombinationPadlock/CombinationPadlock.js
+++ b/BondageClub/Screens/Inventory/ItemMisc/CombinationPadlock/CombinationPadlock.js
@@ -22,24 +22,24 @@ function InventoryItemMiscCombinationPadlockDraw() {
 	DrawRect(1387, 225, 225, 275, "white");
 	DrawImageResize("Assets/" + DialogFocusItem.Asset.Group.Family + "/" + DialogFocusItem.Asset.Group.Name + "/Preview/" + DialogFocusItem.Asset.Name + ".png", 1389, 227, 221, 221);
 	DrawTextFit(DialogFocusItem.Asset.Description, 1500, 475, 221, "black");
-	DrawText(DialogFind(Player, DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Intro"), 1500, 600, "white", "gray");
+	DrawText(GetPlayerDialog(DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Intro"), 1500, 600, "white", "gray");
 	if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property != null) && (DialogFocusSourceItem.Property.LockMemberNumber != null))
-		DrawText(DialogFind(Player, "LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 700, "white", "gray");
+		DrawText(GetPlayerDialog("LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 700, "white", "gray");
 
 	if (InventoryGroupIsBlocked(C, C.FocusGroup.Name)) {
 		// If the zone is blocked, just display some text informing the player that they can't access the lock
-		DrawText(DialogFind(Player, "LockZoneBlocked"), 1500, 800, "white", "gray");
+		DrawText(GetPlayerDialog("LockZoneBlocked"), 1500, 800, "white", "gray");
 	} else {
 		// Otherwise, draw the combination inputs
 		MainCanvas.textAlign = "right";
-		DrawText(DialogFind(Player, "CombinationOld"), 1400, 803, "white", "gray");
-		DrawText(DialogFind(Player, "CombinationNew"), 1400, 883, "white", "gray");
+		DrawText(GetPlayerDialog("CombinationOld"), 1400, 803, "white", "gray");
+		DrawText(GetPlayerDialog("CombinationNew"), 1400, 883, "white", "gray");
 		MainCanvas.textAlign = "center";
 		ElementPosition("CombinationNumber", 1500, 800, 125);
 		ElementPosition("NewCombinationNumber", 1500, 880, 125);
-		DrawButton(1600, 771, 350, 64, DialogFind(Player, "CombinationEnter"), "White", "");
-		DrawButton(1600, 851, 350, 64, DialogFind(Player, "CombinationChange"), "White", "");
-		if (PreferenceMessage != "") DrawText(DialogFind(Player, PreferenceMessage), 1500, 963, "Red", "Black");
+		DrawButton(1600, 771, 350, 64, GetPlayerDialog("CombinationEnter"), "White", "");
+		DrawButton(1600, 851, 350, 64, GetPlayerDialog("CombinationChange"), "White", "");
+		if (PreferenceMessage != "") DrawText(GetPlayerDialog(PreferenceMessage), 1500, 963, "Red", "Black");
 	}
 }
 

--- a/BondageClub/Screens/Inventory/ItemMisc/ExclusivePadlock/ExclusivePadlock.js
+++ b/BondageClub/Screens/Inventory/ItemMisc/ExclusivePadlock/ExclusivePadlock.js
@@ -9,10 +9,10 @@ function InventoryItemMiscExclusivePadlockDraw() {
 	DrawRect(1387, 225, 225, 275, "white");
 	DrawImageResize("Assets/" + DialogFocusItem.Asset.Group.Family + "/" + DialogFocusItem.Asset.Group.Name + "/Preview/" + DialogFocusItem.Asset.Name + ".png", 1389, 227, 221, 221);
 	DrawTextFit(DialogFocusItem.Asset.Description, 1500, 475, 221, "black");
-	DrawText(GetPlayerDialog(DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Intro"), 1500, 600, "white", "gray");
-	DrawText(GetPlayerDialog(DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Detail"), 1500, 700, "white", "gray");
+	DrawText(DialogFindPlayer(DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Intro"), 1500, 600, "white", "gray");
+	DrawText(DialogFindPlayer(DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Detail"), 1500, 700, "white", "gray");
 	if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property != null) && (DialogFocusSourceItem.Property.LockMemberNumber != null)) 
-		DrawText(GetPlayerDialog("LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 800, "white", "gray");
+		DrawText(DialogFindPlayer("LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 800, "white", "gray");
 }
 
 // Catches the item extension clicks

--- a/BondageClub/Screens/Inventory/ItemMisc/ExclusivePadlock/ExclusivePadlock.js
+++ b/BondageClub/Screens/Inventory/ItemMisc/ExclusivePadlock/ExclusivePadlock.js
@@ -9,10 +9,10 @@ function InventoryItemMiscExclusivePadlockDraw() {
 	DrawRect(1387, 225, 225, 275, "white");
 	DrawImageResize("Assets/" + DialogFocusItem.Asset.Group.Family + "/" + DialogFocusItem.Asset.Group.Name + "/Preview/" + DialogFocusItem.Asset.Name + ".png", 1389, 227, 221, 221);
 	DrawTextFit(DialogFocusItem.Asset.Description, 1500, 475, 221, "black");
-	DrawText(DialogFind(Player, DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Intro"), 1500, 600, "white", "gray");
-	DrawText(DialogFind(Player, DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Detail"), 1500, 700, "white", "gray");
+	DrawText(GetPlayerDialog(DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Intro"), 1500, 600, "white", "gray");
+	DrawText(GetPlayerDialog(DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Detail"), 1500, 700, "white", "gray");
 	if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property != null) && (DialogFocusSourceItem.Property.LockMemberNumber != null)) 
-		DrawText(DialogFind(Player, "LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 800, "white", "gray");
+		DrawText(GetPlayerDialog("LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 800, "white", "gray");
 }
 
 // Catches the item extension clicks

--- a/BondageClub/Screens/Inventory/ItemMisc/HighSecurityPadlock/HighSecurityPadlock.js
+++ b/BondageClub/Screens/Inventory/ItemMisc/HighSecurityPadlock/HighSecurityPadlock.js
@@ -56,26 +56,26 @@ function InventoryItemMiscHighSecurityPadlockDraw() {
 	DrawImageResize("Assets/" + DialogFocusItem.Asset.Group.Family + "/" + DialogFocusItem.Asset.Group.Name + "/Preview/" + DialogFocusItem.Asset.Name + ".png", 1389, 227, 221, 221);
 	DrawTextFit(DialogFocusItem.Asset.Description, 1500, 475, 221, "black");
 	if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property != null) && (DialogFocusSourceItem.Property.LockMemberNumber != null)) 
-		DrawText(GetPlayerDialog("LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 650, "white", "gray");
+		DrawText(DialogFindPlayer("LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 650, "white", "gray");
 	
 	if (!InventoryGroupIsBlocked(C, C.FocusGroup.Name)&& (DialogFocusSourceItem != null && ((DialogFocusSourceItem.Property.MemberNumberList && CommonConvertStringToArray("" + DialogFocusSourceItem.Property.MemberNumberList).indexOf(Player.MemberNumber) >= 0)))) {
-		DrawText(GetPlayerDialog("HighSecuritySaveIntro"), 1500, 600, "white", "gray");
+		DrawText(DialogFindPlayer("HighSecuritySaveIntro"), 1500, 600, "white", "gray");
 		ElementPosition("MemberNumberList", 1260, 780, 300, 170);
-		DrawButton(1135, 920, 230, 64, GetPlayerDialog("HighSecuritySave"), "White", "");
+		DrawButton(1135, 920, 230, 64, DialogFindPlayer("HighSecuritySave"), "White", "");
 		
 		MainCanvas.textAlign = "left";
-		DrawCheckboxColor(1450, 700, 64, 64, GetPlayerDialog("HighSecurityAppendOwner"), HighSecurityPadlockConfigOwner, "White");
-		DrawCheckboxColor(1450, 780, 64, 64, GetPlayerDialog("HighSecurityAppendLover"), HighSecurityPadlockConfigLover, "White");
-		DrawCheckboxColor(1450, 860, 64, 64, GetPlayerDialog("HighSecurityAppendWhitelist"), HighSecurityPadlockConfigWhitelist, "White");
+		DrawCheckboxColor(1450, 700, 64, 64, DialogFindPlayer("HighSecurityAppendOwner"), HighSecurityPadlockConfigOwner, "White");
+		DrawCheckboxColor(1450, 780, 64, 64, DialogFindPlayer("HighSecurityAppendLover"), HighSecurityPadlockConfigLover, "White");
+		DrawCheckboxColor(1450, 860, 64, 64, DialogFindPlayer("HighSecurityAppendWhitelist"), HighSecurityPadlockConfigWhitelist, "White");
 		MainCanvas.textAlign = "center";
 
 		
 		if (!InventoryItemMiscHighSecurityPadlockPlayerCanUnlock) {
-			DrawText(GetPlayerDialog("HighSecurityWarning"), 1500, 550, "red", "gray");
+			DrawText(DialogFindPlayer("HighSecurityWarning"), 1500, 550, "red", "gray");
 		}
 	} else {
 		
-		DrawText(GetPlayerDialog(DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Intro"), 1500, 600, "white", "gray");
+		DrawText(DialogFindPlayer(DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Intro"), 1500, 600, "white", "gray");
 	}
 }
 

--- a/BondageClub/Screens/Inventory/ItemMisc/HighSecurityPadlock/HighSecurityPadlock.js
+++ b/BondageClub/Screens/Inventory/ItemMisc/HighSecurityPadlock/HighSecurityPadlock.js
@@ -56,26 +56,26 @@ function InventoryItemMiscHighSecurityPadlockDraw() {
 	DrawImageResize("Assets/" + DialogFocusItem.Asset.Group.Family + "/" + DialogFocusItem.Asset.Group.Name + "/Preview/" + DialogFocusItem.Asset.Name + ".png", 1389, 227, 221, 221);
 	DrawTextFit(DialogFocusItem.Asset.Description, 1500, 475, 221, "black");
 	if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property != null) && (DialogFocusSourceItem.Property.LockMemberNumber != null)) 
-		DrawText(DialogFind(Player, "LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 650, "white", "gray");
+		DrawText(GetPlayerDialog("LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 650, "white", "gray");
 	
 	if (!InventoryGroupIsBlocked(C, C.FocusGroup.Name)&& (DialogFocusSourceItem != null && ((DialogFocusSourceItem.Property.MemberNumberList && CommonConvertStringToArray("" + DialogFocusSourceItem.Property.MemberNumberList).indexOf(Player.MemberNumber) >= 0)))) {
-		DrawText(DialogFind(Player, "HighSecuritySaveIntro"), 1500, 600, "white", "gray");
+		DrawText(GetPlayerDialog("HighSecuritySaveIntro"), 1500, 600, "white", "gray");
 		ElementPosition("MemberNumberList", 1260, 780, 300, 170);
-		DrawButton(1135, 920, 230, 64, DialogFind(Player, "HighSecuritySave"), "White", "");
+		DrawButton(1135, 920, 230, 64, GetPlayerDialog("HighSecuritySave"), "White", "");
 		
 		MainCanvas.textAlign = "left";
-		DrawCheckboxColor(1450, 700, 64, 64, DialogFind(Player, "HighSecurityAppendOwner"), HighSecurityPadlockConfigOwner, "White");
-		DrawCheckboxColor(1450, 780, 64, 64, DialogFind(Player, "HighSecurityAppendLover"), HighSecurityPadlockConfigLover, "White");
-		DrawCheckboxColor(1450, 860, 64, 64, DialogFind(Player, "HighSecurityAppendWhitelist"), HighSecurityPadlockConfigWhitelist, "White");
+		DrawCheckboxColor(1450, 700, 64, 64, GetPlayerDialog("HighSecurityAppendOwner"), HighSecurityPadlockConfigOwner, "White");
+		DrawCheckboxColor(1450, 780, 64, 64, GetPlayerDialog("HighSecurityAppendLover"), HighSecurityPadlockConfigLover, "White");
+		DrawCheckboxColor(1450, 860, 64, 64, GetPlayerDialog("HighSecurityAppendWhitelist"), HighSecurityPadlockConfigWhitelist, "White");
 		MainCanvas.textAlign = "center";
 
 		
 		if (!InventoryItemMiscHighSecurityPadlockPlayerCanUnlock) {
-			DrawText(DialogFind(Player, "HighSecurityWarning"), 1500, 550, "red", "gray");
+			DrawText(GetPlayerDialog("HighSecurityWarning"), 1500, 550, "red", "gray");
 		}
 	} else {
 		
-		DrawText(DialogFind(Player, DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Intro"), 1500, 600, "white", "gray");
+		DrawText(GetPlayerDialog(DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Intro"), 1500, 600, "white", "gray");
 	}
 }
 

--- a/BondageClub/Screens/Inventory/ItemMisc/IntricatePadlock/IntricatePadlock.js
+++ b/BondageClub/Screens/Inventory/ItemMisc/IntricatePadlock/IntricatePadlock.js
@@ -9,9 +9,9 @@ function InventoryItemMiscIntricatePadlockDraw() {
 	DrawRect(1387, 225, 225, 275, "white");
 	DrawImageResize("Assets/" + DialogFocusItem.Asset.Group.Family + "/" + DialogFocusItem.Asset.Group.Name + "/Preview/" + DialogFocusItem.Asset.Name + ".png", 1389, 227, 221, 221);
 	DrawTextFit(DialogFocusItem.Asset.Description, 1500, 475, 221, "black");
-	DrawText(GetPlayerDialog(DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Intro"), 1500, 600, "white", "gray");
+	DrawText(DialogFindPlayer(DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Intro"), 1500, 600, "white", "gray");
 	if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property != null) && (DialogFocusSourceItem.Property.LockMemberNumber != null)) 
-		DrawText(GetPlayerDialog("LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 700, "white", "gray");
+		DrawText(DialogFindPlayer("LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 700, "white", "gray");
 }
 
 // Catches the item extension clicks

--- a/BondageClub/Screens/Inventory/ItemMisc/IntricatePadlock/IntricatePadlock.js
+++ b/BondageClub/Screens/Inventory/ItemMisc/IntricatePadlock/IntricatePadlock.js
@@ -9,9 +9,9 @@ function InventoryItemMiscIntricatePadlockDraw() {
 	DrawRect(1387, 225, 225, 275, "white");
 	DrawImageResize("Assets/" + DialogFocusItem.Asset.Group.Family + "/" + DialogFocusItem.Asset.Group.Name + "/Preview/" + DialogFocusItem.Asset.Name + ".png", 1389, 227, 221, 221);
 	DrawTextFit(DialogFocusItem.Asset.Description, 1500, 475, 221, "black");
-	DrawText(DialogFind(Player, DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Intro"), 1500, 600, "white", "gray");
+	DrawText(GetPlayerDialog(DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Intro"), 1500, 600, "white", "gray");
 	if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property != null) && (DialogFocusSourceItem.Property.LockMemberNumber != null)) 
-		DrawText(DialogFind(Player, "LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 700, "white", "gray");
+		DrawText(GetPlayerDialog("LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 700, "white", "gray");
 }
 
 // Catches the item extension clicks

--- a/BondageClub/Screens/Inventory/ItemMisc/LoversPadlock/LoversPadlock.js
+++ b/BondageClub/Screens/Inventory/ItemMisc/LoversPadlock/LoversPadlock.js
@@ -9,10 +9,10 @@ function InventoryItemMiscLoversPadlockDraw() {
     DrawRect(1387, 225, 225, 275, "white");
     DrawImageResize("Assets/" + DialogFocusItem.Asset.Group.Family + "/" + DialogFocusItem.Asset.Group.Name + "/Preview/" + DialogFocusItem.Asset.Name + ".png", 1389, 227, 221, 221);
     DrawTextFit(DialogFocusItem.Asset.Description, 1500, 475, 221, "black");
-    DrawText(GetPlayerDialog(DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Intro"), 1500, 600, "white", "gray");
+    DrawText(DialogFindPlayer(DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Intro"), 1500, 600, "white", "gray");
     if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property != null) && (DialogFocusSourceItem.Property.LockMemberNumber != null))
-        DrawText(GetPlayerDialog("LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 700, "white", "gray");
-    DrawText(GetPlayerDialog(DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Detail"), 1500, 800, "white", "gray");
+        DrawText(DialogFindPlayer("LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 700, "white", "gray");
+    DrawText(DialogFindPlayer(DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Detail"), 1500, 800, "white", "gray");
 }
 
 // Catches the item extension clicks

--- a/BondageClub/Screens/Inventory/ItemMisc/LoversPadlock/LoversPadlock.js
+++ b/BondageClub/Screens/Inventory/ItemMisc/LoversPadlock/LoversPadlock.js
@@ -9,10 +9,10 @@ function InventoryItemMiscLoversPadlockDraw() {
     DrawRect(1387, 225, 225, 275, "white");
     DrawImageResize("Assets/" + DialogFocusItem.Asset.Group.Family + "/" + DialogFocusItem.Asset.Group.Name + "/Preview/" + DialogFocusItem.Asset.Name + ".png", 1389, 227, 221, 221);
     DrawTextFit(DialogFocusItem.Asset.Description, 1500, 475, 221, "black");
-    DrawText(DialogFind(Player, DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Intro"), 1500, 600, "white", "gray");
+    DrawText(GetPlayerDialog(DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Intro"), 1500, 600, "white", "gray");
     if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property != null) && (DialogFocusSourceItem.Property.LockMemberNumber != null))
-        DrawText(DialogFind(Player, "LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 700, "white", "gray");
-    DrawText(DialogFind(Player, DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Detail"), 1500, 800, "white", "gray");
+        DrawText(GetPlayerDialog("LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 700, "white", "gray");
+    DrawText(GetPlayerDialog(DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Detail"), 1500, 800, "white", "gray");
 }
 
 // Catches the item extension clicks

--- a/BondageClub/Screens/Inventory/ItemMisc/LoversTimerPadlock/LoversTimerPadlock.js
+++ b/BondageClub/Screens/Inventory/ItemMisc/LoversTimerPadlock/LoversTimerPadlock.js
@@ -17,44 +17,44 @@ function InventoryItemMiscLoversTimerPadlockDraw() {
     var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
     if ((DialogFocusItem == null) || (DialogFocusSourceItem.Property.RemoveTimer < CurrentTime)) { InventoryItemMiscLoversTimerPadlockExit(); return; }
     if (DialogFocusSourceItem.Property.ShowTimer) {
-        DrawText(DialogFind(Player, "TimerLeft") + " " + TimerToString(DialogFocusSourceItem.Property.RemoveTimer - CurrentTime), 1500, 150, "white", "gray");
-    } else { DrawText(DialogFind(Player, "TimerUnknown"), 1500, 150, "white", "gray"); }
+        DrawText(GetPlayerDialog("TimerLeft") + " " + TimerToString(DialogFocusSourceItem.Property.RemoveTimer - CurrentTime), 1500, 150, "white", "gray");
+    } else { DrawText(GetPlayerDialog("TimerUnknown"), 1500, 150, "white", "gray"); }
     DrawRect(1387, 225, 225, 275, "white");
     DrawImageResize("Assets/" + DialogFocusItem.Asset.Group.Family + "/" + DialogFocusItem.Asset.Group.Name + "/Preview/" + DialogFocusItem.Asset.Name + ".png", 1389, 227, 221, 221);
     DrawTextFit(DialogFocusItem.Asset.Description, 1500, 475, 221, "black");
-    DrawText(DialogFind(Player, DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Intro"), 1500, 600, "white", "gray");
+    DrawText(GetPlayerDialog(DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Intro"), 1500, 600, "white", "gray");
 
     // Draw the settings
     if (Player.CanInteract() && (C.IsLoverOfPlayer())) {
         MainCanvas.textAlign = "left";
         DrawButton(1100, 666, 64, 64, "", "White", (DialogFocusSourceItem.Property.RemoveItem) ? "Icons/Checked.png" : "");
-        DrawText(DialogFind(Player, "RemoveItemWithTimer"), 1200, 698, "white", "gray");
+        DrawText(GetPlayerDialog("RemoveItemWithTimer"), 1200, 698, "white", "gray");
         DrawButton( 1100, 746, 64, 64, "", "White", (DialogFocusSourceItem.Property.ShowTimer) ? "Icons/Checked.png" : "");
         DrawText(DialogFind(Player,"ShowItemWithTimerRemaining"), 1200, 778, "white", "gray");
         DrawButton(1100, 826, 64, 64, "", "White", (DialogFocusSourceItem.Property.EnableRandomInput) ? "Icons/Checked.png" : "");
-        DrawText(DialogFind(Player, "EnableRandomInput"), 1200, 858, "white", "gray");
+        DrawText(GetPlayerDialog("EnableRandomInput"), 1200, 858, "white", "gray");
         MainCanvas.textAlign = "center";
     } else {
         if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property != null) && (DialogFocusSourceItem.Property.LockMemberNumber != null))
-            DrawText(DialogFind(Player, "LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 700, "white", "gray");
-        DrawText(DialogFind(Player, DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Detail"), 1500, 800, "white", "gray");
-        DrawText(DialogFind(Player, (DialogFocusSourceItem.Property.RemoveItem) ? "WillRemoveItemWithTimer" : "WontRemoveItemWithTimer"), 1500, 868, "white", "gray");
+            DrawText(GetPlayerDialog("LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 700, "white", "gray");
+        DrawText(GetPlayerDialog(DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Detail"), 1500, 800, "white", "gray");
+        DrawText(GetPlayerDialog((DialogFocusSourceItem.Property.RemoveItem) ? "WillRemoveItemWithTimer" : "WontRemoveItemWithTimer"), 1500, 868, "white", "gray");
     }
 
     // Draw buttons to add/remove time if available
     if (Player.CanInteract() && (C.IsLoverOfPlayer())) {
-        DrawButton(1100, 910, 250, 70, DialogFind(Player, "AddTimerTime"), "White");
-        DrawBackNextButton(1400, 910, 250, 70, LoverTimerChooseList[LoverTimerChooseIndex] + " " + DialogFind(Player, "Hours"), "White", "",
-            () => LoverTimerChooseList[(LoverTimerChooseList.length + LoverTimerChooseIndex - 1) % LoverTimerChooseList.length] + " " + DialogFind(Player, "Hours"),
-            () => LoverTimerChooseList[(LoverTimerChooseIndex + 1) % LoverTimerChooseList.length] + " " + DialogFind(Player, "Hours"));
+        DrawButton(1100, 910, 250, 70, GetPlayerDialog("AddTimerTime"), "White");
+        DrawBackNextButton(1400, 910, 250, 70, LoverTimerChooseList[LoverTimerChooseIndex] + " " + GetPlayerDialog("Hours"), "White", "",
+            () => LoverTimerChooseList[(LoverTimerChooseList.length + LoverTimerChooseIndex - 1) % LoverTimerChooseList.length] + " " + GetPlayerDialog("Hours"),
+            () => LoverTimerChooseList[(LoverTimerChooseIndex + 1) % LoverTimerChooseList.length] + " " + GetPlayerDialog("Hours"));
     }
     else if (Player.CanInteract() && DialogFocusSourceItem.Property.EnableRandomInput) {
         for (let I = 0; I < DialogFocusSourceItem.Property.MemberNumberList.length; I++) {
             if (DialogFocusSourceItem.Property.MemberNumberList[I] == Player.MemberNumber) return;
         }
-        DrawButton(1100, 910, 250, 70, "- 2 " + DialogFind(Player, "Hours"), "White");
-        DrawButton(1400, 910, 250, 70, DialogFind(Player, "Random"), "White");
-        DrawButton(1700, 910, 250, 70, "+ 2 " + DialogFind(Player, "Hours"), "White");
+        DrawButton(1100, 910, 250, 70, "- 2 " + GetPlayerDialog("Hours"), "White");
+        DrawButton(1400, 910, 250, 70, GetPlayerDialog("Random"), "White");
+        DrawButton(1700, 910, 250, 70, "+ 2 " + GetPlayerDialog("Hours"), "White");
     }
 }
 

--- a/BondageClub/Screens/Inventory/ItemMisc/LoversTimerPadlock/LoversTimerPadlock.js
+++ b/BondageClub/Screens/Inventory/ItemMisc/LoversTimerPadlock/LoversTimerPadlock.js
@@ -17,44 +17,44 @@ function InventoryItemMiscLoversTimerPadlockDraw() {
     var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
     if ((DialogFocusItem == null) || (DialogFocusSourceItem.Property.RemoveTimer < CurrentTime)) { InventoryItemMiscLoversTimerPadlockExit(); return; }
     if (DialogFocusSourceItem.Property.ShowTimer) {
-        DrawText(GetPlayerDialog("TimerLeft") + " " + TimerToString(DialogFocusSourceItem.Property.RemoveTimer - CurrentTime), 1500, 150, "white", "gray");
-    } else { DrawText(GetPlayerDialog("TimerUnknown"), 1500, 150, "white", "gray"); }
+        DrawText(DialogFindPlayer("TimerLeft") + " " + TimerToString(DialogFocusSourceItem.Property.RemoveTimer - CurrentTime), 1500, 150, "white", "gray");
+    } else { DrawText(DialogFindPlayer("TimerUnknown"), 1500, 150, "white", "gray"); }
     DrawRect(1387, 225, 225, 275, "white");
     DrawImageResize("Assets/" + DialogFocusItem.Asset.Group.Family + "/" + DialogFocusItem.Asset.Group.Name + "/Preview/" + DialogFocusItem.Asset.Name + ".png", 1389, 227, 221, 221);
     DrawTextFit(DialogFocusItem.Asset.Description, 1500, 475, 221, "black");
-    DrawText(GetPlayerDialog(DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Intro"), 1500, 600, "white", "gray");
+    DrawText(DialogFindPlayer(DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Intro"), 1500, 600, "white", "gray");
 
     // Draw the settings
     if (Player.CanInteract() && (C.IsLoverOfPlayer())) {
         MainCanvas.textAlign = "left";
         DrawButton(1100, 666, 64, 64, "", "White", (DialogFocusSourceItem.Property.RemoveItem) ? "Icons/Checked.png" : "");
-        DrawText(GetPlayerDialog("RemoveItemWithTimer"), 1200, 698, "white", "gray");
+        DrawText(DialogFindPlayer("RemoveItemWithTimer"), 1200, 698, "white", "gray");
         DrawButton( 1100, 746, 64, 64, "", "White", (DialogFocusSourceItem.Property.ShowTimer) ? "Icons/Checked.png" : "");
         DrawText(DialogFind(Player,"ShowItemWithTimerRemaining"), 1200, 778, "white", "gray");
         DrawButton(1100, 826, 64, 64, "", "White", (DialogFocusSourceItem.Property.EnableRandomInput) ? "Icons/Checked.png" : "");
-        DrawText(GetPlayerDialog("EnableRandomInput"), 1200, 858, "white", "gray");
+        DrawText(DialogFindPlayer("EnableRandomInput"), 1200, 858, "white", "gray");
         MainCanvas.textAlign = "center";
     } else {
         if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property != null) && (DialogFocusSourceItem.Property.LockMemberNumber != null))
-            DrawText(GetPlayerDialog("LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 700, "white", "gray");
-        DrawText(GetPlayerDialog(DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Detail"), 1500, 800, "white", "gray");
-        DrawText(GetPlayerDialog((DialogFocusSourceItem.Property.RemoveItem) ? "WillRemoveItemWithTimer" : "WontRemoveItemWithTimer"), 1500, 868, "white", "gray");
+            DrawText(DialogFindPlayer("LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 700, "white", "gray");
+        DrawText(DialogFindPlayer(DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Detail"), 1500, 800, "white", "gray");
+        DrawText(DialogFindPlayer((DialogFocusSourceItem.Property.RemoveItem) ? "WillRemoveItemWithTimer" : "WontRemoveItemWithTimer"), 1500, 868, "white", "gray");
     }
 
     // Draw buttons to add/remove time if available
     if (Player.CanInteract() && (C.IsLoverOfPlayer())) {
-        DrawButton(1100, 910, 250, 70, GetPlayerDialog("AddTimerTime"), "White");
-        DrawBackNextButton(1400, 910, 250, 70, LoverTimerChooseList[LoverTimerChooseIndex] + " " + GetPlayerDialog("Hours"), "White", "",
-            () => LoverTimerChooseList[(LoverTimerChooseList.length + LoverTimerChooseIndex - 1) % LoverTimerChooseList.length] + " " + GetPlayerDialog("Hours"),
-            () => LoverTimerChooseList[(LoverTimerChooseIndex + 1) % LoverTimerChooseList.length] + " " + GetPlayerDialog("Hours"));
+        DrawButton(1100, 910, 250, 70, DialogFindPlayer("AddTimerTime"), "White");
+        DrawBackNextButton(1400, 910, 250, 70, LoverTimerChooseList[LoverTimerChooseIndex] + " " + DialogFindPlayer("Hours"), "White", "",
+            () => LoverTimerChooseList[(LoverTimerChooseList.length + LoverTimerChooseIndex - 1) % LoverTimerChooseList.length] + " " + DialogFindPlayer("Hours"),
+            () => LoverTimerChooseList[(LoverTimerChooseIndex + 1) % LoverTimerChooseList.length] + " " + DialogFindPlayer("Hours"));
     }
     else if (Player.CanInteract() && DialogFocusSourceItem.Property.EnableRandomInput) {
         for (let I = 0; I < DialogFocusSourceItem.Property.MemberNumberList.length; I++) {
             if (DialogFocusSourceItem.Property.MemberNumberList[I] == Player.MemberNumber) return;
         }
-        DrawButton(1100, 910, 250, 70, "- 2 " + GetPlayerDialog("Hours"), "White");
-        DrawButton(1400, 910, 250, 70, GetPlayerDialog("Random"), "White");
-        DrawButton(1700, 910, 250, 70, "+ 2 " + GetPlayerDialog("Hours"), "White");
+        DrawButton(1100, 910, 250, 70, "- 2 " + DialogFindPlayer("Hours"), "White");
+        DrawButton(1400, 910, 250, 70, DialogFindPlayer("Random"), "White");
+        DrawButton(1700, 910, 250, 70, "+ 2 " + DialogFindPlayer("Hours"), "White");
     }
 }
 

--- a/BondageClub/Screens/Inventory/ItemMisc/MetalPadlock/MetalPadlock.js
+++ b/BondageClub/Screens/Inventory/ItemMisc/MetalPadlock/MetalPadlock.js
@@ -9,9 +9,9 @@ function InventoryItemMiscMetalPadlockDraw() {
 	DrawRect(1387, 225, 225, 275, "white");
 	DrawImageResize("Assets/" + DialogFocusItem.Asset.Group.Family + "/" + DialogFocusItem.Asset.Group.Name + "/Preview/" + DialogFocusItem.Asset.Name + ".png", 1389, 227, 221, 221);
 	DrawTextFit(DialogFocusItem.Asset.Description, 1500, 475, 221, "black");
-	DrawText(DialogFind(Player, DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Intro"), 1500, 600, "white", "gray");
+	DrawText(GetPlayerDialog(DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Intro"), 1500, 600, "white", "gray");
 	if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property != null) && (DialogFocusSourceItem.Property.LockMemberNumber != null)) 
-		DrawText(DialogFind(Player, "LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 700, "white", "gray");
+		DrawText(GetPlayerDialog("LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 700, "white", "gray");
 }
 
 // Catches the item extension clicks

--- a/BondageClub/Screens/Inventory/ItemMisc/MetalPadlock/MetalPadlock.js
+++ b/BondageClub/Screens/Inventory/ItemMisc/MetalPadlock/MetalPadlock.js
@@ -9,9 +9,9 @@ function InventoryItemMiscMetalPadlockDraw() {
 	DrawRect(1387, 225, 225, 275, "white");
 	DrawImageResize("Assets/" + DialogFocusItem.Asset.Group.Family + "/" + DialogFocusItem.Asset.Group.Name + "/Preview/" + DialogFocusItem.Asset.Name + ".png", 1389, 227, 221, 221);
 	DrawTextFit(DialogFocusItem.Asset.Description, 1500, 475, 221, "black");
-	DrawText(GetPlayerDialog(DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Intro"), 1500, 600, "white", "gray");
+	DrawText(DialogFindPlayer(DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Intro"), 1500, 600, "white", "gray");
 	if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property != null) && (DialogFocusSourceItem.Property.LockMemberNumber != null)) 
-		DrawText(GetPlayerDialog("LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 700, "white", "gray");
+		DrawText(DialogFindPlayer("LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 700, "white", "gray");
 }
 
 // Catches the item extension clicks

--- a/BondageClub/Screens/Inventory/ItemMisc/MistressPadlock/MistressPadlock.js
+++ b/BondageClub/Screens/Inventory/ItemMisc/MistressPadlock/MistressPadlock.js
@@ -9,9 +9,9 @@ function InventoryItemMiscMistressPadlockDraw() {
 	DrawRect(1387, 225, 225, 275, "white");
 	DrawImageResize("Assets/" + DialogFocusItem.Asset.Group.Family + "/" + DialogFocusItem.Asset.Group.Name + "/Preview/" + DialogFocusItem.Asset.Name + ".png", 1389, 227, 221, 221);
 	DrawTextFit(DialogFocusItem.Asset.Description, 1500, 475, 221, "black");
-	DrawText(DialogFind(Player, DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Intro"), 1500, 600, "white", "gray");
+	DrawText(GetPlayerDialog(DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Intro"), 1500, 600, "white", "gray");
 	if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property != null) && (DialogFocusSourceItem.Property.LockMemberNumber != null)) 
-		DrawText(DialogFind(Player, "LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 700, "white", "gray");
+		DrawText(GetPlayerDialog("LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 700, "white", "gray");
 }
 
 // Catches the item extension clicks

--- a/BondageClub/Screens/Inventory/ItemMisc/MistressPadlock/MistressPadlock.js
+++ b/BondageClub/Screens/Inventory/ItemMisc/MistressPadlock/MistressPadlock.js
@@ -9,9 +9,9 @@ function InventoryItemMiscMistressPadlockDraw() {
 	DrawRect(1387, 225, 225, 275, "white");
 	DrawImageResize("Assets/" + DialogFocusItem.Asset.Group.Family + "/" + DialogFocusItem.Asset.Group.Name + "/Preview/" + DialogFocusItem.Asset.Name + ".png", 1389, 227, 221, 221);
 	DrawTextFit(DialogFocusItem.Asset.Description, 1500, 475, 221, "black");
-	DrawText(GetPlayerDialog(DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Intro"), 1500, 600, "white", "gray");
+	DrawText(DialogFindPlayer(DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Intro"), 1500, 600, "white", "gray");
 	if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property != null) && (DialogFocusSourceItem.Property.LockMemberNumber != null)) 
-		DrawText(GetPlayerDialog("LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 700, "white", "gray");
+		DrawText(DialogFindPlayer("LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 700, "white", "gray");
 }
 
 // Catches the item extension clicks

--- a/BondageClub/Screens/Inventory/ItemMisc/MistressTimerPadlock/MistressTimerPadlock.js
+++ b/BondageClub/Screens/Inventory/ItemMisc/MistressTimerPadlock/MistressTimerPadlock.js
@@ -16,43 +16,43 @@ function InventoryItemMiscMistressTimerPadlockLoad() {
 function InventoryItemMiscMistressTimerPadlockDraw() {
     if ((DialogFocusItem == null) || (DialogFocusSourceItem.Property.RemoveTimer < CurrentTime)) { InventoryItemMiscMistressTimerPadlockExit(); return; }
     if (DialogFocusSourceItem.Property.ShowTimer) {
-        DrawText(DialogFind(Player, "TimerLeft") + " " + TimerToString(DialogFocusSourceItem.Property.RemoveTimer - CurrentTime), 1500, 150, "white", "gray");
-    } else { DrawText(DialogFind(Player, "TimerUnknown"), 1500, 150, "white", "gray"); }
+        DrawText(GetPlayerDialog("TimerLeft") + " " + TimerToString(DialogFocusSourceItem.Property.RemoveTimer - CurrentTime), 1500, 150, "white", "gray");
+    } else { DrawText(GetPlayerDialog("TimerUnknown"), 1500, 150, "white", "gray"); }
     DrawRect(1387, 225, 225, 275, "white");
     DrawImageResize("Assets/" + DialogFocusItem.Asset.Group.Family + "/" + DialogFocusItem.Asset.Group.Name + "/Preview/" + DialogFocusItem.Asset.Name + ".png", 1389, 227, 221, 221);
     DrawTextFit(DialogFocusItem.Asset.Description, 1500, 475, 221, "black");
-    DrawText(DialogFind(Player, DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Intro"), 1500, 600, "white", "gray");
+    DrawText(GetPlayerDialog(DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Intro"), 1500, 600, "white", "gray");
 
     // Draw the settings
     if (Player.CanInteract() && (Player.MemberNumber == DialogFocusSourceItem.Property.LockMemberNumber)) {
         MainCanvas.textAlign = "left";
         DrawButton(1100, 666, 64, 64, "", "White", (DialogFocusSourceItem.Property.RemoveItem) ? "Icons/Checked.png" : "");
-        DrawText(DialogFind(Player, "RemoveItemWithTimer"), 1200, 698, "white", "gray");
+        DrawText(GetPlayerDialog("RemoveItemWithTimer"), 1200, 698, "white", "gray");
         DrawButton( 1100, 746, 64, 64, "", "White", (DialogFocusSourceItem.Property.ShowTimer) ? "Icons/Checked.png" : "");
         DrawText(DialogFind(Player,"ShowItemWithTimerRemaining"), 1200, 778, "white", "gray");
         DrawButton(1100, 828, 64, 64, "", "White", (DialogFocusSourceItem.Property.EnableRandomInput) ? "Icons/Checked.png" : "");
-        DrawText(DialogFind(Player, "EnableRandomInput"), 1200, 858, "white", "gray");
+        DrawText(GetPlayerDialog("EnableRandomInput"), 1200, 858, "white", "gray");
         MainCanvas.textAlign = "center";
     } else {
         if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property != null) && (DialogFocusSourceItem.Property.LockMemberNumber != null))
-            DrawText(DialogFind(Player, "LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 700, "white", "gray");
-        DrawText(DialogFind(Player, (DialogFocusSourceItem.Property.RemoveItem) ? "WillRemoveItemWithTimer" : "WontRemoveItemWithTimer"), 1500, 868, "white", "gray");
+            DrawText(GetPlayerDialog("LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 700, "white", "gray");
+        DrawText(GetPlayerDialog((DialogFocusSourceItem.Property.RemoveItem) ? "WillRemoveItemWithTimer" : "WontRemoveItemWithTimer"), 1500, 868, "white", "gray");
     }
 
     // Draw buttons to add/remove time if available
     if (Player.CanInteract() && (LogQuery("ClubMistress", "Management") || (Player.MemberNumber == DialogFocusSourceItem.Property.LockMemberNumber))) {
-        DrawButton(1100, 910, 250, 70, DialogFind(Player, "AddTimerTime"), "White");
-        DrawBackNextButton(1400, 910, 250, 70, MistressTimerChooseList[MistressTimerChooseIndex] + " " + DialogFind(Player, "Minutes"), "White", "",
-            () => MistressTimerChooseList[(MistressTimerChooseList.length + MistressTimerChooseIndex - 1) % MistressTimerChooseList.length] + " " + DialogFind(Player, "Minutes"),
-            () => MistressTimerChooseList[(MistressTimerChooseIndex + 1) % MistressTimerChooseList.length] + " " + DialogFind(Player, "Minutes"));
+        DrawButton(1100, 910, 250, 70, GetPlayerDialog("AddTimerTime"), "White");
+        DrawBackNextButton(1400, 910, 250, 70, MistressTimerChooseList[MistressTimerChooseIndex] + " " + GetPlayerDialog("Minutes"), "White", "",
+            () => MistressTimerChooseList[(MistressTimerChooseList.length + MistressTimerChooseIndex - 1) % MistressTimerChooseList.length] + " " + GetPlayerDialog("Minutes"),
+            () => MistressTimerChooseList[(MistressTimerChooseIndex + 1) % MistressTimerChooseList.length] + " " + GetPlayerDialog("Minutes"));
     }
     else if (Player.CanInteract() && DialogFocusSourceItem.Property.EnableRandomInput) {
         for (let I = 0; I < DialogFocusSourceItem.Property.MemberNumberList.length; I++) {
             if (DialogFocusSourceItem.Property.MemberNumberList[I] == Player.MemberNumber) return;
         }
-        DrawButton(1100, 910, 250, 70, "- " + DialogFocusItem.Asset.RemoveTimer * 3 / 60 + " " + DialogFind(Player, "Minutes"), "White");
-        DrawButton(1400, 910, 250, 70, DialogFind(Player, "Random"), "White");
-        DrawButton(1700, 910, 250, 70, "+ " + DialogFocusItem.Asset.RemoveTimer * 3 / 60 + " " + DialogFind(Player, "Minutes"), "White");
+        DrawButton(1100, 910, 250, 70, "- " + DialogFocusItem.Asset.RemoveTimer * 3 / 60 + " " + GetPlayerDialog("Minutes"), "White");
+        DrawButton(1400, 910, 250, 70, GetPlayerDialog("Random"), "White");
+        DrawButton(1700, 910, 250, 70, "+ " + DialogFocusItem.Asset.RemoveTimer * 3 / 60 + " " + GetPlayerDialog("Minutes"), "White");
     }
 }
 

--- a/BondageClub/Screens/Inventory/ItemMisc/MistressTimerPadlock/MistressTimerPadlock.js
+++ b/BondageClub/Screens/Inventory/ItemMisc/MistressTimerPadlock/MistressTimerPadlock.js
@@ -16,43 +16,43 @@ function InventoryItemMiscMistressTimerPadlockLoad() {
 function InventoryItemMiscMistressTimerPadlockDraw() {
     if ((DialogFocusItem == null) || (DialogFocusSourceItem.Property.RemoveTimer < CurrentTime)) { InventoryItemMiscMistressTimerPadlockExit(); return; }
     if (DialogFocusSourceItem.Property.ShowTimer) {
-        DrawText(GetPlayerDialog("TimerLeft") + " " + TimerToString(DialogFocusSourceItem.Property.RemoveTimer - CurrentTime), 1500, 150, "white", "gray");
-    } else { DrawText(GetPlayerDialog("TimerUnknown"), 1500, 150, "white", "gray"); }
+        DrawText(DialogFindPlayer("TimerLeft") + " " + TimerToString(DialogFocusSourceItem.Property.RemoveTimer - CurrentTime), 1500, 150, "white", "gray");
+    } else { DrawText(DialogFindPlayer("TimerUnknown"), 1500, 150, "white", "gray"); }
     DrawRect(1387, 225, 225, 275, "white");
     DrawImageResize("Assets/" + DialogFocusItem.Asset.Group.Family + "/" + DialogFocusItem.Asset.Group.Name + "/Preview/" + DialogFocusItem.Asset.Name + ".png", 1389, 227, 221, 221);
     DrawTextFit(DialogFocusItem.Asset.Description, 1500, 475, 221, "black");
-    DrawText(GetPlayerDialog(DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Intro"), 1500, 600, "white", "gray");
+    DrawText(DialogFindPlayer(DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Intro"), 1500, 600, "white", "gray");
 
     // Draw the settings
     if (Player.CanInteract() && (Player.MemberNumber == DialogFocusSourceItem.Property.LockMemberNumber)) {
         MainCanvas.textAlign = "left";
         DrawButton(1100, 666, 64, 64, "", "White", (DialogFocusSourceItem.Property.RemoveItem) ? "Icons/Checked.png" : "");
-        DrawText(GetPlayerDialog("RemoveItemWithTimer"), 1200, 698, "white", "gray");
+        DrawText(DialogFindPlayer("RemoveItemWithTimer"), 1200, 698, "white", "gray");
         DrawButton( 1100, 746, 64, 64, "", "White", (DialogFocusSourceItem.Property.ShowTimer) ? "Icons/Checked.png" : "");
         DrawText(DialogFind(Player,"ShowItemWithTimerRemaining"), 1200, 778, "white", "gray");
         DrawButton(1100, 828, 64, 64, "", "White", (DialogFocusSourceItem.Property.EnableRandomInput) ? "Icons/Checked.png" : "");
-        DrawText(GetPlayerDialog("EnableRandomInput"), 1200, 858, "white", "gray");
+        DrawText(DialogFindPlayer("EnableRandomInput"), 1200, 858, "white", "gray");
         MainCanvas.textAlign = "center";
     } else {
         if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property != null) && (DialogFocusSourceItem.Property.LockMemberNumber != null))
-            DrawText(GetPlayerDialog("LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 700, "white", "gray");
-        DrawText(GetPlayerDialog((DialogFocusSourceItem.Property.RemoveItem) ? "WillRemoveItemWithTimer" : "WontRemoveItemWithTimer"), 1500, 868, "white", "gray");
+            DrawText(DialogFindPlayer("LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 700, "white", "gray");
+        DrawText(DialogFindPlayer((DialogFocusSourceItem.Property.RemoveItem) ? "WillRemoveItemWithTimer" : "WontRemoveItemWithTimer"), 1500, 868, "white", "gray");
     }
 
     // Draw buttons to add/remove time if available
     if (Player.CanInteract() && (LogQuery("ClubMistress", "Management") || (Player.MemberNumber == DialogFocusSourceItem.Property.LockMemberNumber))) {
-        DrawButton(1100, 910, 250, 70, GetPlayerDialog("AddTimerTime"), "White");
-        DrawBackNextButton(1400, 910, 250, 70, MistressTimerChooseList[MistressTimerChooseIndex] + " " + GetPlayerDialog("Minutes"), "White", "",
-            () => MistressTimerChooseList[(MistressTimerChooseList.length + MistressTimerChooseIndex - 1) % MistressTimerChooseList.length] + " " + GetPlayerDialog("Minutes"),
-            () => MistressTimerChooseList[(MistressTimerChooseIndex + 1) % MistressTimerChooseList.length] + " " + GetPlayerDialog("Minutes"));
+        DrawButton(1100, 910, 250, 70, DialogFindPlayer("AddTimerTime"), "White");
+        DrawBackNextButton(1400, 910, 250, 70, MistressTimerChooseList[MistressTimerChooseIndex] + " " + DialogFindPlayer("Minutes"), "White", "",
+            () => MistressTimerChooseList[(MistressTimerChooseList.length + MistressTimerChooseIndex - 1) % MistressTimerChooseList.length] + " " + DialogFindPlayer("Minutes"),
+            () => MistressTimerChooseList[(MistressTimerChooseIndex + 1) % MistressTimerChooseList.length] + " " + DialogFindPlayer("Minutes"));
     }
     else if (Player.CanInteract() && DialogFocusSourceItem.Property.EnableRandomInput) {
         for (let I = 0; I < DialogFocusSourceItem.Property.MemberNumberList.length; I++) {
             if (DialogFocusSourceItem.Property.MemberNumberList[I] == Player.MemberNumber) return;
         }
-        DrawButton(1100, 910, 250, 70, "- " + DialogFocusItem.Asset.RemoveTimer * 3 / 60 + " " + GetPlayerDialog("Minutes"), "White");
-        DrawButton(1400, 910, 250, 70, GetPlayerDialog("Random"), "White");
-        DrawButton(1700, 910, 250, 70, "+ " + DialogFocusItem.Asset.RemoveTimer * 3 / 60 + " " + GetPlayerDialog("Minutes"), "White");
+        DrawButton(1100, 910, 250, 70, "- " + DialogFocusItem.Asset.RemoveTimer * 3 / 60 + " " + DialogFindPlayer("Minutes"), "White");
+        DrawButton(1400, 910, 250, 70, DialogFindPlayer("Random"), "White");
+        DrawButton(1700, 910, 250, 70, "+ " + DialogFocusItem.Asset.RemoveTimer * 3 / 60 + " " + DialogFindPlayer("Minutes"), "White");
     }
 }
 

--- a/BondageClub/Screens/Inventory/ItemMisc/OwnerPadlock/OwnerPadlock.js
+++ b/BondageClub/Screens/Inventory/ItemMisc/OwnerPadlock/OwnerPadlock.js
@@ -9,10 +9,10 @@ function InventoryItemMiscOwnerPadlockDraw() {
 	DrawRect(1387, 225, 225, 275, "white");
 	DrawImageResize("Assets/" + DialogFocusItem.Asset.Group.Family + "/" + DialogFocusItem.Asset.Group.Name + "/Preview/" + DialogFocusItem.Asset.Name + ".png", 1389, 227, 221, 221);
 	DrawTextFit(DialogFocusItem.Asset.Description, 1500, 475, 221, "black");
-	DrawText(DialogFind(Player, DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Intro"), 1500, 600, "white", "gray");
+	DrawText(GetPlayerDialog(DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Intro"), 1500, 600, "white", "gray");
 	if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property != null) && (DialogFocusSourceItem.Property.LockMemberNumber != null)) 
-		DrawText(DialogFind(Player, "LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 700, "white", "gray");
-	DrawText(DialogFind(Player, DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Detail"), 1500, 800, "white", "gray");
+		DrawText(GetPlayerDialog("LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 700, "white", "gray");
+	DrawText(GetPlayerDialog(DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Detail"), 1500, 800, "white", "gray");
 }
 
 // Catches the item extension clicks

--- a/BondageClub/Screens/Inventory/ItemMisc/OwnerPadlock/OwnerPadlock.js
+++ b/BondageClub/Screens/Inventory/ItemMisc/OwnerPadlock/OwnerPadlock.js
@@ -9,10 +9,10 @@ function InventoryItemMiscOwnerPadlockDraw() {
 	DrawRect(1387, 225, 225, 275, "white");
 	DrawImageResize("Assets/" + DialogFocusItem.Asset.Group.Family + "/" + DialogFocusItem.Asset.Group.Name + "/Preview/" + DialogFocusItem.Asset.Name + ".png", 1389, 227, 221, 221);
 	DrawTextFit(DialogFocusItem.Asset.Description, 1500, 475, 221, "black");
-	DrawText(GetPlayerDialog(DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Intro"), 1500, 600, "white", "gray");
+	DrawText(DialogFindPlayer(DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Intro"), 1500, 600, "white", "gray");
 	if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property != null) && (DialogFocusSourceItem.Property.LockMemberNumber != null)) 
-		DrawText(GetPlayerDialog("LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 700, "white", "gray");
-	DrawText(GetPlayerDialog(DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Detail"), 1500, 800, "white", "gray");
+		DrawText(DialogFindPlayer("LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 700, "white", "gray");
+	DrawText(DialogFindPlayer(DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Detail"), 1500, 800, "white", "gray");
 }
 
 // Catches the item extension clicks

--- a/BondageClub/Screens/Inventory/ItemMisc/OwnerTimerPadlock/OwnerTimerPadlock.js
+++ b/BondageClub/Screens/Inventory/ItemMisc/OwnerTimerPadlock/OwnerTimerPadlock.js
@@ -16,45 +16,45 @@ function InventoryItemMiscOwnerTimerPadlockLoad() {
 function InventoryItemMiscOwnerTimerPadlockDraw() {
     if ((DialogFocusItem == null) || (DialogFocusSourceItem.Property.RemoveTimer < CurrentTime)) { InventoryItemMiscOwnerTimerPadlockExit(); return; }
     if (DialogFocusSourceItem.Property.ShowTimer) {
-        DrawText(GetPlayerDialog("TimerLeft") + " " + TimerToString(DialogFocusSourceItem.Property.RemoveTimer - CurrentTime), 1500, 150, "white", "gray");
-    } else { DrawText(GetPlayerDialog("TimerUnknown"), 1500, 150, "white", "gray"); }
+        DrawText(DialogFindPlayer("TimerLeft") + " " + TimerToString(DialogFocusSourceItem.Property.RemoveTimer - CurrentTime), 1500, 150, "white", "gray");
+    } else { DrawText(DialogFindPlayer("TimerUnknown"), 1500, 150, "white", "gray"); }
     DrawRect(1387, 225, 225, 275, "white");
     DrawImageResize("Assets/" + DialogFocusItem.Asset.Group.Family + "/" + DialogFocusItem.Asset.Group.Name + "/Preview/" + DialogFocusItem.Asset.Name + ".png", 1389, 227, 221, 221);
     DrawTextFit(DialogFocusItem.Asset.Description, 1500, 475, 221, "black");
-    DrawText(GetPlayerDialog(DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Intro"), 1500, 600, "white", "gray");
+    DrawText(DialogFindPlayer(DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Intro"), 1500, 600, "white", "gray");
 
     var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
     // Draw the settings
     if (Player.CanInteract() && C.IsOwnedByPlayer()) {
         MainCanvas.textAlign = "left";
         DrawButton(1100, 666, 64, 64, "", "White", (DialogFocusSourceItem.Property.RemoveItem) ? "Icons/Checked.png" : "");
-        DrawText(GetPlayerDialog("RemoveItemWithTimer"), 1200, 698, "white", "gray");
+        DrawText(DialogFindPlayer("RemoveItemWithTimer"), 1200, 698, "white", "gray");
         DrawButton( 1100, 746, 64, 64, "", "White", (DialogFocusSourceItem.Property.ShowTimer) ? "Icons/Checked.png" : "");
         DrawText(DialogFind(Player,"ShowItemWithTimerRemaining"), 1200, 778, "white", "gray");
         DrawButton(1100, 826, 64, 64, "", "White", (DialogFocusSourceItem.Property.EnableRandomInput) ? "Icons/Checked.png" : "");
-        DrawText(GetPlayerDialog("EnableRandomInput"), 1200, 858, "white", "gray");
+        DrawText(DialogFindPlayer("EnableRandomInput"), 1200, 858, "white", "gray");
         MainCanvas.textAlign = "center";
     } else {
         if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property != null) && (DialogFocusSourceItem.Property.LockMemberNumber != null))
-            DrawText(GetPlayerDialog("LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 700, "white", "gray");
-        DrawText(GetPlayerDialog(DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Detail"), 1500, 800, "white", "gray");
-        DrawText(GetPlayerDialog((DialogFocusSourceItem.Property.RemoveItem) ? "WillRemoveItemWithTimer" : "WontRemoveItemWithTimer"), 1500, 868, "white", "gray");
+            DrawText(DialogFindPlayer("LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 700, "white", "gray");
+        DrawText(DialogFindPlayer(DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Detail"), 1500, 800, "white", "gray");
+        DrawText(DialogFindPlayer((DialogFocusSourceItem.Property.RemoveItem) ? "WillRemoveItemWithTimer" : "WontRemoveItemWithTimer"), 1500, 868, "white", "gray");
     }
 
     // Draw buttons to add/remove time if available
     if (Player.CanInteract() && C.IsOwnedByPlayer()) {
-        DrawButton(1100, 910, 250, 70, GetPlayerDialog("AddTimerTime"), "White");
-        DrawBackNextButton(1400, 910, 250, 70, OwnerTimerChooseList[OwnerTimerChooseIndex] + " " + GetPlayerDialog("Hours"), "White", "",
-            () => OwnerTimerChooseList[(OwnerTimerChooseList.length + OwnerTimerChooseIndex - 1) % OwnerTimerChooseList.length] + " " + GetPlayerDialog("Hours"),
-            () => OwnerTimerChooseList[(OwnerTimerChooseIndex + 1) % OwnerTimerChooseList.length] + " " + GetPlayerDialog("Hours"));
+        DrawButton(1100, 910, 250, 70, DialogFindPlayer("AddTimerTime"), "White");
+        DrawBackNextButton(1400, 910, 250, 70, OwnerTimerChooseList[OwnerTimerChooseIndex] + " " + DialogFindPlayer("Hours"), "White", "",
+            () => OwnerTimerChooseList[(OwnerTimerChooseList.length + OwnerTimerChooseIndex - 1) % OwnerTimerChooseList.length] + " " + DialogFindPlayer("Hours"),
+            () => OwnerTimerChooseList[(OwnerTimerChooseIndex + 1) % OwnerTimerChooseList.length] + " " + DialogFindPlayer("Hours"));
     }
     else if (Player.CanInteract() && DialogFocusSourceItem.Property.EnableRandomInput) {
         for (let I = 0; I < DialogFocusSourceItem.Property.MemberNumberList.length; I++) {
             if (DialogFocusSourceItem.Property.MemberNumberList[I] == Player.MemberNumber) return;
         }
-        DrawButton(1100, 910, 250, 70, "- 2 " + GetPlayerDialog("Hours"), "White");
-        DrawButton(1400, 910, 250, 70, GetPlayerDialog("Random"), "White");
-        DrawButton(1700, 910, 250, 70, "+ 2 " + GetPlayerDialog("Hours"), "White");
+        DrawButton(1100, 910, 250, 70, "- 2 " + DialogFindPlayer("Hours"), "White");
+        DrawButton(1400, 910, 250, 70, DialogFindPlayer("Random"), "White");
+        DrawButton(1700, 910, 250, 70, "+ 2 " + DialogFindPlayer("Hours"), "White");
     }
 }
 

--- a/BondageClub/Screens/Inventory/ItemMisc/OwnerTimerPadlock/OwnerTimerPadlock.js
+++ b/BondageClub/Screens/Inventory/ItemMisc/OwnerTimerPadlock/OwnerTimerPadlock.js
@@ -16,45 +16,45 @@ function InventoryItemMiscOwnerTimerPadlockLoad() {
 function InventoryItemMiscOwnerTimerPadlockDraw() {
     if ((DialogFocusItem == null) || (DialogFocusSourceItem.Property.RemoveTimer < CurrentTime)) { InventoryItemMiscOwnerTimerPadlockExit(); return; }
     if (DialogFocusSourceItem.Property.ShowTimer) {
-        DrawText(DialogFind(Player, "TimerLeft") + " " + TimerToString(DialogFocusSourceItem.Property.RemoveTimer - CurrentTime), 1500, 150, "white", "gray");
-    } else { DrawText(DialogFind(Player, "TimerUnknown"), 1500, 150, "white", "gray"); }
+        DrawText(GetPlayerDialog("TimerLeft") + " " + TimerToString(DialogFocusSourceItem.Property.RemoveTimer - CurrentTime), 1500, 150, "white", "gray");
+    } else { DrawText(GetPlayerDialog("TimerUnknown"), 1500, 150, "white", "gray"); }
     DrawRect(1387, 225, 225, 275, "white");
     DrawImageResize("Assets/" + DialogFocusItem.Asset.Group.Family + "/" + DialogFocusItem.Asset.Group.Name + "/Preview/" + DialogFocusItem.Asset.Name + ".png", 1389, 227, 221, 221);
     DrawTextFit(DialogFocusItem.Asset.Description, 1500, 475, 221, "black");
-    DrawText(DialogFind(Player, DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Intro"), 1500, 600, "white", "gray");
+    DrawText(GetPlayerDialog(DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Intro"), 1500, 600, "white", "gray");
 
     var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
     // Draw the settings
     if (Player.CanInteract() && C.IsOwnedByPlayer()) {
         MainCanvas.textAlign = "left";
         DrawButton(1100, 666, 64, 64, "", "White", (DialogFocusSourceItem.Property.RemoveItem) ? "Icons/Checked.png" : "");
-        DrawText(DialogFind(Player, "RemoveItemWithTimer"), 1200, 698, "white", "gray");
+        DrawText(GetPlayerDialog("RemoveItemWithTimer"), 1200, 698, "white", "gray");
         DrawButton( 1100, 746, 64, 64, "", "White", (DialogFocusSourceItem.Property.ShowTimer) ? "Icons/Checked.png" : "");
         DrawText(DialogFind(Player,"ShowItemWithTimerRemaining"), 1200, 778, "white", "gray");
         DrawButton(1100, 826, 64, 64, "", "White", (DialogFocusSourceItem.Property.EnableRandomInput) ? "Icons/Checked.png" : "");
-        DrawText(DialogFind(Player, "EnableRandomInput"), 1200, 858, "white", "gray");
+        DrawText(GetPlayerDialog("EnableRandomInput"), 1200, 858, "white", "gray");
         MainCanvas.textAlign = "center";
     } else {
         if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property != null) && (DialogFocusSourceItem.Property.LockMemberNumber != null))
-            DrawText(DialogFind(Player, "LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 700, "white", "gray");
-        DrawText(DialogFind(Player, DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Detail"), 1500, 800, "white", "gray");
-        DrawText(DialogFind(Player, (DialogFocusSourceItem.Property.RemoveItem) ? "WillRemoveItemWithTimer" : "WontRemoveItemWithTimer"), 1500, 868, "white", "gray");
+            DrawText(GetPlayerDialog("LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 700, "white", "gray");
+        DrawText(GetPlayerDialog(DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Detail"), 1500, 800, "white", "gray");
+        DrawText(GetPlayerDialog((DialogFocusSourceItem.Property.RemoveItem) ? "WillRemoveItemWithTimer" : "WontRemoveItemWithTimer"), 1500, 868, "white", "gray");
     }
 
     // Draw buttons to add/remove time if available
     if (Player.CanInteract() && C.IsOwnedByPlayer()) {
-        DrawButton(1100, 910, 250, 70, DialogFind(Player, "AddTimerTime"), "White");
-        DrawBackNextButton(1400, 910, 250, 70, OwnerTimerChooseList[OwnerTimerChooseIndex] + " " + DialogFind(Player, "Hours"), "White", "",
-            () => OwnerTimerChooseList[(OwnerTimerChooseList.length + OwnerTimerChooseIndex - 1) % OwnerTimerChooseList.length] + " " + DialogFind(Player, "Hours"),
-            () => OwnerTimerChooseList[(OwnerTimerChooseIndex + 1) % OwnerTimerChooseList.length] + " " + DialogFind(Player, "Hours"));
+        DrawButton(1100, 910, 250, 70, GetPlayerDialog("AddTimerTime"), "White");
+        DrawBackNextButton(1400, 910, 250, 70, OwnerTimerChooseList[OwnerTimerChooseIndex] + " " + GetPlayerDialog("Hours"), "White", "",
+            () => OwnerTimerChooseList[(OwnerTimerChooseList.length + OwnerTimerChooseIndex - 1) % OwnerTimerChooseList.length] + " " + GetPlayerDialog("Hours"),
+            () => OwnerTimerChooseList[(OwnerTimerChooseIndex + 1) % OwnerTimerChooseList.length] + " " + GetPlayerDialog("Hours"));
     }
     else if (Player.CanInteract() && DialogFocusSourceItem.Property.EnableRandomInput) {
         for (let I = 0; I < DialogFocusSourceItem.Property.MemberNumberList.length; I++) {
             if (DialogFocusSourceItem.Property.MemberNumberList[I] == Player.MemberNumber) return;
         }
-        DrawButton(1100, 910, 250, 70, "- 2 " + DialogFind(Player, "Hours"), "White");
-        DrawButton(1400, 910, 250, 70, DialogFind(Player, "Random"), "White");
-        DrawButton(1700, 910, 250, 70, "+ 2 " + DialogFind(Player, "Hours"), "White");
+        DrawButton(1100, 910, 250, 70, "- 2 " + GetPlayerDialog("Hours"), "White");
+        DrawButton(1400, 910, 250, 70, GetPlayerDialog("Random"), "White");
+        DrawButton(1700, 910, 250, 70, "+ 2 " + GetPlayerDialog("Hours"), "White");
     }
 }
 

--- a/BondageClub/Screens/Inventory/ItemMisc/PasswordPadlock/PasswordPadlock.js
+++ b/BondageClub/Screens/Inventory/ItemMisc/PasswordPadlock/PasswordPadlock.js
@@ -37,11 +37,11 @@ function InventoryItemMiscPasswordPadlockDraw() {
 	DrawImageResize("Assets/" + DialogFocusItem.Asset.Group.Family + "/" + DialogFocusItem.Asset.Group.Name + "/Preview/" + DialogFocusItem.Asset.Name + ".png", 1389, 227, 221, 221);
 	DrawTextFit(DialogFocusItem.Asset.Description, 1500, 475, 221, "black");
 	if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property != null) && (DialogFocusSourceItem.Property.LockMemberNumber != null))
-		DrawText(DialogFind(Player, "LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 600, "white", "gray");
+		DrawText(GetPlayerDialog("LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 600, "white", "gray");
 
 	if (InventoryGroupIsBlocked(C, C.FocusGroup.Name)) {
 		// If the zone is blocked, just display some text informing the player that they can't access the lock
-		DrawText(DialogFind(Player, "LockZoneBlocked"), 1500, 800, "white", "gray");
+		DrawText(GetPlayerDialog("LockZoneBlocked"), 1500, 800, "white", "gray");
 	} else {
 		if (DialogFocusSourceItem.Property && (DialogFocusSourceItem.Property.LockSet || 
 		(DialogFocusSourceItem.Property.LockMemberNumber && DialogFocusSourceItem.Property.LockMemberNumber != Player.MemberNumber))) {
@@ -49,20 +49,20 @@ function InventoryItemMiscPasswordPadlockDraw() {
 			if (DialogFocusSourceItem && DialogFocusSourceItem.Property && DialogFocusSourceItem.Property.Hint)
 				DrawText("\"" + DialogFocusSourceItem.Property.Hint + "\"", 1500, 700, "white", "gray");
 			MainCanvas.textAlign = "right";
-			DrawText(DialogFind(Player, "PasswordPadlockOld"), 1490, 805, "white", "gray");
+			DrawText(GetPlayerDialog("PasswordPadlockOld"), 1490, 805, "white", "gray");
 			ElementPosition("Password", 1640, 805, 250);
 			MainCanvas.textAlign = "center";
-			DrawButton(1370, 871, 250, 64, DialogFind(Player, "PasswordPadlockEnter"), "White", "");
-			if (PreferenceMessage != "") DrawText(DialogFind(Player, PreferenceMessage), 1500, 963, "Red", "Black");
+			DrawButton(1370, 871, 250, 64, GetPlayerDialog("PasswordPadlockEnter"), "White", "");
+			if (PreferenceMessage != "") DrawText(GetPlayerDialog(PreferenceMessage), 1500, 963, "Red", "Black");
 		} else {
 			ElementPosition("SetHint", 1643, 700, 550);
 			ElementPosition("SetPassword", 1491, 770, 250);
 			MainCanvas.textAlign = "left";
-			DrawText(DialogFind(Player, "PasswordPadlockSetHint"), 1100, 703, "white", "gray");
-			DrawText(DialogFind(Player, "PasswordPadlockSetPassword"), 1100, 773, "white", "gray");
+			DrawText(GetPlayerDialog("PasswordPadlockSetHint"), 1100, 703, "white", "gray");
+			DrawText(GetPlayerDialog("PasswordPadlockSetPassword"), 1100, 773, "white", "gray");
 			MainCanvas.textAlign = "center";
-			DrawButton(1360, 871, 250, 64, DialogFind(Player, "PasswordPadlockChangePassword"), "White", "");
-			if (PreferenceMessage != "") DrawText(DialogFind(Player, PreferenceMessage), 1500, 963, "Red", "Black");
+			DrawButton(1360, 871, 250, 64, GetPlayerDialog("PasswordPadlockChangePassword"), "White", "");
+			if (PreferenceMessage != "") DrawText(GetPlayerDialog(PreferenceMessage), 1500, 963, "Red", "Black");
 		}
 	}
 }

--- a/BondageClub/Screens/Inventory/ItemMisc/PasswordPadlock/PasswordPadlock.js
+++ b/BondageClub/Screens/Inventory/ItemMisc/PasswordPadlock/PasswordPadlock.js
@@ -37,11 +37,11 @@ function InventoryItemMiscPasswordPadlockDraw() {
 	DrawImageResize("Assets/" + DialogFocusItem.Asset.Group.Family + "/" + DialogFocusItem.Asset.Group.Name + "/Preview/" + DialogFocusItem.Asset.Name + ".png", 1389, 227, 221, 221);
 	DrawTextFit(DialogFocusItem.Asset.Description, 1500, 475, 221, "black");
 	if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property != null) && (DialogFocusSourceItem.Property.LockMemberNumber != null))
-		DrawText(GetPlayerDialog("LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 600, "white", "gray");
+		DrawText(DialogFindPlayer("LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 600, "white", "gray");
 
 	if (InventoryGroupIsBlocked(C, C.FocusGroup.Name)) {
 		// If the zone is blocked, just display some text informing the player that they can't access the lock
-		DrawText(GetPlayerDialog("LockZoneBlocked"), 1500, 800, "white", "gray");
+		DrawText(DialogFindPlayer("LockZoneBlocked"), 1500, 800, "white", "gray");
 	} else {
 		if (DialogFocusSourceItem.Property && (DialogFocusSourceItem.Property.LockSet || 
 		(DialogFocusSourceItem.Property.LockMemberNumber && DialogFocusSourceItem.Property.LockMemberNumber != Player.MemberNumber))) {
@@ -49,20 +49,20 @@ function InventoryItemMiscPasswordPadlockDraw() {
 			if (DialogFocusSourceItem && DialogFocusSourceItem.Property && DialogFocusSourceItem.Property.Hint)
 				DrawText("\"" + DialogFocusSourceItem.Property.Hint + "\"", 1500, 700, "white", "gray");
 			MainCanvas.textAlign = "right";
-			DrawText(GetPlayerDialog("PasswordPadlockOld"), 1490, 805, "white", "gray");
+			DrawText(DialogFindPlayer("PasswordPadlockOld"), 1490, 805, "white", "gray");
 			ElementPosition("Password", 1640, 805, 250);
 			MainCanvas.textAlign = "center";
-			DrawButton(1370, 871, 250, 64, GetPlayerDialog("PasswordPadlockEnter"), "White", "");
-			if (PreferenceMessage != "") DrawText(GetPlayerDialog(PreferenceMessage), 1500, 963, "Red", "Black");
+			DrawButton(1370, 871, 250, 64, DialogFindPlayer("PasswordPadlockEnter"), "White", "");
+			if (PreferenceMessage != "") DrawText(DialogFindPlayer(PreferenceMessage), 1500, 963, "Red", "Black");
 		} else {
 			ElementPosition("SetHint", 1643, 700, 550);
 			ElementPosition("SetPassword", 1491, 770, 250);
 			MainCanvas.textAlign = "left";
-			DrawText(GetPlayerDialog("PasswordPadlockSetHint"), 1100, 703, "white", "gray");
-			DrawText(GetPlayerDialog("PasswordPadlockSetPassword"), 1100, 773, "white", "gray");
+			DrawText(DialogFindPlayer("PasswordPadlockSetHint"), 1100, 703, "white", "gray");
+			DrawText(DialogFindPlayer("PasswordPadlockSetPassword"), 1100, 773, "white", "gray");
 			MainCanvas.textAlign = "center";
-			DrawButton(1360, 871, 250, 64, GetPlayerDialog("PasswordPadlockChangePassword"), "White", "");
-			if (PreferenceMessage != "") DrawText(GetPlayerDialog(PreferenceMessage), 1500, 963, "Red", "Black");
+			DrawButton(1360, 871, 250, 64, DialogFindPlayer("PasswordPadlockChangePassword"), "White", "");
+			if (PreferenceMessage != "") DrawText(DialogFindPlayer(PreferenceMessage), 1500, 963, "Red", "Black");
 		}
 	}
 }

--- a/BondageClub/Screens/Inventory/ItemMisc/TimerPadlock/TimerPadlock.js
+++ b/BondageClub/Screens/Inventory/ItemMisc/TimerPadlock/TimerPadlock.js
@@ -9,20 +9,20 @@ function InventoryItemMiscTimerPadlockLoad() {
 // Draw the extension screen
 function InventoryItemMiscTimerPadlockDraw() {
 	if ((DialogFocusItem == null) || (DialogFocusSourceItem.Property.RemoveTimer < CurrentTime)) { InventoryItemMiscTimerPadlockExit(); return; }
-	DrawText(GetPlayerDialog("TimerLeft") + " " + TimerToString(DialogFocusSourceItem.Property.RemoveTimer - CurrentTime), 1500, 150, "white", "gray");
+	DrawText(DialogFindPlayer("TimerLeft") + " " + TimerToString(DialogFocusSourceItem.Property.RemoveTimer - CurrentTime), 1500, 150, "white", "gray");
 	DrawRect(1387, 225, 225, 275, "white");
 	DrawImageResize("Assets/" + DialogFocusItem.Asset.Group.Family + "/" + DialogFocusItem.Asset.Group.Name + "/Preview/" + DialogFocusItem.Asset.Name + ".png", 1389, 227, 221, 221);
 	DrawTextFit(DialogFocusItem.Asset.Description, 1500, 475, 221, "black");
-	DrawText(GetPlayerDialog(DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Intro"), 1500, 600, "white", "gray");
+	DrawText(DialogFindPlayer(DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Intro"), 1500, 600, "white", "gray");
 	if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property != null) && (DialogFocusSourceItem.Property.LockMemberNumber != null))
-		DrawText(GetPlayerDialog("LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 700, "white", "gray");
+		DrawText(DialogFindPlayer("LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 700, "white", "gray");
 	if ((Player.MemberNumber == DialogFocusSourceItem.Property.LockMemberNumber) && Player.CanInteract()) {
 		MainCanvas.textAlign = "left";
 		DrawButton(1100, 836, 64, 64, "", "White", (DialogFocusSourceItem.Property.RemoveItem) ? "Icons/Checked.png" : "");	
-		DrawText(GetPlayerDialog("RemoveItemWithTimer"), 1200, 868, "white", "gray");
+		DrawText(DialogFindPlayer("RemoveItemWithTimer"), 1200, 868, "white", "gray");
 		MainCanvas.textAlign = "center";
-	} else DrawText(GetPlayerDialog((DialogFocusSourceItem.Property.RemoveItem) ? "WillRemoveItemWithTimer" : "WontRemoveItemWithTimer"), 1500, 868, "white", "gray");
-	if (Player.CanInteract()) DrawButton(1350, 910, 300, 65, GetPlayerDialog("RestartTimer"), "White");
+	} else DrawText(DialogFindPlayer((DialogFocusSourceItem.Property.RemoveItem) ? "WillRemoveItemWithTimer" : "WontRemoveItemWithTimer"), 1500, 868, "white", "gray");
+	if (Player.CanInteract()) DrawButton(1350, 910, 300, 65, DialogFindPlayer("RestartTimer"), "White");
 }
 
 // Catches the item extension clicks

--- a/BondageClub/Screens/Inventory/ItemMisc/TimerPadlock/TimerPadlock.js
+++ b/BondageClub/Screens/Inventory/ItemMisc/TimerPadlock/TimerPadlock.js
@@ -9,20 +9,20 @@ function InventoryItemMiscTimerPadlockLoad() {
 // Draw the extension screen
 function InventoryItemMiscTimerPadlockDraw() {
 	if ((DialogFocusItem == null) || (DialogFocusSourceItem.Property.RemoveTimer < CurrentTime)) { InventoryItemMiscTimerPadlockExit(); return; }
-	DrawText(DialogFind(Player, "TimerLeft") + " " + TimerToString(DialogFocusSourceItem.Property.RemoveTimer - CurrentTime), 1500, 150, "white", "gray");
+	DrawText(GetPlayerDialog("TimerLeft") + " " + TimerToString(DialogFocusSourceItem.Property.RemoveTimer - CurrentTime), 1500, 150, "white", "gray");
 	DrawRect(1387, 225, 225, 275, "white");
 	DrawImageResize("Assets/" + DialogFocusItem.Asset.Group.Family + "/" + DialogFocusItem.Asset.Group.Name + "/Preview/" + DialogFocusItem.Asset.Name + ".png", 1389, 227, 221, 221);
 	DrawTextFit(DialogFocusItem.Asset.Description, 1500, 475, 221, "black");
-	DrawText(DialogFind(Player, DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Intro"), 1500, 600, "white", "gray");
+	DrawText(GetPlayerDialog(DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Intro"), 1500, 600, "white", "gray");
 	if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property != null) && (DialogFocusSourceItem.Property.LockMemberNumber != null))
-		DrawText(DialogFind(Player, "LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 700, "white", "gray");
+		DrawText(GetPlayerDialog("LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 700, "white", "gray");
 	if ((Player.MemberNumber == DialogFocusSourceItem.Property.LockMemberNumber) && Player.CanInteract()) {
 		MainCanvas.textAlign = "left";
 		DrawButton(1100, 836, 64, 64, "", "White", (DialogFocusSourceItem.Property.RemoveItem) ? "Icons/Checked.png" : "");	
-		DrawText(DialogFind(Player, "RemoveItemWithTimer"), 1200, 868, "white", "gray");
+		DrawText(GetPlayerDialog("RemoveItemWithTimer"), 1200, 868, "white", "gray");
 		MainCanvas.textAlign = "center";
-	} else DrawText(DialogFind(Player, (DialogFocusSourceItem.Property.RemoveItem) ? "WillRemoveItemWithTimer" : "WontRemoveItemWithTimer"), 1500, 868, "white", "gray");
-	if (Player.CanInteract()) DrawButton(1350, 910, 300, 65, DialogFind(Player, "RestartTimer"), "White");
+	} else DrawText(GetPlayerDialog((DialogFocusSourceItem.Property.RemoveItem) ? "WillRemoveItemWithTimer" : "WontRemoveItemWithTimer"), 1500, 868, "white", "gray");
+	if (Player.CanInteract()) DrawButton(1350, 910, 300, 65, GetPlayerDialog("RestartTimer"), "White");
 }
 
 // Catches the item extension clicks

--- a/BondageClub/Screens/Inventory/ItemMisc/TimerPasswordPadlock/TimerPasswordPadlock.js
+++ b/BondageClub/Screens/Inventory/ItemMisc/TimerPasswordPadlock/TimerPasswordPadlock.js
@@ -43,18 +43,18 @@ function InventoryItemMiscTimerPasswordPadlockLoad() {
 function InventoryItemMiscTimerPasswordPadlockDraw() {
     if ((DialogFocusItem == null) || (DialogFocusSourceItem.Property.RemoveTimer < CurrentTime)) { InventoryItemMiscTimerPasswordPadlockExit(); return; }
     if (DialogFocusSourceItem.Property.ShowTimer) {
-        DrawText(GetPlayerDialog("TimerLeft") + " " + TimerToString(DialogFocusSourceItem.Property.RemoveTimer - CurrentTime), 1500, 150, "white", "gray");
-    } else { DrawText(GetPlayerDialog("TimerUnknown"), 1500, 150, "white", "gray"); }
+        DrawText(DialogFindPlayer("TimerLeft") + " " + TimerToString(DialogFocusSourceItem.Property.RemoveTimer - CurrentTime), 1500, 150, "white", "gray");
+    } else { DrawText(DialogFindPlayer("TimerUnknown"), 1500, 150, "white", "gray"); }
 	var C = CharacterGetCurrent();
 	DrawRect(1412, 225, 175, 225, "white");
 	DrawImageResize("Assets/" + DialogFocusItem.Asset.Group.Family + "/" + DialogFocusItem.Asset.Group.Name + "/Preview/" + DialogFocusItem.Asset.Name + ".png", 1414, 227, 171, 171);
 	DrawTextFit(DialogFocusItem.Asset.Description, 1500, 425, 171, "black");
 	if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property != null) && (DialogFocusSourceItem.Property.LockMemberNumber != null))
-	DrawText(GetPlayerDialog("LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 500, "white", "gray");
+	DrawText(DialogFindPlayer("LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 500, "white", "gray");
 
 	if (InventoryGroupIsBlocked(C, C.FocusGroup.Name)) {
 		// If the zone is blocked, just display some text informing the player that they can't access the lock
-		DrawText(GetPlayerDialog("LockZoneBlocked"), 1500, 550, "white", "gray");
+		DrawText(DialogFindPlayer("LockZoneBlocked"), 1500, 550, "white", "gray");
 	} else {
 		if (DialogFocusSourceItem.Property && (DialogFocusSourceItem.Property.LockSet || 
 		(DialogFocusSourceItem.Property.LockMemberNumber && DialogFocusSourceItem.Property.LockMemberNumber != Player.MemberNumber))) {
@@ -62,20 +62,20 @@ function InventoryItemMiscTimerPasswordPadlockDraw() {
 			if (DialogFocusSourceItem && DialogFocusSourceItem.Property && DialogFocusSourceItem.Property.Hint)
 				DrawText("\"" + DialogFocusSourceItem.Property.Hint + "\"", 1500, 550, "white", "gray");
 			MainCanvas.textAlign = "right";
-			DrawText(GetPlayerDialog("PasswordPadlockOld"), 1390, 605, "white", "gray");
+			DrawText(DialogFindPlayer("PasswordPadlockOld"), 1390, 605, "white", "gray");
 			ElementPosition("Password", 1540, 605, 250);
 			MainCanvas.textAlign = "center";
-			DrawButton(1670, 580, 250, 64, GetPlayerDialog("PasswordPadlockEnter"), "White", "");
-			if (PreferenceMessage != "") DrawText(GetPlayerDialog(PreferenceMessage), 1500, 200, "Red", "Black");
+			DrawButton(1670, 580, 250, 64, DialogFindPlayer("PasswordPadlockEnter"), "White", "");
+			if (PreferenceMessage != "") DrawText(DialogFindPlayer(PreferenceMessage), 1500, 200, "Red", "Black");
 		} else {
 			ElementPosition("SetHint", 1643, 550, 550);
 			ElementPosition("SetPassword", 1491, 620, 250);
 			MainCanvas.textAlign = "left";
-			DrawText(GetPlayerDialog("PasswordPadlockSetHint"), 1100, 553, "white", "gray");
-			DrawText(GetPlayerDialog("PasswordPadlockSetPassword"), 1100, 623, "white", "gray");
+			DrawText(DialogFindPlayer("PasswordPadlockSetHint"), 1100, 553, "white", "gray");
+			DrawText(DialogFindPlayer("PasswordPadlockSetPassword"), 1100, 623, "white", "gray");
 			MainCanvas.textAlign = "center";
-			DrawButton(1653, 593, 250, 64, GetPlayerDialog("PasswordPadlockChangePassword"), "White", "");
-			if (PreferenceMessage != "") DrawText(GetPlayerDialog(PreferenceMessage), 1500, 200, "Red", "Black");
+			DrawButton(1653, 593, 250, 64, DialogFindPlayer("PasswordPadlockChangePassword"), "White", "");
+			if (PreferenceMessage != "") DrawText(DialogFindPlayer(PreferenceMessage), 1500, 200, "Red", "Black");
 		}
 	}
 	
@@ -85,32 +85,32 @@ function InventoryItemMiscTimerPasswordPadlockDraw() {
     if (Player.CanInteract() && (Player.MemberNumber == DialogFocusSourceItem.Property.LockMemberNumber)) {
         MainCanvas.textAlign = "left";
         DrawButton(1100, 666, 64, 64, "", "White", (DialogFocusSourceItem.Property.RemoveItem) ? "Icons/Checked.png" : "");
-        DrawText(GetPlayerDialog("RemoveItemWithTimer"), 1200, 698, "white", "gray");
+        DrawText(DialogFindPlayer("RemoveItemWithTimer"), 1200, 698, "white", "gray");
         DrawButton( 1100, 746, 64, 64, "", "White", (DialogFocusSourceItem.Property.ShowTimer) ? "Icons/Checked.png" : "");
         DrawText(DialogFind(Player,"ShowItemWithTimerRemaining"), 1200, 778, "white", "gray");
         DrawButton(1100, 828, 64, 64, "", "White", (DialogFocusSourceItem.Property.EnableRandomInput) ? "Icons/Checked.png" : "");
-        DrawText(GetPlayerDialog("EnableRandomInput"), 1200, 858, "white", "gray");
+        DrawText(DialogFindPlayer("EnableRandomInput"), 1200, 858, "white", "gray");
         MainCanvas.textAlign = "center";
     } else {
         if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property != null) && (DialogFocusSourceItem.Property.LockMemberNumber != null))
-            DrawText(GetPlayerDialog("LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 700, "white", "gray");
-        DrawText(GetPlayerDialog((DialogFocusSourceItem.Property.RemoveItem) ? "WillRemoveItemWithTimer" : "WontRemoveItemWithTimer"), 1500, 868, "white", "gray");
+            DrawText(DialogFindPlayer("LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 700, "white", "gray");
+        DrawText(DialogFindPlayer((DialogFocusSourceItem.Property.RemoveItem) ? "WillRemoveItemWithTimer" : "WontRemoveItemWithTimer"), 1500, 868, "white", "gray");
     }
 
     // Draw buttons to add/remove time if available
     if (Player.CanInteract() && (Player.MemberNumber == DialogFocusSourceItem.Property.LockMemberNumber)) {
-        DrawButton(1100, 910, 250, 70, GetPlayerDialog("AddTimerTime"), "White");
-        DrawBackNextButton(1400, 910, 250, 70, PasswordTimerChooseList[PasswordTimerChooseIndex] + " " + GetPlayerDialog("Minutes"), "White", "",
-            () => PasswordTimerChooseList[(PasswordTimerChooseList.length + PasswordTimerChooseIndex - 1) % PasswordTimerChooseList.length] + " " + GetPlayerDialog("Minutes"),
-            () => PasswordTimerChooseList[(PasswordTimerChooseIndex + 1) % PasswordTimerChooseList.length] + " " + GetPlayerDialog("Minutes"));
+        DrawButton(1100, 910, 250, 70, DialogFindPlayer("AddTimerTime"), "White");
+        DrawBackNextButton(1400, 910, 250, 70, PasswordTimerChooseList[PasswordTimerChooseIndex] + " " + DialogFindPlayer("Minutes"), "White", "",
+            () => PasswordTimerChooseList[(PasswordTimerChooseList.length + PasswordTimerChooseIndex - 1) % PasswordTimerChooseList.length] + " " + DialogFindPlayer("Minutes"),
+            () => PasswordTimerChooseList[(PasswordTimerChooseIndex + 1) % PasswordTimerChooseList.length] + " " + DialogFindPlayer("Minutes"));
     }
     else if (Player.CanInteract() && DialogFocusSourceItem.Property.EnableRandomInput) {
         for (let I = 0; I < DialogFocusSourceItem.Property.MemberNumberList.length; I++) {
             if (DialogFocusSourceItem.Property.MemberNumberList[I] == Player.MemberNumber) return;
         }
-        DrawButton(1100, 910, 250, 70, "- " + DialogFocusItem.Asset.RemoveTimer * 3 / 60 + " " + GetPlayerDialog("Minutes"), "White");
-        DrawButton(1400, 910, 250, 70, GetPlayerDialog("Random"), "White");
-        DrawButton(1700, 910, 250, 70, "+ " + DialogFocusItem.Asset.RemoveTimer * 3 / 60 + " " + GetPlayerDialog("Minutes"), "White");
+        DrawButton(1100, 910, 250, 70, "- " + DialogFocusItem.Asset.RemoveTimer * 3 / 60 + " " + DialogFindPlayer("Minutes"), "White");
+        DrawButton(1400, 910, 250, 70, DialogFindPlayer("Random"), "White");
+        DrawButton(1700, 910, 250, 70, "+ " + DialogFocusItem.Asset.RemoveTimer * 3 / 60 + " " + DialogFindPlayer("Minutes"), "White");
     }
 }
 

--- a/BondageClub/Screens/Inventory/ItemMisc/TimerPasswordPadlock/TimerPasswordPadlock.js
+++ b/BondageClub/Screens/Inventory/ItemMisc/TimerPasswordPadlock/TimerPasswordPadlock.js
@@ -43,18 +43,18 @@ function InventoryItemMiscTimerPasswordPadlockLoad() {
 function InventoryItemMiscTimerPasswordPadlockDraw() {
     if ((DialogFocusItem == null) || (DialogFocusSourceItem.Property.RemoveTimer < CurrentTime)) { InventoryItemMiscTimerPasswordPadlockExit(); return; }
     if (DialogFocusSourceItem.Property.ShowTimer) {
-        DrawText(DialogFind(Player, "TimerLeft") + " " + TimerToString(DialogFocusSourceItem.Property.RemoveTimer - CurrentTime), 1500, 150, "white", "gray");
-    } else { DrawText(DialogFind(Player, "TimerUnknown"), 1500, 150, "white", "gray"); }
+        DrawText(GetPlayerDialog("TimerLeft") + " " + TimerToString(DialogFocusSourceItem.Property.RemoveTimer - CurrentTime), 1500, 150, "white", "gray");
+    } else { DrawText(GetPlayerDialog("TimerUnknown"), 1500, 150, "white", "gray"); }
 	var C = CharacterGetCurrent();
 	DrawRect(1412, 225, 175, 225, "white");
 	DrawImageResize("Assets/" + DialogFocusItem.Asset.Group.Family + "/" + DialogFocusItem.Asset.Group.Name + "/Preview/" + DialogFocusItem.Asset.Name + ".png", 1414, 227, 171, 171);
 	DrawTextFit(DialogFocusItem.Asset.Description, 1500, 425, 171, "black");
 	if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property != null) && (DialogFocusSourceItem.Property.LockMemberNumber != null))
-	DrawText(DialogFind(Player, "LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 500, "white", "gray");
+	DrawText(GetPlayerDialog("LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 500, "white", "gray");
 
 	if (InventoryGroupIsBlocked(C, C.FocusGroup.Name)) {
 		// If the zone is blocked, just display some text informing the player that they can't access the lock
-		DrawText(DialogFind(Player, "LockZoneBlocked"), 1500, 550, "white", "gray");
+		DrawText(GetPlayerDialog("LockZoneBlocked"), 1500, 550, "white", "gray");
 	} else {
 		if (DialogFocusSourceItem.Property && (DialogFocusSourceItem.Property.LockSet || 
 		(DialogFocusSourceItem.Property.LockMemberNumber && DialogFocusSourceItem.Property.LockMemberNumber != Player.MemberNumber))) {
@@ -62,20 +62,20 @@ function InventoryItemMiscTimerPasswordPadlockDraw() {
 			if (DialogFocusSourceItem && DialogFocusSourceItem.Property && DialogFocusSourceItem.Property.Hint)
 				DrawText("\"" + DialogFocusSourceItem.Property.Hint + "\"", 1500, 550, "white", "gray");
 			MainCanvas.textAlign = "right";
-			DrawText(DialogFind(Player, "PasswordPadlockOld"), 1390, 605, "white", "gray");
+			DrawText(GetPlayerDialog("PasswordPadlockOld"), 1390, 605, "white", "gray");
 			ElementPosition("Password", 1540, 605, 250);
 			MainCanvas.textAlign = "center";
-			DrawButton(1670, 580, 250, 64, DialogFind(Player, "PasswordPadlockEnter"), "White", "");
-			if (PreferenceMessage != "") DrawText(DialogFind(Player, PreferenceMessage), 1500, 200, "Red", "Black");
+			DrawButton(1670, 580, 250, 64, GetPlayerDialog("PasswordPadlockEnter"), "White", "");
+			if (PreferenceMessage != "") DrawText(GetPlayerDialog(PreferenceMessage), 1500, 200, "Red", "Black");
 		} else {
 			ElementPosition("SetHint", 1643, 550, 550);
 			ElementPosition("SetPassword", 1491, 620, 250);
 			MainCanvas.textAlign = "left";
-			DrawText(DialogFind(Player, "PasswordPadlockSetHint"), 1100, 553, "white", "gray");
-			DrawText(DialogFind(Player, "PasswordPadlockSetPassword"), 1100, 623, "white", "gray");
+			DrawText(GetPlayerDialog("PasswordPadlockSetHint"), 1100, 553, "white", "gray");
+			DrawText(GetPlayerDialog("PasswordPadlockSetPassword"), 1100, 623, "white", "gray");
 			MainCanvas.textAlign = "center";
-			DrawButton(1653, 593, 250, 64, DialogFind(Player, "PasswordPadlockChangePassword"), "White", "");
-			if (PreferenceMessage != "") DrawText(DialogFind(Player, PreferenceMessage), 1500, 200, "Red", "Black");
+			DrawButton(1653, 593, 250, 64, GetPlayerDialog("PasswordPadlockChangePassword"), "White", "");
+			if (PreferenceMessage != "") DrawText(GetPlayerDialog(PreferenceMessage), 1500, 200, "Red", "Black");
 		}
 	}
 	
@@ -85,32 +85,32 @@ function InventoryItemMiscTimerPasswordPadlockDraw() {
     if (Player.CanInteract() && (Player.MemberNumber == DialogFocusSourceItem.Property.LockMemberNumber)) {
         MainCanvas.textAlign = "left";
         DrawButton(1100, 666, 64, 64, "", "White", (DialogFocusSourceItem.Property.RemoveItem) ? "Icons/Checked.png" : "");
-        DrawText(DialogFind(Player, "RemoveItemWithTimer"), 1200, 698, "white", "gray");
+        DrawText(GetPlayerDialog("RemoveItemWithTimer"), 1200, 698, "white", "gray");
         DrawButton( 1100, 746, 64, 64, "", "White", (DialogFocusSourceItem.Property.ShowTimer) ? "Icons/Checked.png" : "");
         DrawText(DialogFind(Player,"ShowItemWithTimerRemaining"), 1200, 778, "white", "gray");
         DrawButton(1100, 828, 64, 64, "", "White", (DialogFocusSourceItem.Property.EnableRandomInput) ? "Icons/Checked.png" : "");
-        DrawText(DialogFind(Player, "EnableRandomInput"), 1200, 858, "white", "gray");
+        DrawText(GetPlayerDialog("EnableRandomInput"), 1200, 858, "white", "gray");
         MainCanvas.textAlign = "center";
     } else {
         if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property != null) && (DialogFocusSourceItem.Property.LockMemberNumber != null))
-            DrawText(DialogFind(Player, "LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 700, "white", "gray");
-        DrawText(DialogFind(Player, (DialogFocusSourceItem.Property.RemoveItem) ? "WillRemoveItemWithTimer" : "WontRemoveItemWithTimer"), 1500, 868, "white", "gray");
+            DrawText(GetPlayerDialog("LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 700, "white", "gray");
+        DrawText(GetPlayerDialog((DialogFocusSourceItem.Property.RemoveItem) ? "WillRemoveItemWithTimer" : "WontRemoveItemWithTimer"), 1500, 868, "white", "gray");
     }
 
     // Draw buttons to add/remove time if available
     if (Player.CanInteract() && (Player.MemberNumber == DialogFocusSourceItem.Property.LockMemberNumber)) {
-        DrawButton(1100, 910, 250, 70, DialogFind(Player, "AddTimerTime"), "White");
-        DrawBackNextButton(1400, 910, 250, 70, PasswordTimerChooseList[PasswordTimerChooseIndex] + " " + DialogFind(Player, "Minutes"), "White", "",
-            () => PasswordTimerChooseList[(PasswordTimerChooseList.length + PasswordTimerChooseIndex - 1) % PasswordTimerChooseList.length] + " " + DialogFind(Player, "Minutes"),
-            () => PasswordTimerChooseList[(PasswordTimerChooseIndex + 1) % PasswordTimerChooseList.length] + " " + DialogFind(Player, "Minutes"));
+        DrawButton(1100, 910, 250, 70, GetPlayerDialog("AddTimerTime"), "White");
+        DrawBackNextButton(1400, 910, 250, 70, PasswordTimerChooseList[PasswordTimerChooseIndex] + " " + GetPlayerDialog("Minutes"), "White", "",
+            () => PasswordTimerChooseList[(PasswordTimerChooseList.length + PasswordTimerChooseIndex - 1) % PasswordTimerChooseList.length] + " " + GetPlayerDialog("Minutes"),
+            () => PasswordTimerChooseList[(PasswordTimerChooseIndex + 1) % PasswordTimerChooseList.length] + " " + GetPlayerDialog("Minutes"));
     }
     else if (Player.CanInteract() && DialogFocusSourceItem.Property.EnableRandomInput) {
         for (let I = 0; I < DialogFocusSourceItem.Property.MemberNumberList.length; I++) {
             if (DialogFocusSourceItem.Property.MemberNumberList[I] == Player.MemberNumber) return;
         }
-        DrawButton(1100, 910, 250, 70, "- " + DialogFocusItem.Asset.RemoveTimer * 3 / 60 + " " + DialogFind(Player, "Minutes"), "White");
-        DrawButton(1400, 910, 250, 70, DialogFind(Player, "Random"), "White");
-        DrawButton(1700, 910, 250, 70, "+ " + DialogFocusItem.Asset.RemoveTimer * 3 / 60 + " " + DialogFind(Player, "Minutes"), "White");
+        DrawButton(1100, 910, 250, 70, "- " + DialogFocusItem.Asset.RemoveTimer * 3 / 60 + " " + GetPlayerDialog("Minutes"), "White");
+        DrawButton(1400, 910, 250, 70, GetPlayerDialog("Random"), "White");
+        DrawButton(1700, 910, 250, 70, "+ " + DialogFocusItem.Asset.RemoveTimer * 3 / 60 + " " + GetPlayerDialog("Minutes"), "White");
     }
 }
 

--- a/BondageClub/Screens/Inventory/ItemMisc/WoodenSign/WoodenSign.js
+++ b/BondageClub/Screens/Inventory/ItemMisc/WoodenSign/WoodenSign.js
@@ -30,7 +30,7 @@ function InventoryItemMiscWoodenSignDraw() {
 
     ElementPosition("WoodenSignText1", 1505, 600, 350);
     ElementPosition("WoodenSignText2", 1505, 680, 350);
-    DrawButton(1330, 731, 340, 64, GetPlayerDialog("SaveText"), (ElementValue("WoodenSignText1") + ElementValue("WoodenSignText2")).match(InventoryItemMiscWoodenSignAllowedChars) ? "White" : "#888", "");
+    DrawButton(1330, 731, 340, 64, DialogFindPlayer("SaveText"), (ElementValue("WoodenSignText1") + ElementValue("WoodenSignText2")).match(InventoryItemMiscWoodenSignAllowedChars) ? "White" : "#888", "");
 }
 
 // Catches the item extension clicks

--- a/BondageClub/Screens/Inventory/ItemMisc/WoodenSign/WoodenSign.js
+++ b/BondageClub/Screens/Inventory/ItemMisc/WoodenSign/WoodenSign.js
@@ -30,7 +30,7 @@ function InventoryItemMiscWoodenSignDraw() {
 
     ElementPosition("WoodenSignText1", 1505, 600, 350);
     ElementPosition("WoodenSignText2", 1505, 680, 350);
-    DrawButton(1330, 731, 340, 64, DialogFind(Player, "SaveText"), (ElementValue("WoodenSignText1") + ElementValue("WoodenSignText2")).match(InventoryItemMiscWoodenSignAllowedChars) ? "White" : "#888", "");
+    DrawButton(1330, 731, 340, 64, GetPlayerDialog("SaveText"), (ElementValue("WoodenSignText1") + ElementValue("WoodenSignText2")).match(InventoryItemMiscWoodenSignAllowedChars) ? "White" : "#888", "");
 }
 
 // Catches the item extension clicks

--- a/BondageClub/Screens/Inventory/ItemMouth/FuturisticPanelGag/FuturisticPanelGag.js
+++ b/BondageClub/Screens/Inventory/ItemMouth/FuturisticPanelGag/FuturisticPanelGag.js
@@ -107,11 +107,11 @@ function InventoryItemMouthFuturisticPanelGagDrawAccessDenied() {
 	DrawImageResize("Assets/" + DialogFocusItem.Asset.Group.Family + "/" + DialogFocusItem.Asset.Group.Name + "/Preview/" + DialogFocusItem.Asset.Name + ".png", 1389, 227, 221, 221);
 	DrawTextFit(DialogFocusItem.Asset.Description, 1500, 475, 221, "black");
 	
-	DrawText(DialogFind(Player, "FuturisticItemLoginScreen"), 1500, 600, "White", "Gray");
+	DrawText(GetPlayerDialog("FuturisticItemLoginScreen"), 1500, 600, "White", "Gray");
 	
 	ElementPosition("PasswordField", 1505, 750, 350);
-	DrawText(DialogFind(Player, "FuturisticItemPassword"), 1500, 700, "White", "Gray");
-	DrawButton(1400, 800, 200, 64, DialogFind(Player, "FuturisticItemLogIn"), "White", "");
+	DrawText(GetPlayerDialog("FuturisticItemPassword"), 1500, 700, "White", "Gray");
+	DrawButton(1400, 800, 200, 64, GetPlayerDialog("FuturisticItemLogIn"), "White", "");
 	
 	if (FuturisticAccessDeniedMessage && FuturisticAccessDeniedMessage != "") DrawText(FuturisticAccessDeniedMessage, 1500, 963, "Red", "Black");
 	
@@ -142,7 +142,7 @@ function InventoryItemMouthFuturisticPanelGagClickAccessDenied() {
 			Player.FocusGroup = null
 			InventoryItemMouthFuturisticPanelGagExit();
 		} else {
-			FuturisticAccessDeniedMessage = DialogFind(Player, "CantChangeWhileLockedFuturistic");
+			FuturisticAccessDeniedMessage = GetPlayerDialog("CantChangeWhileLockedFuturistic");
 			var vol = 1
 			if (Player.AudioSettings && Player.AudioSettings.Volume) {
 				vol = Player.AudioSettings.Volume
@@ -177,47 +177,47 @@ function InventoryItemMouthFuturisticPanelGagDraw() {
 		DrawRect(1387, 75, 225, 275, "white");
 		DrawImageResize("Assets/" + DialogFocusItem.Asset.Group.Family + "/" + DialogFocusItem.Asset.Group.Name + "/Preview/" + DialogFocusItem.Asset.Name + ".png", 1389, 77, 221, 221);
 		DrawTextFit(DialogFocusItem.Asset.Description, 1500, 325, 221, "black");
-		
+
 		if (DialogFocusItem.Property.AutoPunishUndoTime - CurrentTime > 0)
-			DrawText(DialogFind(Player, "FuturisticPanelGagMouthDeflationTime") + " " + TimerToString(DialogFocusItem.Property.AutoPunishUndoTime - CurrentTime), 1500, 415, "White", "Gray");		
-		
+			DrawText(GetPlayerDialog("FuturisticPanelGagMouthDeflationTime") + " " + TimerToString(DialogFocusItem.Property.AutoPunishUndoTime - CurrentTime), 1500, 415, "White", "Gray");		
+
 		var type = "FuturisticPanelGagMouthType" + ((DialogFocusItem.Property.Type != null) ? DialogFocusItem.Property.Type : "Padded")
-		DrawText(DialogFind(Player, "FuturisticPanelGagMouthTypeDesc") + " " +
-			DialogFind(Player, type), 1350, 475, "White", "Gray");	
-				
+		DrawText(GetPlayerDialog("FuturisticPanelGagMouthTypeDesc") + " " +
+			GetPlayerDialog(type), 1350, 475, "White", "Gray");	
+
 		MainCanvas.textAlign = "left";
 		DrawCheckbox(1100, 890, 64, 64, "", DialogFocusItem.Property.ChatMessage, "White");
-		DrawText(DialogFind(Player, "FuturisticPanelGagMouthButtonChatMessage"), 1200, 923, "White", "Gray");	
+		DrawText(GetPlayerDialog("FuturisticPanelGagMouthButtonChatMessage"), 1200, 923, "White", "Gray");	
 		MainCanvas.textAlign = "center";
-		
+
 		var autopunish = "Off" 
 		if (DialogFocusItem.Property.AutoPunish == 0) {}
 		else if (DialogFocusItem.Property.AutoPunish == 1) {autopunish = "Low"}
 		else if (DialogFocusItem.Property.AutoPunish == 2) {autopunish = "Medium"}
 		else {autopunish = "Maximum"}
-		
-		DrawText(DialogFind(Player, "FuturisticPanelGagMouthButtonAutoPunish") + " " + autopunish, 1350, 683, "White", "Gray");
+
+		DrawText(GetPlayerDialog("FuturisticPanelGagMouthButtonAutoPunish") + " " + autopunish, 1350, 683, "White", "Gray");
 		if (DialogFocusItem) {
-			if (DialogFocusItem.Property.Type != null) DrawButton(1100, 500, 200, 64, DialogFind(Player, "FuturisticPanelGagMouthTypePadded"), "White", "");
-			if (DialogFocusItem.Property.Type != "LightBall") DrawButton(1400, 500, 200, 64, DialogFind(Player, "FuturisticPanelGagMouthTypeLightBall"), "White", "");
-			if (DialogFocusItem.Property.Type != "Ball") DrawButton(1100, 570, 200, 64, DialogFind(Player, "FuturisticPanelGagMouthTypeBall"), "White", "");
-			if (DialogFocusItem.Property.Type != "Plug") DrawButton(1400, 570, 200, 64, DialogFind(Player, "FuturisticPanelGagMouthTypePlug"), "White", "");
-			
-			if (DialogFocusItem.Property.AutoPunish != 0) DrawButton(1100, 707, 200, 64, DialogFind(Player, "TurnOff"), "White", "");
-			if (DialogFocusItem.Property.AutoPunish != 1) DrawButton(1400, 707, 200, 64, DialogFind(Player, "Low"), "White", "");
-			if (DialogFocusItem.Property.AutoPunish != 2) DrawButton(1100, 777, 200, 64, DialogFind(Player, "Medium"), "White", "");
-			if (DialogFocusItem.Property.AutoPunish != 3) DrawButton(1400, 777, 200, 64, DialogFind(Player, "Maximum"), "White", "");
-			
-			DrawText(DialogFind(Player, "FuturisticPanelGagMouthDeflationTimeSetting" + DialogFocusItem.Property.AutoPunishUndoTimeSetting), 1775, 475, "White", "Gray");	
-			if (DialogFocusItem.Property.AutoPunishUndoTimeSetting != 120000) DrawButton(1675, 500, 200, 64, DialogFind(Player, "FuturisticPanelGagMouthDeflationTimeButton120000"), "White", "");
-			if (DialogFocusItem.Property.AutoPunishUndoTimeSetting != 300000) DrawButton(1675, 570, 200, 64, DialogFind(Player, "FuturisticPanelGagMouthDeflationTimeButton300000"), "White", "");
-			if (DialogFocusItem.Property.AutoPunishUndoTimeSetting != 900000) DrawButton(1675, 640, 200, 64, DialogFind(Player, "FuturisticPanelGagMouthDeflationTimeButton900000"), "White", "");
-			if (DialogFocusItem.Property.AutoPunishUndoTimeSetting != 3600000) DrawButton(1675, 710, 200, 64, DialogFind(Player, "FuturisticPanelGagMouthDeflationTimeButton3600000"), "White", "");
-			if (DialogFocusItem.Property.AutoPunishUndoTimeSetting != 72000000) DrawButton(1675, 780, 200, 64, DialogFind(Player, "FuturisticPanelGagMouthDeflationTimeButton72000000"), "White", "");
-			
-			if (DialogFocusItem.Property.AutoPunishUndoTimeSetting) DrawButton(1675, 880, 200, 64, DialogFind(Player, "FuturisticPanelGagMouthDeflationTimeButtonPump"), "White", "");
+			if (DialogFocusItem.Property.Type != null) DrawButton(1100, 500, 200, 64, GetPlayerDialog("FuturisticPanelGagMouthTypePadded"), "White", "");
+			if (DialogFocusItem.Property.Type != "LightBall") DrawButton(1400, 500, 200, 64, GetPlayerDialog("FuturisticPanelGagMouthTypeLightBall"), "White", "");
+			if (DialogFocusItem.Property.Type != "Ball") DrawButton(1100, 570, 200, 64, GetPlayerDialog("FuturisticPanelGagMouthTypeBall"), "White", "");
+			if (DialogFocusItem.Property.Type != "Plug") DrawButton(1400, 570, 200, 64, GetPlayerDialog("FuturisticPanelGagMouthTypePlug"), "White", "");
+
+			if (DialogFocusItem.Property.AutoPunish != 0) DrawButton(1100, 707, 200, 64, GetPlayerDialog("TurnOff"), "White", "");
+			if (DialogFocusItem.Property.AutoPunish != 1) DrawButton(1400, 707, 200, 64, GetPlayerDialog("Low"), "White", "");
+			if (DialogFocusItem.Property.AutoPunish != 2) DrawButton(1100, 777, 200, 64, GetPlayerDialog("Medium"), "White", "");
+			if (DialogFocusItem.Property.AutoPunish != 3) DrawButton(1400, 777, 200, 64, GetPlayerDialog("Maximum"), "White", "");
+
+			DrawText(GetPlayerDialog("FuturisticPanelGagMouthDeflationTimeSetting" + DialogFocusItem.Property.AutoPunishUndoTimeSetting), 1775, 475, "White", "Gray");	
+			if (DialogFocusItem.Property.AutoPunishUndoTimeSetting != 120000) DrawButton(1675, 500, 200, 64, GetPlayerDialog("FuturisticPanelGagMouthDeflationTimeButton120000"), "White", "");
+			if (DialogFocusItem.Property.AutoPunishUndoTimeSetting != 300000) DrawButton(1675, 570, 200, 64, GetPlayerDialog("FuturisticPanelGagMouthDeflationTimeButton300000"), "White", "");
+			if (DialogFocusItem.Property.AutoPunishUndoTimeSetting != 900000) DrawButton(1675, 640, 200, 64, GetPlayerDialog("FuturisticPanelGagMouthDeflationTimeButton900000"), "White", "");
+			if (DialogFocusItem.Property.AutoPunishUndoTimeSetting != 3600000) DrawButton(1675, 710, 200, 64, GetPlayerDialog("FuturisticPanelGagMouthDeflationTimeButton3600000"), "White", "");
+			if (DialogFocusItem.Property.AutoPunishUndoTimeSetting != 72000000) DrawButton(1675, 780, 200, 64, GetPlayerDialog("FuturisticPanelGagMouthDeflationTimeButton72000000"), "White", "");
+
+			if (DialogFocusItem.Property.AutoPunishUndoTimeSetting) DrawButton(1675, 880, 200, 64, GetPlayerDialog("FuturisticPanelGagMouthDeflationTimeButtonPump"), "White", "");
 		}
-		
+
 	}
 }
 
@@ -286,7 +286,7 @@ function InventoryItemMouthFuturisticPanelGagValidate(C, Option) {
 	if (DialogFocusItem && DialogFocusItem.Property && DialogFocusItem.Property.LockedBy && !DialogCanUnlock(C, DialogFocusItem)) {
 		var collar = InventoryGet(C, "ItemNeck")
 		if (collar && (!collar.Property || collar.Property.OpenPermission != true)) {
-			Allowed = DialogExtendedMessage = DialogFind(Player, "CantChangeWhileLockedFuturistic");
+			Allowed = DialogExtendedMessage = GetPlayerDialog("CantChangeWhileLockedFuturistic");
 		}
 	}
 

--- a/BondageClub/Screens/Inventory/ItemMouth/FuturisticPanelGag/FuturisticPanelGag.js
+++ b/BondageClub/Screens/Inventory/ItemMouth/FuturisticPanelGag/FuturisticPanelGag.js
@@ -107,11 +107,11 @@ function InventoryItemMouthFuturisticPanelGagDrawAccessDenied() {
 	DrawImageResize("Assets/" + DialogFocusItem.Asset.Group.Family + "/" + DialogFocusItem.Asset.Group.Name + "/Preview/" + DialogFocusItem.Asset.Name + ".png", 1389, 227, 221, 221);
 	DrawTextFit(DialogFocusItem.Asset.Description, 1500, 475, 221, "black");
 	
-	DrawText(GetPlayerDialog("FuturisticItemLoginScreen"), 1500, 600, "White", "Gray");
+	DrawText(DialogFindPlayer("FuturisticItemLoginScreen"), 1500, 600, "White", "Gray");
 	
 	ElementPosition("PasswordField", 1505, 750, 350);
-	DrawText(GetPlayerDialog("FuturisticItemPassword"), 1500, 700, "White", "Gray");
-	DrawButton(1400, 800, 200, 64, GetPlayerDialog("FuturisticItemLogIn"), "White", "");
+	DrawText(DialogFindPlayer("FuturisticItemPassword"), 1500, 700, "White", "Gray");
+	DrawButton(1400, 800, 200, 64, DialogFindPlayer("FuturisticItemLogIn"), "White", "");
 	
 	if (FuturisticAccessDeniedMessage && FuturisticAccessDeniedMessage != "") DrawText(FuturisticAccessDeniedMessage, 1500, 963, "Red", "Black");
 	
@@ -142,7 +142,7 @@ function InventoryItemMouthFuturisticPanelGagClickAccessDenied() {
 			Player.FocusGroup = null
 			InventoryItemMouthFuturisticPanelGagExit();
 		} else {
-			FuturisticAccessDeniedMessage = GetPlayerDialog("CantChangeWhileLockedFuturistic");
+			FuturisticAccessDeniedMessage = DialogFindPlayer("CantChangeWhileLockedFuturistic");
 			var vol = 1
 			if (Player.AudioSettings && Player.AudioSettings.Volume) {
 				vol = Player.AudioSettings.Volume
@@ -179,15 +179,15 @@ function InventoryItemMouthFuturisticPanelGagDraw() {
 		DrawTextFit(DialogFocusItem.Asset.Description, 1500, 325, 221, "black");
 
 		if (DialogFocusItem.Property.AutoPunishUndoTime - CurrentTime > 0)
-			DrawText(GetPlayerDialog("FuturisticPanelGagMouthDeflationTime") + " " + TimerToString(DialogFocusItem.Property.AutoPunishUndoTime - CurrentTime), 1500, 415, "White", "Gray");		
+			DrawText(DialogFindPlayer("FuturisticPanelGagMouthDeflationTime") + " " + TimerToString(DialogFocusItem.Property.AutoPunishUndoTime - CurrentTime), 1500, 415, "White", "Gray");		
 
 		var type = "FuturisticPanelGagMouthType" + ((DialogFocusItem.Property.Type != null) ? DialogFocusItem.Property.Type : "Padded")
-		DrawText(GetPlayerDialog("FuturisticPanelGagMouthTypeDesc") + " " +
-			GetPlayerDialog(type), 1350, 475, "White", "Gray");	
+		DrawText(DialogFindPlayer("FuturisticPanelGagMouthTypeDesc") + " " +
+			DialogFindPlayer(type), 1350, 475, "White", "Gray");	
 
 		MainCanvas.textAlign = "left";
 		DrawCheckbox(1100, 890, 64, 64, "", DialogFocusItem.Property.ChatMessage, "White");
-		DrawText(GetPlayerDialog("FuturisticPanelGagMouthButtonChatMessage"), 1200, 923, "White", "Gray");	
+		DrawText(DialogFindPlayer("FuturisticPanelGagMouthButtonChatMessage"), 1200, 923, "White", "Gray");	
 		MainCanvas.textAlign = "center";
 
 		var autopunish = "Off" 
@@ -196,26 +196,26 @@ function InventoryItemMouthFuturisticPanelGagDraw() {
 		else if (DialogFocusItem.Property.AutoPunish == 2) {autopunish = "Medium"}
 		else {autopunish = "Maximum"}
 
-		DrawText(GetPlayerDialog("FuturisticPanelGagMouthButtonAutoPunish") + " " + autopunish, 1350, 683, "White", "Gray");
+		DrawText(DialogFindPlayer("FuturisticPanelGagMouthButtonAutoPunish") + " " + autopunish, 1350, 683, "White", "Gray");
 		if (DialogFocusItem) {
-			if (DialogFocusItem.Property.Type != null) DrawButton(1100, 500, 200, 64, GetPlayerDialog("FuturisticPanelGagMouthTypePadded"), "White", "");
-			if (DialogFocusItem.Property.Type != "LightBall") DrawButton(1400, 500, 200, 64, GetPlayerDialog("FuturisticPanelGagMouthTypeLightBall"), "White", "");
-			if (DialogFocusItem.Property.Type != "Ball") DrawButton(1100, 570, 200, 64, GetPlayerDialog("FuturisticPanelGagMouthTypeBall"), "White", "");
-			if (DialogFocusItem.Property.Type != "Plug") DrawButton(1400, 570, 200, 64, GetPlayerDialog("FuturisticPanelGagMouthTypePlug"), "White", "");
+			if (DialogFocusItem.Property.Type != null) DrawButton(1100, 500, 200, 64, DialogFindPlayer("FuturisticPanelGagMouthTypePadded"), "White", "");
+			if (DialogFocusItem.Property.Type != "LightBall") DrawButton(1400, 500, 200, 64, DialogFindPlayer("FuturisticPanelGagMouthTypeLightBall"), "White", "");
+			if (DialogFocusItem.Property.Type != "Ball") DrawButton(1100, 570, 200, 64, DialogFindPlayer("FuturisticPanelGagMouthTypeBall"), "White", "");
+			if (DialogFocusItem.Property.Type != "Plug") DrawButton(1400, 570, 200, 64, DialogFindPlayer("FuturisticPanelGagMouthTypePlug"), "White", "");
 
-			if (DialogFocusItem.Property.AutoPunish != 0) DrawButton(1100, 707, 200, 64, GetPlayerDialog("TurnOff"), "White", "");
-			if (DialogFocusItem.Property.AutoPunish != 1) DrawButton(1400, 707, 200, 64, GetPlayerDialog("Low"), "White", "");
-			if (DialogFocusItem.Property.AutoPunish != 2) DrawButton(1100, 777, 200, 64, GetPlayerDialog("Medium"), "White", "");
-			if (DialogFocusItem.Property.AutoPunish != 3) DrawButton(1400, 777, 200, 64, GetPlayerDialog("Maximum"), "White", "");
+			if (DialogFocusItem.Property.AutoPunish != 0) DrawButton(1100, 707, 200, 64, DialogFindPlayer("TurnOff"), "White", "");
+			if (DialogFocusItem.Property.AutoPunish != 1) DrawButton(1400, 707, 200, 64, DialogFindPlayer("Low"), "White", "");
+			if (DialogFocusItem.Property.AutoPunish != 2) DrawButton(1100, 777, 200, 64, DialogFindPlayer("Medium"), "White", "");
+			if (DialogFocusItem.Property.AutoPunish != 3) DrawButton(1400, 777, 200, 64, DialogFindPlayer("Maximum"), "White", "");
 
-			DrawText(GetPlayerDialog("FuturisticPanelGagMouthDeflationTimeSetting" + DialogFocusItem.Property.AutoPunishUndoTimeSetting), 1775, 475, "White", "Gray");	
-			if (DialogFocusItem.Property.AutoPunishUndoTimeSetting != 120000) DrawButton(1675, 500, 200, 64, GetPlayerDialog("FuturisticPanelGagMouthDeflationTimeButton120000"), "White", "");
-			if (DialogFocusItem.Property.AutoPunishUndoTimeSetting != 300000) DrawButton(1675, 570, 200, 64, GetPlayerDialog("FuturisticPanelGagMouthDeflationTimeButton300000"), "White", "");
-			if (DialogFocusItem.Property.AutoPunishUndoTimeSetting != 900000) DrawButton(1675, 640, 200, 64, GetPlayerDialog("FuturisticPanelGagMouthDeflationTimeButton900000"), "White", "");
-			if (DialogFocusItem.Property.AutoPunishUndoTimeSetting != 3600000) DrawButton(1675, 710, 200, 64, GetPlayerDialog("FuturisticPanelGagMouthDeflationTimeButton3600000"), "White", "");
-			if (DialogFocusItem.Property.AutoPunishUndoTimeSetting != 72000000) DrawButton(1675, 780, 200, 64, GetPlayerDialog("FuturisticPanelGagMouthDeflationTimeButton72000000"), "White", "");
+			DrawText(DialogFindPlayer("FuturisticPanelGagMouthDeflationTimeSetting" + DialogFocusItem.Property.AutoPunishUndoTimeSetting), 1775, 475, "White", "Gray");	
+			if (DialogFocusItem.Property.AutoPunishUndoTimeSetting != 120000) DrawButton(1675, 500, 200, 64, DialogFindPlayer("FuturisticPanelGagMouthDeflationTimeButton120000"), "White", "");
+			if (DialogFocusItem.Property.AutoPunishUndoTimeSetting != 300000) DrawButton(1675, 570, 200, 64, DialogFindPlayer("FuturisticPanelGagMouthDeflationTimeButton300000"), "White", "");
+			if (DialogFocusItem.Property.AutoPunishUndoTimeSetting != 900000) DrawButton(1675, 640, 200, 64, DialogFindPlayer("FuturisticPanelGagMouthDeflationTimeButton900000"), "White", "");
+			if (DialogFocusItem.Property.AutoPunishUndoTimeSetting != 3600000) DrawButton(1675, 710, 200, 64, DialogFindPlayer("FuturisticPanelGagMouthDeflationTimeButton3600000"), "White", "");
+			if (DialogFocusItem.Property.AutoPunishUndoTimeSetting != 72000000) DrawButton(1675, 780, 200, 64, DialogFindPlayer("FuturisticPanelGagMouthDeflationTimeButton72000000"), "White", "");
 
-			if (DialogFocusItem.Property.AutoPunishUndoTimeSetting) DrawButton(1675, 880, 200, 64, GetPlayerDialog("FuturisticPanelGagMouthDeflationTimeButtonPump"), "White", "");
+			if (DialogFocusItem.Property.AutoPunishUndoTimeSetting) DrawButton(1675, 880, 200, 64, DialogFindPlayer("FuturisticPanelGagMouthDeflationTimeButtonPump"), "White", "");
 		}
 
 	}
@@ -286,7 +286,7 @@ function InventoryItemMouthFuturisticPanelGagValidate(C, Option) {
 	if (DialogFocusItem && DialogFocusItem.Property && DialogFocusItem.Property.LockedBy && !DialogCanUnlock(C, DialogFocusItem)) {
 		var collar = InventoryGet(C, "ItemNeck")
 		if (collar && (!collar.Property || collar.Property.OpenPermission != true)) {
-			Allowed = DialogExtendedMessage = GetPlayerDialog("CantChangeWhileLockedFuturistic");
+			Allowed = DialogExtendedMessage = DialogFindPlayer("CantChangeWhileLockedFuturistic");
 		}
 	}
 

--- a/BondageClub/Screens/Inventory/ItemNeck/FuturisticCollar/FuturisticCollar.js
+++ b/BondageClub/Screens/Inventory/ItemNeck/FuturisticCollar/FuturisticCollar.js
@@ -27,9 +27,9 @@ function InventoryItemNeckFuturisticCollarDraw() {
 		
 
 		DrawButton(1125, 395, 64, 64, "", "White", DialogFocusItem.Property.OpenPermission ? "Icons/Checked.png" : "");
-		DrawText(GetPlayerDialog("FuturisticCollarOpenPermission"), 1550, 425, "White", "Gray");
+		DrawText(DialogFindPlayer("FuturisticCollarOpenPermission"), 1550, 425, "White", "Gray");
 		DrawButton(1125, 465, 64, 64, "", "White", DialogFocusItem.Property.BlockRemotes ? "Icons/Checked.png" : "");
-		DrawText(GetPlayerDialog("FuturisticCollarBlockRemotes"), 1450, 495, "White", "Gray");
+		DrawText(DialogFindPlayer("FuturisticCollarBlockRemotes"), 1450, 495, "White", "Gray");
 
 		var FuturisticCollarStatus = "NoItems"
 		var FuturisticCollarItems = InventoryItemNeckFuturisticCollarGetItems(C)
@@ -46,24 +46,24 @@ function InventoryItemNeckFuturisticCollarDraw() {
 			else if (lockedItems == FuturisticCollarItems.length) FuturisticCollarStatus = "FullyLocked"
 		}
 
-		DrawText(GetPlayerDialog("FuturisticCollarOptions" + FuturisticCollarStatus), 1500, 560, "White", "Gray");
+		DrawText(DialogFindPlayer("FuturisticCollarOptions" + FuturisticCollarStatus), 1500, 560, "White", "Gray");
 
 		if (FuturisticCollarItems.length > 0 && lockedItems < FuturisticCollarItems.length) {
-			if (InventoryItemNeckFuturisticCollarCanLock(C, "MetalPadlock", "ItemMisc")) DrawButton(1250, 590, 200, 55, GetPlayerDialog("FuturisticCollarLockMetal"), "White");
-			if (InventoryItemNeckFuturisticCollarCanLock(C, "ExclusivePadlock", "ItemMisc")) DrawButton(1550, 590, 200, 55, GetPlayerDialog("FuturisticCollarLockExclusive"), "White");
-			if (InventoryItemNeckFuturisticCollarCanLock(C, "IntricatePadlock", "ItemMisc")) DrawButton(1250, 650, 200, 55, GetPlayerDialog("FuturisticCollarLockIntricate"), "White");
-			if (InventoryItemNeckFuturisticCollarCanLock(C, "HighSecurityPadlock", "ItemMisc")) DrawButton(1550, 650, 200, 55, GetPlayerDialog("FuturisticCollarLockHighSec"), "White");
-			if (InventoryItemNeckFuturisticCollarCanLock(C, "TimerPadlock", "ItemMisc")) DrawButton(1250, 710, 200, 55, GetPlayerDialog("FuturisticCollarLockTimer"), "White");
-			if (InventoryItemNeckFuturisticCollarCanLock(C, "MistressPadlock", "ItemMisc")) DrawButton(1550, 710, 200, 55, GetPlayerDialog("FuturisticCollarLockMistress"), "White");
-			if (InventoryItemNeckFuturisticCollarCanLock(C, "LoversPadlock", "ItemMisc")) DrawButton(1250, 770, 200, 55, GetPlayerDialog("FuturisticCollarLockLover"), "White");
-			if (InventoryItemNeckFuturisticCollarCanLock(C, "OwnerPadlock", "ItemMisc")) DrawButton(1550, 770, 200, 55, GetPlayerDialog("FuturisticCollarLockOwner"), "White");
+			if (InventoryItemNeckFuturisticCollarCanLock(C, "MetalPadlock", "ItemMisc")) DrawButton(1250, 590, 200, 55, DialogFindPlayer("FuturisticCollarLockMetal"), "White");
+			if (InventoryItemNeckFuturisticCollarCanLock(C, "ExclusivePadlock", "ItemMisc")) DrawButton(1550, 590, 200, 55, DialogFindPlayer("FuturisticCollarLockExclusive"), "White");
+			if (InventoryItemNeckFuturisticCollarCanLock(C, "IntricatePadlock", "ItemMisc")) DrawButton(1250, 650, 200, 55, DialogFindPlayer("FuturisticCollarLockIntricate"), "White");
+			if (InventoryItemNeckFuturisticCollarCanLock(C, "HighSecurityPadlock", "ItemMisc")) DrawButton(1550, 650, 200, 55, DialogFindPlayer("FuturisticCollarLockHighSec"), "White");
+			if (InventoryItemNeckFuturisticCollarCanLock(C, "TimerPadlock", "ItemMisc")) DrawButton(1250, 710, 200, 55, DialogFindPlayer("FuturisticCollarLockTimer"), "White");
+			if (InventoryItemNeckFuturisticCollarCanLock(C, "MistressPadlock", "ItemMisc")) DrawButton(1550, 710, 200, 55, DialogFindPlayer("FuturisticCollarLockMistress"), "White");
+			if (InventoryItemNeckFuturisticCollarCanLock(C, "LoversPadlock", "ItemMisc")) DrawButton(1250, 770, 200, 55, DialogFindPlayer("FuturisticCollarLockLover"), "White");
+			if (InventoryItemNeckFuturisticCollarCanLock(C, "OwnerPadlock", "ItemMisc")) DrawButton(1550, 770, 200, 55, DialogFindPlayer("FuturisticCollarLockOwner"), "White");
 		}
 
 		if (FuturisticCollarItemsUnlockable.length > 0) {
-			DrawButton(1400, 850, 200, 55, GetPlayerDialog("FuturisticCollarUnlock"), "White");
+			DrawButton(1400, 850, 200, 55, DialogFindPlayer("FuturisticCollarUnlock"), "White");
 		}
 		if (FuturisticCollarItems.length > 0) {
-			DrawButton(1400, 910, 200, 55, GetPlayerDialog("FuturisticCollarColor"), "White");
+			DrawButton(1400, 910, 200, 55, DialogFindPlayer("FuturisticCollarColor"), "White");
 		}
 
 

--- a/BondageClub/Screens/Inventory/ItemNeck/FuturisticCollar/FuturisticCollar.js
+++ b/BondageClub/Screens/Inventory/ItemNeck/FuturisticCollar/FuturisticCollar.js
@@ -27,10 +27,10 @@ function InventoryItemNeckFuturisticCollarDraw() {
 		
 
 		DrawButton(1125, 395, 64, 64, "", "White", DialogFocusItem.Property.OpenPermission ? "Icons/Checked.png" : "");
-		DrawText(DialogFind(Player, "FuturisticCollarOpenPermission"), 1550, 425, "White", "Gray");
+		DrawText(GetPlayerDialog("FuturisticCollarOpenPermission"), 1550, 425, "White", "Gray");
 		DrawButton(1125, 465, 64, 64, "", "White", DialogFocusItem.Property.BlockRemotes ? "Icons/Checked.png" : "");
-		DrawText(DialogFind(Player, "FuturisticCollarBlockRemotes"), 1450, 495, "White", "Gray");
-		
+		DrawText(GetPlayerDialog("FuturisticCollarBlockRemotes"), 1450, 495, "White", "Gray");
+
 		var FuturisticCollarStatus = "NoItems"
 		var FuturisticCollarItems = InventoryItemNeckFuturisticCollarGetItems(C)
 		var FuturisticCollarItemsUnlockable = InventoryItemNeckFuturisticCollarGetItems(C, true)
@@ -45,28 +45,28 @@ function InventoryItemNeckFuturisticCollarDraw() {
 			else if (lockedItems < FuturisticCollarItems.length) FuturisticCollarStatus = "PartialLocks"
 			else if (lockedItems == FuturisticCollarItems.length) FuturisticCollarStatus = "FullyLocked"
 		}
-		
-		DrawText(DialogFind(Player, "FuturisticCollarOptions" + FuturisticCollarStatus), 1500, 560, "White", "Gray");
-		
+
+		DrawText(GetPlayerDialog("FuturisticCollarOptions" + FuturisticCollarStatus), 1500, 560, "White", "Gray");
+
 		if (FuturisticCollarItems.length > 0 && lockedItems < FuturisticCollarItems.length) {
-			if (InventoryItemNeckFuturisticCollarCanLock(C, "MetalPadlock", "ItemMisc")) DrawButton(1250, 590, 200, 55, DialogFind(Player, "FuturisticCollarLockMetal"), "White");
-			if (InventoryItemNeckFuturisticCollarCanLock(C, "ExclusivePadlock", "ItemMisc")) DrawButton(1550, 590, 200, 55, DialogFind(Player, "FuturisticCollarLockExclusive"), "White");
-			if (InventoryItemNeckFuturisticCollarCanLock(C, "IntricatePadlock", "ItemMisc")) DrawButton(1250, 650, 200, 55, DialogFind(Player, "FuturisticCollarLockIntricate"), "White");
-			if (InventoryItemNeckFuturisticCollarCanLock(C, "HighSecurityPadlock", "ItemMisc")) DrawButton(1550, 650, 200, 55, DialogFind(Player, "FuturisticCollarLockHighSec"), "White");
-			if (InventoryItemNeckFuturisticCollarCanLock(C, "TimerPadlock", "ItemMisc")) DrawButton(1250, 710, 200, 55, DialogFind(Player, "FuturisticCollarLockTimer"), "White");
-			if (InventoryItemNeckFuturisticCollarCanLock(C, "MistressPadlock", "ItemMisc")) DrawButton(1550, 710, 200, 55, DialogFind(Player, "FuturisticCollarLockMistress"), "White");
-			if (InventoryItemNeckFuturisticCollarCanLock(C, "LoversPadlock", "ItemMisc")) DrawButton(1250, 770, 200, 55, DialogFind(Player, "FuturisticCollarLockLover"), "White");
-			if (InventoryItemNeckFuturisticCollarCanLock(C, "OwnerPadlock", "ItemMisc")) DrawButton(1550, 770, 200, 55, DialogFind(Player, "FuturisticCollarLockOwner"), "White");
+			if (InventoryItemNeckFuturisticCollarCanLock(C, "MetalPadlock", "ItemMisc")) DrawButton(1250, 590, 200, 55, GetPlayerDialog("FuturisticCollarLockMetal"), "White");
+			if (InventoryItemNeckFuturisticCollarCanLock(C, "ExclusivePadlock", "ItemMisc")) DrawButton(1550, 590, 200, 55, GetPlayerDialog("FuturisticCollarLockExclusive"), "White");
+			if (InventoryItemNeckFuturisticCollarCanLock(C, "IntricatePadlock", "ItemMisc")) DrawButton(1250, 650, 200, 55, GetPlayerDialog("FuturisticCollarLockIntricate"), "White");
+			if (InventoryItemNeckFuturisticCollarCanLock(C, "HighSecurityPadlock", "ItemMisc")) DrawButton(1550, 650, 200, 55, GetPlayerDialog("FuturisticCollarLockHighSec"), "White");
+			if (InventoryItemNeckFuturisticCollarCanLock(C, "TimerPadlock", "ItemMisc")) DrawButton(1250, 710, 200, 55, GetPlayerDialog("FuturisticCollarLockTimer"), "White");
+			if (InventoryItemNeckFuturisticCollarCanLock(C, "MistressPadlock", "ItemMisc")) DrawButton(1550, 710, 200, 55, GetPlayerDialog("FuturisticCollarLockMistress"), "White");
+			if (InventoryItemNeckFuturisticCollarCanLock(C, "LoversPadlock", "ItemMisc")) DrawButton(1250, 770, 200, 55, GetPlayerDialog("FuturisticCollarLockLover"), "White");
+			if (InventoryItemNeckFuturisticCollarCanLock(C, "OwnerPadlock", "ItemMisc")) DrawButton(1550, 770, 200, 55, GetPlayerDialog("FuturisticCollarLockOwner"), "White");
 		}
-		
+
 		if (FuturisticCollarItemsUnlockable.length > 0) {
-			DrawButton(1400, 850, 200, 55, DialogFind(Player, "FuturisticCollarUnlock"), "White");
+			DrawButton(1400, 850, 200, 55, GetPlayerDialog("FuturisticCollarUnlock"), "White");
 		}
 		if (FuturisticCollarItems.length > 0) {
-			DrawButton(1400, 910, 200, 55, DialogFind(Player, "FuturisticCollarColor"), "White");
+			DrawButton(1400, 910, 200, 55, GetPlayerDialog("FuturisticCollarColor"), "White");
 		}
-		
-		
+
+
 	}
 }
 

--- a/BondageClub/Screens/Inventory/ItemNeck/SlaveCollar/SlaveCollar.js
+++ b/BondageClub/Screens/Inventory/ItemNeck/SlaveCollar/SlaveCollar.js
@@ -122,7 +122,7 @@ function InventoryItemNeckSlaveCollarDraw() {
 
             // In regular mode, the owner can select the collar model and change the offset to get the next 8 models
             ColorPickerHide();
-			DrawText(GetPlayerDialog("SlaveCollarSelectType"), 1500, 250, "white", "gray");
+			DrawText(DialogFindPlayer("SlaveCollarSelectType"), 1500, 250, "white", "gray");
 			DrawButton(1665, 25, 90, 90, "", "White", "Icons/Next.png");
 			DrawButton(1775, 25, 90, 90, "", (DialogFocusItem.Color != null && DialogFocusItem.Color != "Default" && DialogFocusItem.Color != "None") ? DialogFocusItem.Color : "White", "Icons/ColorPick.png");
 			for (let I = InventoryItemNeckSlaveCollarOffset; I < InventoryItemNeckSlaveCollarTypes.length && I < InventoryItemNeckSlaveCollarOffset + 8; I++) {

--- a/BondageClub/Screens/Inventory/ItemNeck/SlaveCollar/SlaveCollar.js
+++ b/BondageClub/Screens/Inventory/ItemNeck/SlaveCollar/SlaveCollar.js
@@ -122,7 +122,7 @@ function InventoryItemNeckSlaveCollarDraw() {
 
             // In regular mode, the owner can select the collar model and change the offset to get the next 8 models
             ColorPickerHide();
-			DrawText(DialogFind(Player, "SlaveCollarSelectType"), 1500, 250, "white", "gray");
+			DrawText(GetPlayerDialog("SlaveCollarSelectType"), 1500, 250, "white", "gray");
 			DrawButton(1665, 25, 90, 90, "", "White", "Icons/Next.png");
 			DrawButton(1775, 25, 90, 90, "", (DialogFocusItem.Color != null && DialogFocusItem.Color != "Default" && DialogFocusItem.Color != "None") ? DialogFocusItem.Color : "White", "Icons/ColorPick.png");
 			for (let I = InventoryItemNeckSlaveCollarOffset; I < InventoryItemNeckSlaveCollarTypes.length && I < InventoryItemNeckSlaveCollarOffset + 8; I++) {

--- a/BondageClub/Screens/Inventory/ItemNeckAccessories/CollarAutoShockUnit/CollarAutoShockUnit.js
+++ b/BondageClub/Screens/Inventory/ItemNeckAccessories/CollarAutoShockUnit/CollarAutoShockUnit.js
@@ -14,21 +14,21 @@ function InventoryItemNeckAccessoriesCollarAutoShockUnitDraw() {
 	DrawRect(1387, 205, 225, 275, "white");
 	DrawImageResize("Assets/" + DialogFocusItem.Asset.Group.Family + "/" + DialogFocusItem.Asset.Group.Name + "/Preview/" + DialogFocusItem.Asset.Name + ".png", 1389, 207, 221, 221);
 	DrawTextFit(DialogFocusItem.Asset.Description, 1500, 455, 221, "black");
-	DrawText(GetPlayerDialog("Intensity" + DialogFocusItem.Property.Intensity.toString()).replace("Item", DialogFocusItem.Asset.Description), 1500, 520, "White", "Gray");
-	if (DialogFocusItem.Property.Intensity > 0) DrawButton(1100, 550, 200, 55, GetPlayerDialog("Low"), "White");
-	if (DialogFocusItem.Property.Intensity < 1 || DialogFocusItem.Property.Intensity > 1) DrawButton(1375, 550, 200, 55, GetPlayerDialog("Medium"), "White");
-	if (DialogFocusItem.Property.Intensity < 2) DrawButton(1650, 550, 200, 55, GetPlayerDialog("High"), "White");
+	DrawText(DialogFindPlayer("Intensity" + DialogFocusItem.Property.Intensity.toString()).replace("Item", DialogFocusItem.Asset.Description), 1500, 520, "White", "Gray");
+	if (DialogFocusItem.Property.Intensity > 0) DrawButton(1100, 550, 200, 55, DialogFindPlayer("Low"), "White");
+	if (DialogFocusItem.Property.Intensity < 1 || DialogFocusItem.Property.Intensity > 1) DrawButton(1375, 550, 200, 55, DialogFindPlayer("Medium"), "White");
+	if (DialogFocusItem.Property.Intensity < 2) DrawButton(1650, 550, 200, 55, DialogFindPlayer("High"), "White");
 
-	DrawText(GetPlayerDialog("Sensitivity" + (DialogFocusItem.Property.Sensitivity-1).toString()).replace("Item", DialogFocusItem.Asset.Description), 1500, 660, "White", "Gray");
+	DrawText(DialogFindPlayer("Sensitivity" + (DialogFocusItem.Property.Sensitivity-1).toString()).replace("Item", DialogFocusItem.Asset.Description), 1500, 660, "White", "Gray");
 
-	if (DialogFocusItem.Property.Sensitivity != 0) DrawButton(1100, 700, 150, 55, GetPlayerDialog("TurnOff"), "White");
-	if (DialogFocusItem.Property.Sensitivity != 1) DrawButton(1300, 700, 150, 55, GetPlayerDialog("Low"), "White");
-	if (DialogFocusItem.Property.Sensitivity != 2) DrawButton(1500, 700, 150, 55, GetPlayerDialog("Medium"), "White");
-	if (DialogFocusItem.Property.Sensitivity != 3) DrawButton(1700, 700, 150, 55, GetPlayerDialog("High"), "White");
+	if (DialogFocusItem.Property.Sensitivity != 0) DrawButton(1100, 700, 150, 55, DialogFindPlayer("TurnOff"), "White");
+	if (DialogFocusItem.Property.Sensitivity != 1) DrawButton(1300, 700, 150, 55, DialogFindPlayer("Low"), "White");
+	if (DialogFocusItem.Property.Sensitivity != 2) DrawButton(1500, 700, 150, 55, DialogFindPlayer("Medium"), "White");
+	if (DialogFocusItem.Property.Sensitivity != 3) DrawButton(1700, 700, 150, 55, DialogFindPlayer("High"), "White");
 
 	if (CurrentScreen == "ChatRoom") DrawButton(1125, 780, 64, 64, "", "White", DialogFocusItem.Property.ShowText ? "Icons/Checked.png" : "");
-	if (CurrentScreen == "ChatRoom") DrawText(GetPlayerDialog("ShockCollarShowChat"), 1370, 813, "White", "Gray");
-	DrawButton(1600, 790, 200, 55, GetPlayerDialog("TriggerShock"), "White");
+	if (CurrentScreen == "ChatRoom") DrawText(DialogFindPlayer("ShockCollarShowChat"), 1370, 813, "White", "Gray");
+	DrawButton(1600, 790, 200, 55, DialogFindPlayer("TriggerShock"), "White");
 }
 
 // Catches the item extension clicks

--- a/BondageClub/Screens/Inventory/ItemNeckAccessories/CollarAutoShockUnit/CollarAutoShockUnit.js
+++ b/BondageClub/Screens/Inventory/ItemNeckAccessories/CollarAutoShockUnit/CollarAutoShockUnit.js
@@ -14,21 +14,21 @@ function InventoryItemNeckAccessoriesCollarAutoShockUnitDraw() {
 	DrawRect(1387, 205, 225, 275, "white");
 	DrawImageResize("Assets/" + DialogFocusItem.Asset.Group.Family + "/" + DialogFocusItem.Asset.Group.Name + "/Preview/" + DialogFocusItem.Asset.Name + ".png", 1389, 207, 221, 221);
 	DrawTextFit(DialogFocusItem.Asset.Description, 1500, 455, 221, "black");
-	DrawText(DialogFind(Player, "Intensity" + DialogFocusItem.Property.Intensity.toString()).replace("Item", DialogFocusItem.Asset.Description), 1500, 520, "White", "Gray");
-	if (DialogFocusItem.Property.Intensity > 0) DrawButton(1100, 550, 200, 55, DialogFind(Player, "Low"), "White");
-	if (DialogFocusItem.Property.Intensity < 1 || DialogFocusItem.Property.Intensity > 1) DrawButton(1375, 550, 200, 55, DialogFind(Player, "Medium"), "White");
-	if (DialogFocusItem.Property.Intensity < 2) DrawButton(1650, 550, 200, 55, DialogFind(Player, "High"), "White");
-	
-	DrawText(DialogFind(Player, "Sensitivity" + (DialogFocusItem.Property.Sensitivity-1).toString()).replace("Item", DialogFocusItem.Asset.Description), 1500, 660, "White", "Gray");
-	
-	if (DialogFocusItem.Property.Sensitivity != 0) DrawButton(1100, 700, 150, 55, DialogFind(Player, "TurnOff"), "White");
-	if (DialogFocusItem.Property.Sensitivity != 1) DrawButton(1300, 700, 150, 55, DialogFind(Player, "Low"), "White");
-	if (DialogFocusItem.Property.Sensitivity != 2) DrawButton(1500, 700, 150, 55, DialogFind(Player, "Medium"), "White");
-	if (DialogFocusItem.Property.Sensitivity != 3) DrawButton(1700, 700, 150, 55, DialogFind(Player, "High"), "White");
-	
+	DrawText(GetPlayerDialog("Intensity" + DialogFocusItem.Property.Intensity.toString()).replace("Item", DialogFocusItem.Asset.Description), 1500, 520, "White", "Gray");
+	if (DialogFocusItem.Property.Intensity > 0) DrawButton(1100, 550, 200, 55, GetPlayerDialog("Low"), "White");
+	if (DialogFocusItem.Property.Intensity < 1 || DialogFocusItem.Property.Intensity > 1) DrawButton(1375, 550, 200, 55, GetPlayerDialog("Medium"), "White");
+	if (DialogFocusItem.Property.Intensity < 2) DrawButton(1650, 550, 200, 55, GetPlayerDialog("High"), "White");
+
+	DrawText(GetPlayerDialog("Sensitivity" + (DialogFocusItem.Property.Sensitivity-1).toString()).replace("Item", DialogFocusItem.Asset.Description), 1500, 660, "White", "Gray");
+
+	if (DialogFocusItem.Property.Sensitivity != 0) DrawButton(1100, 700, 150, 55, GetPlayerDialog("TurnOff"), "White");
+	if (DialogFocusItem.Property.Sensitivity != 1) DrawButton(1300, 700, 150, 55, GetPlayerDialog("Low"), "White");
+	if (DialogFocusItem.Property.Sensitivity != 2) DrawButton(1500, 700, 150, 55, GetPlayerDialog("Medium"), "White");
+	if (DialogFocusItem.Property.Sensitivity != 3) DrawButton(1700, 700, 150, 55, GetPlayerDialog("High"), "White");
+
 	if (CurrentScreen == "ChatRoom") DrawButton(1125, 780, 64, 64, "", "White", DialogFocusItem.Property.ShowText ? "Icons/Checked.png" : "");
-	if (CurrentScreen == "ChatRoom") DrawText(DialogFind(Player, "ShockCollarShowChat"), 1370, 813, "White", "Gray");
-	DrawButton(1600, 790, 200, 55, DialogFind(Player, "TriggerShock"), "White");
+	if (CurrentScreen == "ChatRoom") DrawText(GetPlayerDialog("ShockCollarShowChat"), 1370, 813, "White", "Gray");
+	DrawButton(1600, 790, 200, 55, GetPlayerDialog("TriggerShock"), "White");
 }
 
 // Catches the item extension clicks

--- a/BondageClub/Screens/Inventory/ItemNeckAccessories/CollarNameTag/CollarNameTag.js
+++ b/BondageClub/Screens/Inventory/ItemNeckAccessories/CollarNameTag/CollarNameTag.js
@@ -15,12 +15,12 @@ function InventoryItemNeckAccessoriesCollarNameTagDraw() {
 
 	// Draw the possible tags
 	if (!InventoryItemHasEffect(DialogFocusItem, "Lock", true)) {
-		DrawText(GetPlayerDialog("SelectCollarNameTagType"), 1500, 500, "white", "gray");
+		DrawText(DialogFindPlayer("SelectCollarNameTagType"), 1500, 500, "white", "gray");
 		var List = DialogFocusItem.Asset.AllowType;
 		var X = 955;
 		var Y = 530;
 		for (let T = 0; T < List.length; T++) {
-			if ((DialogFocusItem.Property.Type != List[T])) DrawButton(X, Y, 200, 55, GetPlayerDialog("CollarNameTagType" + List[T]), "White");
+			if ((DialogFocusItem.Property.Type != List[T])) DrawButton(X, Y, 200, 55, DialogFindPlayer("CollarNameTagType" + List[T]), "White");
 			X = X + 210;
 			if (T % 5 == 4) { 
 				X = 955; 
@@ -29,7 +29,7 @@ function InventoryItemNeckAccessoriesCollarNameTagDraw() {
 		}
 	}
 	else {
-		DrawText(GetPlayerDialog("SelectCollarNameTagTypeLocked"), 1500, 500, "white", "gray");
+		DrawText(DialogFindPlayer("SelectCollarNameTagTypeLocked"), 1500, 500, "white", "gray");
 	}
 }
 

--- a/BondageClub/Screens/Inventory/ItemNeckAccessories/CollarNameTag/CollarNameTag.js
+++ b/BondageClub/Screens/Inventory/ItemNeckAccessories/CollarNameTag/CollarNameTag.js
@@ -15,12 +15,12 @@ function InventoryItemNeckAccessoriesCollarNameTagDraw() {
 
 	// Draw the possible tags
 	if (!InventoryItemHasEffect(DialogFocusItem, "Lock", true)) {
-		DrawText(DialogFind(Player, "SelectCollarNameTagType"), 1500, 500, "white", "gray");
+		DrawText(GetPlayerDialog("SelectCollarNameTagType"), 1500, 500, "white", "gray");
 		var List = DialogFocusItem.Asset.AllowType;
 		var X = 955;
 		var Y = 530;
 		for (let T = 0; T < List.length; T++) {
-			if ((DialogFocusItem.Property.Type != List[T])) DrawButton(X, Y, 200, 55, DialogFind(Player, "CollarNameTagType" + List[T]), "White");
+			if ((DialogFocusItem.Property.Type != List[T])) DrawButton(X, Y, 200, 55, GetPlayerDialog("CollarNameTagType" + List[T]), "White");
 			X = X + 210;
 			if (T % 5 == 4) { 
 				X = 955; 
@@ -29,7 +29,7 @@ function InventoryItemNeckAccessoriesCollarNameTagDraw() {
 		}
 	}
 	else {
-		DrawText(DialogFind(Player, "SelectCollarNameTagTypeLocked"), 1500, 500, "white", "gray");
+		DrawText(GetPlayerDialog("SelectCollarNameTagTypeLocked"), 1500, 500, "white", "gray");
 	}
 }
 

--- a/BondageClub/Screens/Inventory/ItemNeckAccessories/CollarNameTagLivestock/CollarNameTagLivestock.js
+++ b/BondageClub/Screens/Inventory/ItemNeckAccessories/CollarNameTagLivestock/CollarNameTagLivestock.js
@@ -15,12 +15,12 @@ function InventoryItemNeckAccessoriesCollarNameTagLivestockDraw() {
 
 	// Draw the possible tags
 	if (!InventoryItemHasEffect(DialogFocusItem, "Lock", true)) {
-		DrawText(DialogFind(Player, "SelectCollarNameTagLivestockType"), 1500, 500, "white", "gray");
+		DrawText(GetPlayerDialog("SelectCollarNameTagLivestockType"), 1500, 500, "white", "gray");
 		var List = DialogFocusItem.Asset.AllowType;
 		var X = 955;
 		var Y = 530;
 		for (let T = 0; T < List.length; T++) {
-			if ((DialogFocusItem.Property.Type != List[T])) DrawButton(X, Y, 200, 55, DialogFind(Player, "CollarNameTagLivestockType" + List[T]), "White");
+			if ((DialogFocusItem.Property.Type != List[T])) DrawButton(X, Y, 200, 55, GetPlayerDialog("CollarNameTagLivestockType" + List[T]), "White");
 			X = X + 210;
 			if (T % 5 == 4) { 
 				X = 955; 
@@ -29,7 +29,7 @@ function InventoryItemNeckAccessoriesCollarNameTagLivestockDraw() {
 		}
 	}
 	else {
-		DrawText(DialogFind(Player, "SelectCollarNameTagLivestockTypeLocked"), 1500, 500, "white", "gray");
+		DrawText(GetPlayerDialog("SelectCollarNameTagLivestockTypeLocked"), 1500, 500, "white", "gray");
 	}
 }
 

--- a/BondageClub/Screens/Inventory/ItemNeckAccessories/CollarNameTagLivestock/CollarNameTagLivestock.js
+++ b/BondageClub/Screens/Inventory/ItemNeckAccessories/CollarNameTagLivestock/CollarNameTagLivestock.js
@@ -15,12 +15,12 @@ function InventoryItemNeckAccessoriesCollarNameTagLivestockDraw() {
 
 	// Draw the possible tags
 	if (!InventoryItemHasEffect(DialogFocusItem, "Lock", true)) {
-		DrawText(GetPlayerDialog("SelectCollarNameTagLivestockType"), 1500, 500, "white", "gray");
+		DrawText(DialogFindPlayer("SelectCollarNameTagLivestockType"), 1500, 500, "white", "gray");
 		var List = DialogFocusItem.Asset.AllowType;
 		var X = 955;
 		var Y = 530;
 		for (let T = 0; T < List.length; T++) {
-			if ((DialogFocusItem.Property.Type != List[T])) DrawButton(X, Y, 200, 55, GetPlayerDialog("CollarNameTagLivestockType" + List[T]), "White");
+			if ((DialogFocusItem.Property.Type != List[T])) DrawButton(X, Y, 200, 55, DialogFindPlayer("CollarNameTagLivestockType" + List[T]), "White");
 			X = X + 210;
 			if (T % 5 == 4) { 
 				X = 955; 
@@ -29,7 +29,7 @@ function InventoryItemNeckAccessoriesCollarNameTagLivestockDraw() {
 		}
 	}
 	else {
-		DrawText(GetPlayerDialog("SelectCollarNameTagLivestockTypeLocked"), 1500, 500, "white", "gray");
+		DrawText(DialogFindPlayer("SelectCollarNameTagLivestockTypeLocked"), 1500, 500, "white", "gray");
 	}
 }
 

--- a/BondageClub/Screens/Inventory/ItemNeckAccessories/CollarNameTagLover/CollarNameTagLover.js
+++ b/BondageClub/Screens/Inventory/ItemNeckAccessories/CollarNameTagLover/CollarNameTagLover.js
@@ -15,12 +15,12 @@ function InventoryItemNeckAccessoriesCollarNameTagLoverDraw() {
 
 	// Draw the possible tags
 	if (!InventoryItemHasEffect(DialogFocusItem, "Lock", true)) {
-		DrawText(GetPlayerDialog("SelectCollarNameTagLoverType"), 1500, 500, "white", "gray");
+		DrawText(DialogFindPlayer("SelectCollarNameTagLoverType"), 1500, 500, "white", "gray");
 		var List = DialogFocusItem.Asset.AllowType;
 		var X = 955;
 		var Y = 530;
 		for (let T = 0; T < List.length; T++) {
-			if ((DialogFocusItem.Property.Type != List[T])) DrawButton(X, Y, 200, 55, GetPlayerDialog("CollarNameTagLoverType" + List[T]), "White");
+			if ((DialogFocusItem.Property.Type != List[T])) DrawButton(X, Y, 200, 55, DialogFindPlayer("CollarNameTagLoverType" + List[T]), "White");
 			X = X + 210;
 			if (T % 5 == 4) { 
 				X = 955; 
@@ -29,7 +29,7 @@ function InventoryItemNeckAccessoriesCollarNameTagLoverDraw() {
 		}
 	}
 	else {
-		DrawText(GetPlayerDialog("SelectCollarNameTagLoverTypeLocked"), 1500, 500, "white", "gray");
+		DrawText(DialogFindPlayer("SelectCollarNameTagLoverTypeLocked"), 1500, 500, "white", "gray");
 	}
 }
 

--- a/BondageClub/Screens/Inventory/ItemNeckAccessories/CollarNameTagLover/CollarNameTagLover.js
+++ b/BondageClub/Screens/Inventory/ItemNeckAccessories/CollarNameTagLover/CollarNameTagLover.js
@@ -15,12 +15,12 @@ function InventoryItemNeckAccessoriesCollarNameTagLoverDraw() {
 
 	// Draw the possible tags
 	if (!InventoryItemHasEffect(DialogFocusItem, "Lock", true)) {
-		DrawText(DialogFind(Player, "SelectCollarNameTagLoverType"), 1500, 500, "white", "gray");
+		DrawText(GetPlayerDialog("SelectCollarNameTagLoverType"), 1500, 500, "white", "gray");
 		var List = DialogFocusItem.Asset.AllowType;
 		var X = 955;
 		var Y = 530;
 		for (let T = 0; T < List.length; T++) {
-			if ((DialogFocusItem.Property.Type != List[T])) DrawButton(X, Y, 200, 55, DialogFind(Player, "CollarNameTagLoverType" + List[T]), "White");
+			if ((DialogFocusItem.Property.Type != List[T])) DrawButton(X, Y, 200, 55, GetPlayerDialog("CollarNameTagLoverType" + List[T]), "White");
 			X = X + 210;
 			if (T % 5 == 4) { 
 				X = 955; 
@@ -29,7 +29,7 @@ function InventoryItemNeckAccessoriesCollarNameTagLoverDraw() {
 		}
 	}
 	else {
-		DrawText(DialogFind(Player, "SelectCollarNameTagLoverTypeLocked"), 1500, 500, "white", "gray");
+		DrawText(GetPlayerDialog("SelectCollarNameTagLoverTypeLocked"), 1500, 500, "white", "gray");
 	}
 }
 

--- a/BondageClub/Screens/Inventory/ItemNeckAccessories/CollarNameTagOval/CollarNameTagOval.js
+++ b/BondageClub/Screens/Inventory/ItemNeckAccessories/CollarNameTagOval/CollarNameTagOval.js
@@ -15,12 +15,12 @@ function InventoryItemNeckAccessoriesCollarNameTagOvalDraw() {
 
 	// Draw the possible tags
 	if (!InventoryItemHasEffect(DialogFocusItem, "Lock", true)) {
-		DrawText(DialogFind(Player, "SelectCollarNameTagOvalType"), 1500, 500, "white", "gray");
+		DrawText(GetPlayerDialog("SelectCollarNameTagOvalType"), 1500, 500, "white", "gray");
 		var List = DialogFocusItem.Asset.AllowType;
 		var X = 955;
 		var Y = 530;
 		for (let T = 0; T < List.length; T++) {
-			if ((DialogFocusItem.Property.Type != List[T])) DrawButton(X, Y, 200, 55, DialogFind(Player, "CollarNameTagOvalType" + List[T]), "White");
+			if ((DialogFocusItem.Property.Type != List[T])) DrawButton(X, Y, 200, 55, GetPlayerDialog("CollarNameTagOvalType" + List[T]), "White");
 			X = X + 210;
 			if (T % 5 == 4) { 
 				X = 955; 
@@ -29,7 +29,7 @@ function InventoryItemNeckAccessoriesCollarNameTagOvalDraw() {
 		}
 	}
 	else {
-		DrawText(DialogFind(Player, "SelectCollarNameTagOvalTypeLocked"), 1500, 500, "white", "gray");
+		DrawText(GetPlayerDialog("SelectCollarNameTagOvalTypeLocked"), 1500, 500, "white", "gray");
 	}
 }
 

--- a/BondageClub/Screens/Inventory/ItemNeckAccessories/CollarNameTagOval/CollarNameTagOval.js
+++ b/BondageClub/Screens/Inventory/ItemNeckAccessories/CollarNameTagOval/CollarNameTagOval.js
@@ -15,12 +15,12 @@ function InventoryItemNeckAccessoriesCollarNameTagOvalDraw() {
 
 	// Draw the possible tags
 	if (!InventoryItemHasEffect(DialogFocusItem, "Lock", true)) {
-		DrawText(GetPlayerDialog("SelectCollarNameTagOvalType"), 1500, 500, "white", "gray");
+		DrawText(DialogFindPlayer("SelectCollarNameTagOvalType"), 1500, 500, "white", "gray");
 		var List = DialogFocusItem.Asset.AllowType;
 		var X = 955;
 		var Y = 530;
 		for (let T = 0; T < List.length; T++) {
-			if ((DialogFocusItem.Property.Type != List[T])) DrawButton(X, Y, 200, 55, GetPlayerDialog("CollarNameTagOvalType" + List[T]), "White");
+			if ((DialogFocusItem.Property.Type != List[T])) DrawButton(X, Y, 200, 55, DialogFindPlayer("CollarNameTagOvalType" + List[T]), "White");
 			X = X + 210;
 			if (T % 5 == 4) { 
 				X = 955; 
@@ -29,7 +29,7 @@ function InventoryItemNeckAccessoriesCollarNameTagOvalDraw() {
 		}
 	}
 	else {
-		DrawText(GetPlayerDialog("SelectCollarNameTagOvalTypeLocked"), 1500, 500, "white", "gray");
+		DrawText(DialogFindPlayer("SelectCollarNameTagOvalTypeLocked"), 1500, 500, "white", "gray");
 	}
 }
 

--- a/BondageClub/Screens/Inventory/ItemNeckAccessories/CollarNameTagPet/CollarNameTagPet.js
+++ b/BondageClub/Screens/Inventory/ItemNeckAccessories/CollarNameTagPet/CollarNameTagPet.js
@@ -15,12 +15,12 @@ function InventoryItemNeckAccessoriesCollarNameTagPetDraw() {
 
 	// Draw the possible tags
 	if (!InventoryItemHasEffect(DialogFocusItem, "Lock", true)) {
-		DrawText(DialogFind(Player, "SelectCollarNameTagPetType"), 1500, 500, "white", "gray");
+		DrawText(GetPlayerDialog("SelectCollarNameTagPetType"), 1500, 500, "white", "gray");
 		var List = DialogFocusItem.Asset.AllowType;
 		var X = 955;
 		var Y = 530;
 		for (let T = 0; T < List.length; T++) {
-			if ((DialogFocusItem.Property.Type != List[T])) DrawButton(X, Y, 200, 55, DialogFind(Player, "CollarNameTagPetType" + List[T]), "White");
+			if ((DialogFocusItem.Property.Type != List[T])) DrawButton(X, Y, 200, 55, GetPlayerDialog("CollarNameTagPetType" + List[T]), "White");
 			X = X + 210;
 			if (T % 5 == 4) { 
 				X = 955; 
@@ -29,7 +29,7 @@ function InventoryItemNeckAccessoriesCollarNameTagPetDraw() {
 		}
 	}
 	else {
-		DrawText(DialogFind(Player, "SelectCollarNameTagPetTypeLocked"), 1500, 500, "white", "gray");
+		DrawText(GetPlayerDialog("SelectCollarNameTagPetTypeLocked"), 1500, 500, "white", "gray");
 	}
 }
 

--- a/BondageClub/Screens/Inventory/ItemNeckAccessories/CollarNameTagPet/CollarNameTagPet.js
+++ b/BondageClub/Screens/Inventory/ItemNeckAccessories/CollarNameTagPet/CollarNameTagPet.js
@@ -15,12 +15,12 @@ function InventoryItemNeckAccessoriesCollarNameTagPetDraw() {
 
 	// Draw the possible tags
 	if (!InventoryItemHasEffect(DialogFocusItem, "Lock", true)) {
-		DrawText(GetPlayerDialog("SelectCollarNameTagPetType"), 1500, 500, "white", "gray");
+		DrawText(DialogFindPlayer("SelectCollarNameTagPetType"), 1500, 500, "white", "gray");
 		var List = DialogFocusItem.Asset.AllowType;
 		var X = 955;
 		var Y = 530;
 		for (let T = 0; T < List.length; T++) {
-			if ((DialogFocusItem.Property.Type != List[T])) DrawButton(X, Y, 200, 55, GetPlayerDialog("CollarNameTagPetType" + List[T]), "White");
+			if ((DialogFocusItem.Property.Type != List[T])) DrawButton(X, Y, 200, 55, DialogFindPlayer("CollarNameTagPetType" + List[T]), "White");
 			X = X + 210;
 			if (T % 5 == 4) { 
 				X = 955; 
@@ -29,7 +29,7 @@ function InventoryItemNeckAccessoriesCollarNameTagPetDraw() {
 		}
 	}
 	else {
-		DrawText(GetPlayerDialog("SelectCollarNameTagPetTypeLocked"), 1500, 500, "white", "gray");
+		DrawText(DialogFindPlayer("SelectCollarNameTagPetTypeLocked"), 1500, 500, "white", "gray");
 	}
 }
 

--- a/BondageClub/Screens/Inventory/ItemNeckAccessories/CollarShockUnit/CollarShockUnit.js
+++ b/BondageClub/Screens/Inventory/ItemNeckAccessories/CollarShockUnit/CollarShockUnit.js
@@ -12,13 +12,13 @@ function InventoryItemNeckAccessoriesCollarShockUnitDraw() {
 	DrawRect(1387, 225, 225, 275, "white");
 	DrawImageResize("Assets/" + DialogFocusItem.Asset.Group.Family + "/" + DialogFocusItem.Asset.Group.Name + "/Preview/" + DialogFocusItem.Asset.Name + ".png", 1389, 227, 221, 221);
 	DrawTextFit(DialogFocusItem.Asset.Description, 1500, 475, 221, "black");
-	DrawText(DialogFind(Player, "Intensity" + DialogFocusItem.Property.Intensity.toString()).replace("Item", DialogFocusItem.Asset.Description), 1500, 600, "White", "Gray");
-	if (DialogFocusItem.Property.Intensity > 0) DrawButton(1200, 650, 200, 55, DialogFind(Player, "Low"), "White");
-	if (DialogFocusItem.Property.Intensity < 1 || DialogFocusItem.Property.Intensity > 1) DrawButton(1550, 650, 200, 55, DialogFind(Player, "Medium"), "White");
-	if (DialogFocusItem.Property.Intensity < 2) DrawButton(1375, 710, 200, 55, DialogFind(Player, "High"), "White");
+	DrawText(GetPlayerDialog("Intensity" + DialogFocusItem.Property.Intensity.toString()).replace("Item", DialogFocusItem.Asset.Description), 1500, 600, "White", "Gray");
+	if (DialogFocusItem.Property.Intensity > 0) DrawButton(1200, 650, 200, 55, GetPlayerDialog("Low"), "White");
+	if (DialogFocusItem.Property.Intensity < 1 || DialogFocusItem.Property.Intensity > 1) DrawButton(1550, 650, 200, 55, GetPlayerDialog("Medium"), "White");
+	if (DialogFocusItem.Property.Intensity < 2) DrawButton(1375, 710, 200, 55, GetPlayerDialog("High"), "White");
 	if (CurrentScreen == "ChatRoom") DrawButton(1325, 800, 64, 64, "", "White", DialogFocusItem.Property.ShowText ? "Icons/Checked.png" : "");
-	if (CurrentScreen == "ChatRoom") DrawText(DialogFind(Player, "ShockCollarShowChat"), 1570, 833, "White", "Gray");
-	DrawButton(1375, 900, 200, 55, DialogFind(Player, "TriggerShock"), "White");
+	if (CurrentScreen == "ChatRoom") DrawText(GetPlayerDialog("ShockCollarShowChat"), 1570, 833, "White", "Gray");
+	DrawButton(1375, 900, 200, 55, GetPlayerDialog("TriggerShock"), "White");
 }
 
 // Catches the item extension clicks

--- a/BondageClub/Screens/Inventory/ItemNeckAccessories/CollarShockUnit/CollarShockUnit.js
+++ b/BondageClub/Screens/Inventory/ItemNeckAccessories/CollarShockUnit/CollarShockUnit.js
@@ -12,13 +12,13 @@ function InventoryItemNeckAccessoriesCollarShockUnitDraw() {
 	DrawRect(1387, 225, 225, 275, "white");
 	DrawImageResize("Assets/" + DialogFocusItem.Asset.Group.Family + "/" + DialogFocusItem.Asset.Group.Name + "/Preview/" + DialogFocusItem.Asset.Name + ".png", 1389, 227, 221, 221);
 	DrawTextFit(DialogFocusItem.Asset.Description, 1500, 475, 221, "black");
-	DrawText(GetPlayerDialog("Intensity" + DialogFocusItem.Property.Intensity.toString()).replace("Item", DialogFocusItem.Asset.Description), 1500, 600, "White", "Gray");
-	if (DialogFocusItem.Property.Intensity > 0) DrawButton(1200, 650, 200, 55, GetPlayerDialog("Low"), "White");
-	if (DialogFocusItem.Property.Intensity < 1 || DialogFocusItem.Property.Intensity > 1) DrawButton(1550, 650, 200, 55, GetPlayerDialog("Medium"), "White");
-	if (DialogFocusItem.Property.Intensity < 2) DrawButton(1375, 710, 200, 55, GetPlayerDialog("High"), "White");
+	DrawText(DialogFindPlayer("Intensity" + DialogFocusItem.Property.Intensity.toString()).replace("Item", DialogFocusItem.Asset.Description), 1500, 600, "White", "Gray");
+	if (DialogFocusItem.Property.Intensity > 0) DrawButton(1200, 650, 200, 55, DialogFindPlayer("Low"), "White");
+	if (DialogFocusItem.Property.Intensity < 1 || DialogFocusItem.Property.Intensity > 1) DrawButton(1550, 650, 200, 55, DialogFindPlayer("Medium"), "White");
+	if (DialogFocusItem.Property.Intensity < 2) DrawButton(1375, 710, 200, 55, DialogFindPlayer("High"), "White");
 	if (CurrentScreen == "ChatRoom") DrawButton(1325, 800, 64, 64, "", "White", DialogFocusItem.Property.ShowText ? "Icons/Checked.png" : "");
-	if (CurrentScreen == "ChatRoom") DrawText(GetPlayerDialog("ShockCollarShowChat"), 1570, 833, "White", "Gray");
-	DrawButton(1375, 900, 200, 55, GetPlayerDialog("TriggerShock"), "White");
+	if (CurrentScreen == "ChatRoom") DrawText(DialogFindPlayer("ShockCollarShowChat"), 1570, 833, "White", "Gray");
+	DrawButton(1375, 900, 200, 55, DialogFindPlayer("TriggerShock"), "White");
 }
 
 // Catches the item extension clicks

--- a/BondageClub/Screens/Inventory/ItemNeckAccessories/CustomCollarTag.js/CustomCollarTag.js
+++ b/BondageClub/Screens/Inventory/ItemNeckAccessories/CustomCollarTag.js/CustomCollarTag.js
@@ -31,9 +31,9 @@ function InventoryItemNeckAccessoriesCustomCollarTagDraw() {
     // Tag data
 	if (!InventoryItemHasEffect(DialogFocusItem, "Lock", true)) {
 		ElementPosition("TagText", 1375, 680, 250);
-		DrawButton(1500, 651, 350, 64, GetPlayerDialog("CustomTagText"), ElementValue("TagText").match(InventoryItemNeckAccessoriesCustomCollarTagAllowedChars) ? "White" : "#888", "");
+		DrawButton(1500, 651, 350, 64, DialogFindPlayer("CustomTagText"), ElementValue("TagText").match(InventoryItemNeckAccessoriesCustomCollarTagAllowedChars) ? "White" : "#888", "");
 	} else {
-		DrawText(GetPlayerDialog("SelectCollarNameTagTypeLocked"), 1500, 500, "white", "gray");
+		DrawText(DialogFindPlayer("SelectCollarNameTagTypeLocked"), 1500, 500, "white", "gray");
     }
 }
 

--- a/BondageClub/Screens/Inventory/ItemNeckAccessories/CustomCollarTag.js/CustomCollarTag.js
+++ b/BondageClub/Screens/Inventory/ItemNeckAccessories/CustomCollarTag.js/CustomCollarTag.js
@@ -31,9 +31,9 @@ function InventoryItemNeckAccessoriesCustomCollarTagDraw() {
     // Tag data
 	if (!InventoryItemHasEffect(DialogFocusItem, "Lock", true)) {
 		ElementPosition("TagText", 1375, 680, 250);
-		DrawButton(1500, 651, 350, 64, DialogFind(Player, "CustomTagText"), ElementValue("TagText").match(InventoryItemNeckAccessoriesCustomCollarTagAllowedChars) ? "White" : "#888", "");
+		DrawButton(1500, 651, 350, 64, GetPlayerDialog("CustomTagText"), ElementValue("TagText").match(InventoryItemNeckAccessoriesCustomCollarTagAllowedChars) ? "White" : "#888", "");
 	} else {
-		DrawText(DialogFind(Player, "SelectCollarNameTagTypeLocked"), 1500, 500, "white", "gray");
+		DrawText(GetPlayerDialog("SelectCollarNameTagTypeLocked"), 1500, 500, "white", "gray");
     }
 }
 

--- a/BondageClub/Screens/Inventory/ItemNose/NoseRing/NoseRing.js
+++ b/BondageClub/Screens/Inventory/ItemNose/NoseRing/NoseRing.js
@@ -108,7 +108,7 @@ function InventoryItemNoseNoseRingValidate(C, Option) {
 		case "ChainLong":
 		case "Leash":
 			if (C.Pose.indexOf("Suspension") >= 0) {
-				ChainShortPrerequisites = GetPlayerDialog("RemoveSuspensionForItem");
+				ChainShortPrerequisites = DialogFindPlayer("RemoveSuspensionForItem");
 			} // if
 			break;
 	} // switch

--- a/BondageClub/Screens/Inventory/ItemNose/NoseRing/NoseRing.js
+++ b/BondageClub/Screens/Inventory/ItemNose/NoseRing/NoseRing.js
@@ -108,7 +108,7 @@ function InventoryItemNoseNoseRingValidate(C, Option) {
 		case "ChainLong":
 		case "Leash":
 			if (C.Pose.indexOf("Suspension") >= 0) {
-				ChainShortPrerequisites = DialogFind(Player, "RemoveSuspensionForItem");
+				ChainShortPrerequisites = GetPlayerDialog("RemoveSuspensionForItem");
 			} // if
 			break;
 	} // switch

--- a/BondageClub/Screens/Inventory/ItemPelvis/FuturisticChastityBelt/FuturisticChastityBelt.js
+++ b/BondageClub/Screens/Inventory/ItemPelvis/FuturisticChastityBelt/FuturisticChastityBelt.js
@@ -58,26 +58,26 @@ function InventoryItemPelvisFuturisticChastityBeltDraw() {
 		DrawTextFit(DialogFocusItem.Asset.Description, 1500, 375, 221, "black");
 
 		if (DialogFocusItem.Property.NextShockTime - CurrentTime > 0)
-			DrawText(GetPlayerDialog("FuturisticChastityBeltTime") + " " + TimerToString(DialogFocusItem.Property.NextShockTime - CurrentTime), 1500, 475, "White", "Gray");
+			DrawText(DialogFindPlayer("FuturisticChastityBeltTime") + " " + TimerToString(DialogFocusItem.Property.NextShockTime - CurrentTime), 1500, 475, "White", "Gray");
 		else
-			DrawText(GetPlayerDialog("FuturisticChastityBeltTimeReady"), 1500, 475, "White", "Gray");
+			DrawText(DialogFindPlayer("FuturisticChastityBeltTimeReady"), 1500, 475, "White", "Gray");
 
 
 		MainCanvas.textAlign = "left";
-		DrawCheckboxColor(1100, 550, 64, 64, GetPlayerDialog("FuturisticChastityBeltPunishChatMessage"), DialogFocusItem.Property.ChatMessage, "White");
-		DrawCheckboxColor(1100, 620, 64, 64, GetPlayerDialog("FuturisticChastityBeltPunishStruggle"), DialogFocusItem.Property.PunishStruggle, "White");
-		DrawCheckboxColor(1100, 690, 64, 64, GetPlayerDialog("FuturisticChastityBeltPunishStruggleOther"), DialogFocusItem.Property.PunishStruggleOther, "White");
-		DrawCheckboxColor(1100, 760, 64, 64, GetPlayerDialog("FuturisticChastityBeltPunishOrgasm"), DialogFocusItem.Property.PunishOrgasm, "White");
+		DrawCheckboxColor(1100, 550, 64, 64, DialogFindPlayer("FuturisticChastityBeltPunishChatMessage"), DialogFocusItem.Property.ChatMessage, "White");
+		DrawCheckboxColor(1100, 620, 64, 64, DialogFindPlayer("FuturisticChastityBeltPunishStruggle"), DialogFocusItem.Property.PunishStruggle, "White");
+		DrawCheckboxColor(1100, 690, 64, 64, DialogFindPlayer("FuturisticChastityBeltPunishStruggleOther"), DialogFocusItem.Property.PunishStruggleOther, "White");
+		DrawCheckboxColor(1100, 760, 64, 64, DialogFindPlayer("FuturisticChastityBeltPunishOrgasm"), DialogFocusItem.Property.PunishOrgasm, "White");
 		MainCanvas.textAlign = "center";
 
 		if (DialogFocusItem.Property.Type != null) {
-			DrawButton(1225, 910, 150, 64, GetPlayerDialog("FuturisticChastityBeltOpenBack"), "White", "");
+			DrawButton(1225, 910, 150, 64, DialogFindPlayer("FuturisticChastityBeltOpenBack"), "White", "");
 		} 
 		if (DialogFocusItem.Property.Type != "OpenFront") {
-			DrawButton(1425, 910, 150, 64, GetPlayerDialog("FuturisticChastityBeltOpenFront"), "White", "");
+			DrawButton(1425, 910, 150, 64, DialogFindPlayer("FuturisticChastityBeltOpenFront"), "White", "");
 		}
 		if (DialogFocusItem.Property.Type != "ClosedBack") {
-			DrawButton(1625, 910, 150, 64, GetPlayerDialog("FuturisticChastityBeltClosedBack"), "White", "");
+			DrawButton(1625, 910, 150, 64, DialogFindPlayer("FuturisticChastityBeltClosedBack"), "White", "");
 		}
 
 		

--- a/BondageClub/Screens/Inventory/ItemPelvis/FuturisticChastityBelt/FuturisticChastityBelt.js
+++ b/BondageClub/Screens/Inventory/ItemPelvis/FuturisticChastityBelt/FuturisticChastityBelt.js
@@ -56,28 +56,28 @@ function InventoryItemPelvisFuturisticChastityBeltDraw() {
 		DrawRect(1387, 125, 225, 275, "white");
 		DrawImageResize("Assets/" + DialogFocusItem.Asset.Group.Family + "/" + DialogFocusItem.Asset.Group.Name + "/Preview/" + DialogFocusItem.Asset.Name + ".png", 1389, 127, 221, 221);
 		DrawTextFit(DialogFocusItem.Asset.Description, 1500, 375, 221, "black");
-		
+
 		if (DialogFocusItem.Property.NextShockTime - CurrentTime > 0)
-			DrawText(DialogFind(Player, "FuturisticChastityBeltTime") + " " + TimerToString(DialogFocusItem.Property.NextShockTime - CurrentTime), 1500, 475, "White", "Gray");
+			DrawText(GetPlayerDialog("FuturisticChastityBeltTime") + " " + TimerToString(DialogFocusItem.Property.NextShockTime - CurrentTime), 1500, 475, "White", "Gray");
 		else
-			DrawText(DialogFind(Player, "FuturisticChastityBeltTimeReady"), 1500, 475, "White", "Gray");
-			
-		
+			DrawText(GetPlayerDialog("FuturisticChastityBeltTimeReady"), 1500, 475, "White", "Gray");
+
+
 		MainCanvas.textAlign = "left";
-		DrawCheckboxColor(1100, 550, 64, 64, DialogFind(Player, "FuturisticChastityBeltPunishChatMessage"), DialogFocusItem.Property.ChatMessage, "White");
-		DrawCheckboxColor(1100, 620, 64, 64, DialogFind(Player, "FuturisticChastityBeltPunishStruggle"), DialogFocusItem.Property.PunishStruggle, "White");
-		DrawCheckboxColor(1100, 690, 64, 64, DialogFind(Player, "FuturisticChastityBeltPunishStruggleOther"), DialogFocusItem.Property.PunishStruggleOther, "White");
-		DrawCheckboxColor(1100, 760, 64, 64, DialogFind(Player, "FuturisticChastityBeltPunishOrgasm"), DialogFocusItem.Property.PunishOrgasm, "White");
+		DrawCheckboxColor(1100, 550, 64, 64, GetPlayerDialog("FuturisticChastityBeltPunishChatMessage"), DialogFocusItem.Property.ChatMessage, "White");
+		DrawCheckboxColor(1100, 620, 64, 64, GetPlayerDialog("FuturisticChastityBeltPunishStruggle"), DialogFocusItem.Property.PunishStruggle, "White");
+		DrawCheckboxColor(1100, 690, 64, 64, GetPlayerDialog("FuturisticChastityBeltPunishStruggleOther"), DialogFocusItem.Property.PunishStruggleOther, "White");
+		DrawCheckboxColor(1100, 760, 64, 64, GetPlayerDialog("FuturisticChastityBeltPunishOrgasm"), DialogFocusItem.Property.PunishOrgasm, "White");
 		MainCanvas.textAlign = "center";
 
 		if (DialogFocusItem.Property.Type != null) {
-			DrawButton(1225, 910, 150, 64, DialogFind(Player, "FuturisticChastityBeltOpenBack"), "White", "");
+			DrawButton(1225, 910, 150, 64, GetPlayerDialog("FuturisticChastityBeltOpenBack"), "White", "");
 		} 
 		if (DialogFocusItem.Property.Type != "OpenFront") {
-			DrawButton(1425, 910, 150, 64, DialogFind(Player, "FuturisticChastityBeltOpenFront"), "White", "");
+			DrawButton(1425, 910, 150, 64, GetPlayerDialog("FuturisticChastityBeltOpenFront"), "White", "");
 		}
 		if (DialogFocusItem.Property.Type != "ClosedBack") {
-			DrawButton(1625, 910, 150, 64, DialogFind(Player, "FuturisticChastityBeltClosedBack"), "White", "");
+			DrawButton(1625, 910, 150, 64, GetPlayerDialog("FuturisticChastityBeltClosedBack"), "White", "");
 		}
 
 		

--- a/BondageClub/Screens/Inventory/ItemPelvis/LoveChastityBelt/LoveChastityBelt.js
+++ b/BondageClub/Screens/Inventory/ItemPelvis/LoveChastityBelt/LoveChastityBelt.js
@@ -20,33 +20,33 @@ function InventoryItemPelvisLoveChastityBeltDraw() {
   else DrawImageResize("Assets/" + DialogFocusItem.Asset.Group.Family + "/" + DialogFocusItem.Asset.Group.Name + "/Preview/" + DialogFocusItem.Asset.Name + ".png", 1389, 227, 221, 221);
   DrawTextFit(DialogFocusItem.Asset.Description, 1500, 475, 221, "black");
   if ((DialogFocusItem.Property.Type == "Shock") || (DialogFocusItem.Property.Type == "Vibe"))
-    DrawText(GetPlayerDialog("Intensity" + DialogFocusItem.Property.Intensity.toString()).replace("Item", DialogFocusItem.Asset.Description), 1500, 550, "White", "Gray");
+    DrawText(DialogFindPlayer("Intensity" + DialogFocusItem.Property.Intensity.toString()).replace("Item", DialogFocusItem.Asset.Description), 1500, 550, "White", "Gray");
 
 
   DrawTextFit(DialogFocusItem.Asset.Description, 1500, 475, 221, "black");
 
   if (CharacterGetCurrent().IsOwnedByPlayer()) {
 
-    if ((DialogFocusItem.Property.Type == "Vibe") && (DialogFocusItem.Property.Intensity > -1)) DrawButton(1200, 600, 250, 65, GetPlayerDialog("TurnOff"), "White");
+    if ((DialogFocusItem.Property.Type == "Vibe") && (DialogFocusItem.Property.Intensity > -1)) DrawButton(1200, 600, 250, 65, DialogFindPlayer("TurnOff"), "White");
     if (DialogFocusItem.Property.Type == "Shock") {
-      DrawButton(1200, 600, 250, 65, GetPlayerDialog("TriggerShock"), "White");
+      DrawButton(1200, 600, 250, 65, DialogFindPlayer("TriggerShock"), "White");
       if (CurrentScreen == "ChatRoom" || true) {
         DrawButton(1200, 900, 64, 64, "", "White", DialogFocusItem.Property.ShowText ? "Icons/Checked.png" : "");
-        DrawText(GetPlayerDialog("ShockCollarShowChat"), 1445, 933, "White", "Gray");
+        DrawText(DialogFindPlayer("ShockCollarShowChat"), 1445, 933, "White", "Gray");
       }
     }
-    if (InventoryItemPelvisLoveChastityBeltIntensityCanDecrease()) DrawButton(1200, 700, 250, 65, GetPlayerDialog("Decrease"), "White");
-    if (InventoryItemPelvisLoveChastityBeltIntensityCanIncrease()) DrawButton(1550, 700, 250, 65, GetPlayerDialog("Increase"), "White");
+    if (InventoryItemPelvisLoveChastityBeltIntensityCanDecrease()) DrawButton(1200, 700, 250, 65, DialogFindPlayer("Decrease"), "White");
+    if (InventoryItemPelvisLoveChastityBeltIntensityCanIncrease()) DrawButton(1550, 700, 250, 65, DialogFindPlayer("Increase"), "White");
 
-    DrawButton(1550, 800, 250, 65, GetPlayerDialog(DialogFocusItem.Property.LockButt ? "LoveChastityBeltUnlockButt" : "LoveChastityBeltLockButt"), "White");
+    DrawButton(1550, 800, 250, 65, DialogFindPlayer(DialogFocusItem.Property.LockButt ? "LoveChastityBeltUnlockButt" : "LoveChastityBeltLockButt"), "White");
 
     if ((DialogFocusItem.Property.Type == "Closed") || (DialogFocusItem.Property.Type == "Vibe") || (DialogFocusItem.Property.Type == "Shock")) {
-      DrawButton(1200, 800, 250, 65, GetPlayerDialog("LoveChastityBeltUnlock" + DialogFocusItem.Property.Type), "White");
+      DrawButton(1200, 800, 250, 65, DialogFindPlayer("LoveChastityBeltUnlock" + DialogFocusItem.Property.Type), "White");
     } else {
-      DrawButton(1200, 800, 250, 65, GetPlayerDialog("LoveChastityBeltAddShield"), "White");
+      DrawButton(1200, 800, 250, 65, DialogFindPlayer("LoveChastityBeltAddShield"), "White");
       if (InventoryItemPelvisLoveChastityBeltCanInsert(CharacterGetCurrent())) {
-        DrawButton(1200, 900, 250, 65, GetPlayerDialog("LoveChastityBeltAddVibe"), "White");
-        DrawButton(1550, 900, 250, 65, GetPlayerDialog("LoveChastityBeltAddShock"), "White");
+        DrawButton(1200, 900, 250, 65, DialogFindPlayer("LoveChastityBeltAddVibe"), "White");
+        DrawButton(1550, 900, 250, 65, DialogFindPlayer("LoveChastityBeltAddShock"), "White");
       }
     }
   }

--- a/BondageClub/Screens/Inventory/ItemPelvis/LoveChastityBelt/LoveChastityBelt.js
+++ b/BondageClub/Screens/Inventory/ItemPelvis/LoveChastityBelt/LoveChastityBelt.js
@@ -20,33 +20,33 @@ function InventoryItemPelvisLoveChastityBeltDraw() {
   else DrawImageResize("Assets/" + DialogFocusItem.Asset.Group.Family + "/" + DialogFocusItem.Asset.Group.Name + "/Preview/" + DialogFocusItem.Asset.Name + ".png", 1389, 227, 221, 221);
   DrawTextFit(DialogFocusItem.Asset.Description, 1500, 475, 221, "black");
   if ((DialogFocusItem.Property.Type == "Shock") || (DialogFocusItem.Property.Type == "Vibe"))
-    DrawText(DialogFind(Player, "Intensity" + DialogFocusItem.Property.Intensity.toString()).replace("Item", DialogFocusItem.Asset.Description), 1500, 550, "White", "Gray");
+    DrawText(GetPlayerDialog("Intensity" + DialogFocusItem.Property.Intensity.toString()).replace("Item", DialogFocusItem.Asset.Description), 1500, 550, "White", "Gray");
 
 
   DrawTextFit(DialogFocusItem.Asset.Description, 1500, 475, 221, "black");
 
   if (CharacterGetCurrent().IsOwnedByPlayer()) {
 
-    if ((DialogFocusItem.Property.Type == "Vibe") && (DialogFocusItem.Property.Intensity > -1)) DrawButton(1200, 600, 250, 65, DialogFind(Player, "TurnOff"), "White");
+    if ((DialogFocusItem.Property.Type == "Vibe") && (DialogFocusItem.Property.Intensity > -1)) DrawButton(1200, 600, 250, 65, GetPlayerDialog("TurnOff"), "White");
     if (DialogFocusItem.Property.Type == "Shock") {
-      DrawButton(1200, 600, 250, 65, DialogFind(Player, "TriggerShock"), "White");
+      DrawButton(1200, 600, 250, 65, GetPlayerDialog("TriggerShock"), "White");
       if (CurrentScreen == "ChatRoom" || true) {
         DrawButton(1200, 900, 64, 64, "", "White", DialogFocusItem.Property.ShowText ? "Icons/Checked.png" : "");
-        DrawText(DialogFind(Player, "ShockCollarShowChat"), 1445, 933, "White", "Gray");
+        DrawText(GetPlayerDialog("ShockCollarShowChat"), 1445, 933, "White", "Gray");
       }
     }
-    if (InventoryItemPelvisLoveChastityBeltIntensityCanDecrease()) DrawButton(1200, 700, 250, 65, DialogFind(Player, "Decrease"), "White");
-    if (InventoryItemPelvisLoveChastityBeltIntensityCanIncrease()) DrawButton(1550, 700, 250, 65, DialogFind(Player, "Increase"), "White");
+    if (InventoryItemPelvisLoveChastityBeltIntensityCanDecrease()) DrawButton(1200, 700, 250, 65, GetPlayerDialog("Decrease"), "White");
+    if (InventoryItemPelvisLoveChastityBeltIntensityCanIncrease()) DrawButton(1550, 700, 250, 65, GetPlayerDialog("Increase"), "White");
 
-    DrawButton(1550, 800, 250, 65, DialogFind(Player, DialogFocusItem.Property.LockButt ? "LoveChastityBeltUnlockButt" : "LoveChastityBeltLockButt"), "White");
+    DrawButton(1550, 800, 250, 65, GetPlayerDialog(DialogFocusItem.Property.LockButt ? "LoveChastityBeltUnlockButt" : "LoveChastityBeltLockButt"), "White");
 
     if ((DialogFocusItem.Property.Type == "Closed") || (DialogFocusItem.Property.Type == "Vibe") || (DialogFocusItem.Property.Type == "Shock")) {
-      DrawButton(1200, 800, 250, 65, DialogFind(Player, "LoveChastityBeltUnlock" + DialogFocusItem.Property.Type), "White");
+      DrawButton(1200, 800, 250, 65, GetPlayerDialog("LoveChastityBeltUnlock" + DialogFocusItem.Property.Type), "White");
     } else {
-      DrawButton(1200, 800, 250, 65, DialogFind(Player, "LoveChastityBeltAddShield"), "White");
+      DrawButton(1200, 800, 250, 65, GetPlayerDialog("LoveChastityBeltAddShield"), "White");
       if (InventoryItemPelvisLoveChastityBeltCanInsert(CharacterGetCurrent())) {
-        DrawButton(1200, 900, 250, 65, DialogFind(Player, "LoveChastityBeltAddVibe"), "White");
-        DrawButton(1550, 900, 250, 65, DialogFind(Player, "LoveChastityBeltAddShock"), "White");
+        DrawButton(1200, 900, 250, 65, GetPlayerDialog("LoveChastityBeltAddVibe"), "White");
+        DrawButton(1550, 900, 250, 65, GetPlayerDialog("LoveChastityBeltAddShock"), "White");
       }
     }
   }

--- a/BondageClub/Screens/Inventory/ItemPelvis/MetalChastityBelt/MetalChastityBelt.js
+++ b/BondageClub/Screens/Inventory/ItemPelvis/MetalChastityBelt/MetalChastityBelt.js
@@ -65,7 +65,7 @@ function InventoryItemPelvisMetalChastityBeltValidate(C) {
 	var Allowed = "";
 
 	if (DialogFocusItem.Property.LockedBy && !DialogCanUnlock(C, DialogFocusItem)) {
-		Allowed = GetPlayerDialog("CantChangeWhileLocked");
+		Allowed = DialogFindPlayer("CantChangeWhileLocked");
 	}
 
 	return Allowed;

--- a/BondageClub/Screens/Inventory/ItemPelvis/MetalChastityBelt/MetalChastityBelt.js
+++ b/BondageClub/Screens/Inventory/ItemPelvis/MetalChastityBelt/MetalChastityBelt.js
@@ -65,8 +65,8 @@ function InventoryItemPelvisMetalChastityBeltValidate(C) {
 	var Allowed = "";
 
 	if (DialogFocusItem.Property.LockedBy && !DialogCanUnlock(C, DialogFocusItem)) {
-		Allowed = DialogFind(Player, "CantChangeWhileLocked");
-	} 
+		Allowed = GetPlayerDialog("CantChangeWhileLocked");
+	}
 
 	return Allowed;
 }

--- a/BondageClub/Screens/Inventory/ItemVulva/ClitAndDildoVibratorbelt/ClitAndDildoVibratorbelt.js
+++ b/BondageClub/Screens/Inventory/ItemVulva/ClitAndDildoVibratorbelt/ClitAndDildoVibratorbelt.js
@@ -19,24 +19,24 @@ function InventoryItemVulvaClitAndDildoVibratorbeltDraw() {
 		DrawImageResize("Assets/" + DialogFocusItem.Asset.Group.Family + "/" + DialogFocusItem.Asset.Group.Name + "/Preview/" + DialogFocusItem.Asset.Name + ".png", 1389 + Math.floor(Math.random() * 3) - 1, 227 + Math.floor(Math.random() * 3) - 1, 221, 221);
 	else DrawImageResize("Assets/" + DialogFocusItem.Asset.Group.Family + "/" + DialogFocusItem.Asset.Group.Name + "/Preview/" + DialogFocusItem.Asset.Name + ".png", 1389, 227, 221, 221);
 	DrawTextFit(DialogFocusItem.Asset.Description, 1500, 475, 221, "black");
-	DrawText(GetPlayerDialog("DildoIntensity" + DialogFocusItem.Property.Intensity.toString()), 1500, 750, "White", "Gray");
-	if (DialogFocusItem.Property.Intensity > -1) DrawButton(1200, 775, 200, 55, GetPlayerDialog("TurnOff"), "White");
-	if (DialogFocusItem.Property.Intensity < 0) DrawButton(1550, 775, 200, 55, GetPlayerDialog("Low"), "White");
-	if (DialogFocusItem.Property.Intensity > 0) DrawButton(1550, 775, 200, 55, GetPlayerDialog("Low"), "White");
-	if (DialogFocusItem.Property.Intensity < 1) DrawButton(1200, 835, 200, 55, GetPlayerDialog("Medium"), "White");
-	if (DialogFocusItem.Property.Intensity > 1) DrawButton(1200, 835, 200, 55, GetPlayerDialog("Medium"), "White");
-	if (DialogFocusItem.Property.Intensity < 2) DrawButton(1550, 835, 200, 55, GetPlayerDialog("High"), "White");
-	if (DialogFocusItem.Property.Intensity > 2) DrawButton(1550, 835, 200, 55, GetPlayerDialog("High"), "White");
-	if (DialogFocusItem.Property.Intensity < 3) DrawButton(1375, 895, 200, 55, GetPlayerDialog("Maximum"), "White");
-	DrawText(GetPlayerDialog("EggIntensity" + DialogFocusItem.Property.Intensity.toString()), 1500, 525, "White", "Gray");
-	if (DialogFocusItem.Property.Intensity > -1) DrawButton(1200, 550, 200, 55, GetPlayerDialog("TurnOff"), "White");
-	if (DialogFocusItem.Property.Intensity < 0) DrawButton(1550, 550, 200, 55, GetPlayerDialog("Low"), "White");
-	if (DialogFocusItem.Property.Intensity > 0) DrawButton(1550, 550, 200, 55, GetPlayerDialog("Low"), "White");
-	if (DialogFocusItem.Property.Intensity < 1) DrawButton(1200, 610, 200, 55, GetPlayerDialog("Medium"), "White");
-	if (DialogFocusItem.Property.Intensity > 1) DrawButton(1200, 610, 200, 55, GetPlayerDialog("Medium"), "White");
-	if (DialogFocusItem.Property.Intensity < 2) DrawButton(1550, 610, 200, 55, GetPlayerDialog("High"), "White");
-	if (DialogFocusItem.Property.Intensity > 2) DrawButton(1550, 610, 200, 55, GetPlayerDialog("High"), "White");
-	if (DialogFocusItem.Property.Intensity < 3) DrawButton(1375, 670, 200, 55, GetPlayerDialog("Maximum"), "White");
+	DrawText(DialogFindPlayer("DildoIntensity" + DialogFocusItem.Property.Intensity.toString()), 1500, 750, "White", "Gray");
+	if (DialogFocusItem.Property.Intensity > -1) DrawButton(1200, 775, 200, 55, DialogFindPlayer("TurnOff"), "White");
+	if (DialogFocusItem.Property.Intensity < 0) DrawButton(1550, 775, 200, 55, DialogFindPlayer("Low"), "White");
+	if (DialogFocusItem.Property.Intensity > 0) DrawButton(1550, 775, 200, 55, DialogFindPlayer("Low"), "White");
+	if (DialogFocusItem.Property.Intensity < 1) DrawButton(1200, 835, 200, 55, DialogFindPlayer("Medium"), "White");
+	if (DialogFocusItem.Property.Intensity > 1) DrawButton(1200, 835, 200, 55, DialogFindPlayer("Medium"), "White");
+	if (DialogFocusItem.Property.Intensity < 2) DrawButton(1550, 835, 200, 55, DialogFindPlayer("High"), "White");
+	if (DialogFocusItem.Property.Intensity > 2) DrawButton(1550, 835, 200, 55, DialogFindPlayer("High"), "White");
+	if (DialogFocusItem.Property.Intensity < 3) DrawButton(1375, 895, 200, 55, DialogFindPlayer("Maximum"), "White");
+	DrawText(DialogFindPlayer("EggIntensity" + DialogFocusItem.Property.Intensity.toString()), 1500, 525, "White", "Gray");
+	if (DialogFocusItem.Property.Intensity > -1) DrawButton(1200, 550, 200, 55, DialogFindPlayer("TurnOff"), "White");
+	if (DialogFocusItem.Property.Intensity < 0) DrawButton(1550, 550, 200, 55, DialogFindPlayer("Low"), "White");
+	if (DialogFocusItem.Property.Intensity > 0) DrawButton(1550, 550, 200, 55, DialogFindPlayer("Low"), "White");
+	if (DialogFocusItem.Property.Intensity < 1) DrawButton(1200, 610, 200, 55, DialogFindPlayer("Medium"), "White");
+	if (DialogFocusItem.Property.Intensity > 1) DrawButton(1200, 610, 200, 55, DialogFindPlayer("Medium"), "White");
+	if (DialogFocusItem.Property.Intensity < 2) DrawButton(1550, 610, 200, 55, DialogFindPlayer("High"), "White");
+	if (DialogFocusItem.Property.Intensity > 2) DrawButton(1550, 610, 200, 55, DialogFindPlayer("High"), "White");
+	if (DialogFocusItem.Property.Intensity < 3) DrawButton(1375, 670, 200, 55, DialogFindPlayer("Maximum"), "White");
 }
 
 // Catches the item extension clicks

--- a/BondageClub/Screens/Inventory/ItemVulva/ClitAndDildoVibratorbelt/ClitAndDildoVibratorbelt.js
+++ b/BondageClub/Screens/Inventory/ItemVulva/ClitAndDildoVibratorbelt/ClitAndDildoVibratorbelt.js
@@ -19,24 +19,24 @@ function InventoryItemVulvaClitAndDildoVibratorbeltDraw() {
 		DrawImageResize("Assets/" + DialogFocusItem.Asset.Group.Family + "/" + DialogFocusItem.Asset.Group.Name + "/Preview/" + DialogFocusItem.Asset.Name + ".png", 1389 + Math.floor(Math.random() * 3) - 1, 227 + Math.floor(Math.random() * 3) - 1, 221, 221);
 	else DrawImageResize("Assets/" + DialogFocusItem.Asset.Group.Family + "/" + DialogFocusItem.Asset.Group.Name + "/Preview/" + DialogFocusItem.Asset.Name + ".png", 1389, 227, 221, 221);
 	DrawTextFit(DialogFocusItem.Asset.Description, 1500, 475, 221, "black");
-	DrawText(DialogFind(Player, "DildoIntensity" + DialogFocusItem.Property.Intensity.toString()), 1500, 750, "White", "Gray");
-	if (DialogFocusItem.Property.Intensity > -1) DrawButton(1200, 775, 200, 55, DialogFind(Player, "TurnOff"), "White");
-	if (DialogFocusItem.Property.Intensity < 0) DrawButton(1550, 775, 200, 55, DialogFind(Player, "Low"), "White");
-	if (DialogFocusItem.Property.Intensity > 0) DrawButton(1550, 775, 200, 55, DialogFind(Player, "Low"), "White");
-	if (DialogFocusItem.Property.Intensity < 1) DrawButton(1200, 835, 200, 55, DialogFind(Player, "Medium"), "White");
-	if (DialogFocusItem.Property.Intensity > 1) DrawButton(1200, 835, 200, 55, DialogFind(Player, "Medium"), "White");
-	if (DialogFocusItem.Property.Intensity < 2) DrawButton(1550, 835, 200, 55, DialogFind(Player, "High"), "White");
-	if (DialogFocusItem.Property.Intensity > 2) DrawButton(1550, 835, 200, 55, DialogFind(Player, "High"), "White");
-	if (DialogFocusItem.Property.Intensity < 3) DrawButton(1375, 895, 200, 55, DialogFind(Player, "Maximum"), "White");
-	DrawText(DialogFind(Player, "EggIntensity" + DialogFocusItem.Property.Intensity.toString()), 1500, 525, "White", "Gray");
-	if (DialogFocusItem.Property.Intensity > -1) DrawButton(1200, 550, 200, 55, DialogFind(Player, "TurnOff"), "White");
-	if (DialogFocusItem.Property.Intensity < 0) DrawButton(1550, 550, 200, 55, DialogFind(Player, "Low"), "White");
-	if (DialogFocusItem.Property.Intensity > 0) DrawButton(1550, 550, 200, 55, DialogFind(Player, "Low"), "White");
-	if (DialogFocusItem.Property.Intensity < 1) DrawButton(1200, 610, 200, 55, DialogFind(Player, "Medium"), "White");
-	if (DialogFocusItem.Property.Intensity > 1) DrawButton(1200, 610, 200, 55, DialogFind(Player, "Medium"), "White");
-	if (DialogFocusItem.Property.Intensity < 2) DrawButton(1550, 610, 200, 55, DialogFind(Player, "High"), "White");
-	if (DialogFocusItem.Property.Intensity > 2) DrawButton(1550, 610, 200, 55, DialogFind(Player, "High"), "White");
-	if (DialogFocusItem.Property.Intensity < 3) DrawButton(1375, 670, 200, 55, DialogFind(Player, "Maximum"), "White");
+	DrawText(GetPlayerDialog("DildoIntensity" + DialogFocusItem.Property.Intensity.toString()), 1500, 750, "White", "Gray");
+	if (DialogFocusItem.Property.Intensity > -1) DrawButton(1200, 775, 200, 55, GetPlayerDialog("TurnOff"), "White");
+	if (DialogFocusItem.Property.Intensity < 0) DrawButton(1550, 775, 200, 55, GetPlayerDialog("Low"), "White");
+	if (DialogFocusItem.Property.Intensity > 0) DrawButton(1550, 775, 200, 55, GetPlayerDialog("Low"), "White");
+	if (DialogFocusItem.Property.Intensity < 1) DrawButton(1200, 835, 200, 55, GetPlayerDialog("Medium"), "White");
+	if (DialogFocusItem.Property.Intensity > 1) DrawButton(1200, 835, 200, 55, GetPlayerDialog("Medium"), "White");
+	if (DialogFocusItem.Property.Intensity < 2) DrawButton(1550, 835, 200, 55, GetPlayerDialog("High"), "White");
+	if (DialogFocusItem.Property.Intensity > 2) DrawButton(1550, 835, 200, 55, GetPlayerDialog("High"), "White");
+	if (DialogFocusItem.Property.Intensity < 3) DrawButton(1375, 895, 200, 55, GetPlayerDialog("Maximum"), "White");
+	DrawText(GetPlayerDialog("EggIntensity" + DialogFocusItem.Property.Intensity.toString()), 1500, 525, "White", "Gray");
+	if (DialogFocusItem.Property.Intensity > -1) DrawButton(1200, 550, 200, 55, GetPlayerDialog("TurnOff"), "White");
+	if (DialogFocusItem.Property.Intensity < 0) DrawButton(1550, 550, 200, 55, GetPlayerDialog("Low"), "White");
+	if (DialogFocusItem.Property.Intensity > 0) DrawButton(1550, 550, 200, 55, GetPlayerDialog("Low"), "White");
+	if (DialogFocusItem.Property.Intensity < 1) DrawButton(1200, 610, 200, 55, GetPlayerDialog("Medium"), "White");
+	if (DialogFocusItem.Property.Intensity > 1) DrawButton(1200, 610, 200, 55, GetPlayerDialog("Medium"), "White");
+	if (DialogFocusItem.Property.Intensity < 2) DrawButton(1550, 610, 200, 55, GetPlayerDialog("High"), "White");
+	if (DialogFocusItem.Property.Intensity > 2) DrawButton(1550, 610, 200, 55, GetPlayerDialog("High"), "White");
+	if (DialogFocusItem.Property.Intensity < 3) DrawButton(1375, 670, 200, 55, GetPlayerDialog("Maximum"), "White");
 }
 
 // Catches the item extension clicks

--- a/BondageClub/Screens/Inventory/ItemVulva/InflatableVibeDildo/InflatableVibeDildo.js
+++ b/BondageClub/Screens/Inventory/ItemVulva/InflatableVibeDildo/InflatableVibeDildo.js
@@ -15,24 +15,24 @@ function InventoryItemVulvaInflatableVibeDildoDraw() {
 		DrawImageResize("Assets/" + DialogFocusItem.Asset.Group.Family + "/" + DialogFocusItem.Asset.Group.Name + "/Preview/" + DialogFocusItem.Asset.Name + ".png", 1389 + Math.floor(Math.random() * 3) - 1, 227 + Math.floor(Math.random() * 3) - 1, 221, 221);
 	else DrawImageResize("Assets/" + DialogFocusItem.Asset.Group.Family + "/" + DialogFocusItem.Asset.Group.Name + "/Preview/" + DialogFocusItem.Asset.Name + ".png", 1389, 227, 221, 221);
 	DrawTextFit(DialogFocusItem.Asset.Description, 1500, 475, 221, "black");
-	DrawText(GetPlayerDialog("InflateLevel" + DialogFocusItem.Property.InflateLevel.toString()), 1500, 750, "White", "Gray");
-	if (DialogFocusItem.Property.InflateLevel > 0) DrawButton(1200, 775, 200, 55, GetPlayerDialog("Empty"), "White");
-	if (DialogFocusItem.Property.InflateLevel < 1) DrawButton(1550, 775, 200, 55, GetPlayerDialog("Light"), "White");
-	if (DialogFocusItem.Property.InflateLevel > 1) DrawButton(1550, 775, 200, 55, GetPlayerDialog("Light"), "White");
-	if (DialogFocusItem.Property.InflateLevel < 2) DrawButton(1200, 835, 200, 55, GetPlayerDialog("Inflated"), "White");
-	if (DialogFocusItem.Property.InflateLevel > 2) DrawButton(1200, 835, 200, 55, GetPlayerDialog("Inflated"), "White");
-	if (DialogFocusItem.Property.InflateLevel < 3) DrawButton(1550, 835, 200, 55, GetPlayerDialog("Bloated"), "White");
-	if (DialogFocusItem.Property.InflateLevel > 3) DrawButton(1550, 835, 200, 55, GetPlayerDialog("Bloated"), "White");
-	if (DialogFocusItem.Property.InflateLevel < 4) DrawButton(1375, 895, 200, 55, GetPlayerDialog("Maximum"), "White");
-	DrawText(GetPlayerDialog("Intensity" + DialogFocusItem.Property.Intensity.toString()), 1500, 525, "White", "Gray");
-	if (DialogFocusItem.Property.Intensity > -1) DrawButton(1200, 550, 200, 55, GetPlayerDialog("TurnOff"), "White");
-	if (DialogFocusItem.Property.Intensity < 0) DrawButton(1550, 550, 200, 55, GetPlayerDialog("Low"), "White");
-	if (DialogFocusItem.Property.Intensity > 0) DrawButton(1550, 550, 200, 55, GetPlayerDialog("Low"), "White");
-	if (DialogFocusItem.Property.Intensity < 1) DrawButton(1200, 610, 200, 55, GetPlayerDialog("Medium"), "White");
-	if (DialogFocusItem.Property.Intensity > 1) DrawButton(1200, 610, 200, 55, GetPlayerDialog("Medium"), "White");
-	if (DialogFocusItem.Property.Intensity < 2) DrawButton(1550, 610, 200, 55, GetPlayerDialog("High"), "White");
-	if (DialogFocusItem.Property.Intensity > 2) DrawButton(1550, 610, 200, 55, GetPlayerDialog("High"), "White");
-	if (DialogFocusItem.Property.Intensity < 3) DrawButton(1375, 670, 200, 55, GetPlayerDialog("Maximum"), "White");
+	DrawText(DialogFindPlayer("InflateLevel" + DialogFocusItem.Property.InflateLevel.toString()), 1500, 750, "White", "Gray");
+	if (DialogFocusItem.Property.InflateLevel > 0) DrawButton(1200, 775, 200, 55, DialogFindPlayer("Empty"), "White");
+	if (DialogFocusItem.Property.InflateLevel < 1) DrawButton(1550, 775, 200, 55, DialogFindPlayer("Light"), "White");
+	if (DialogFocusItem.Property.InflateLevel > 1) DrawButton(1550, 775, 200, 55, DialogFindPlayer("Light"), "White");
+	if (DialogFocusItem.Property.InflateLevel < 2) DrawButton(1200, 835, 200, 55, DialogFindPlayer("Inflated"), "White");
+	if (DialogFocusItem.Property.InflateLevel > 2) DrawButton(1200, 835, 200, 55, DialogFindPlayer("Inflated"), "White");
+	if (DialogFocusItem.Property.InflateLevel < 3) DrawButton(1550, 835, 200, 55, DialogFindPlayer("Bloated"), "White");
+	if (DialogFocusItem.Property.InflateLevel > 3) DrawButton(1550, 835, 200, 55, DialogFindPlayer("Bloated"), "White");
+	if (DialogFocusItem.Property.InflateLevel < 4) DrawButton(1375, 895, 200, 55, DialogFindPlayer("Maximum"), "White");
+	DrawText(DialogFindPlayer("Intensity" + DialogFocusItem.Property.Intensity.toString()), 1500, 525, "White", "Gray");
+	if (DialogFocusItem.Property.Intensity > -1) DrawButton(1200, 550, 200, 55, DialogFindPlayer("TurnOff"), "White");
+	if (DialogFocusItem.Property.Intensity < 0) DrawButton(1550, 550, 200, 55, DialogFindPlayer("Low"), "White");
+	if (DialogFocusItem.Property.Intensity > 0) DrawButton(1550, 550, 200, 55, DialogFindPlayer("Low"), "White");
+	if (DialogFocusItem.Property.Intensity < 1) DrawButton(1200, 610, 200, 55, DialogFindPlayer("Medium"), "White");
+	if (DialogFocusItem.Property.Intensity > 1) DrawButton(1200, 610, 200, 55, DialogFindPlayer("Medium"), "White");
+	if (DialogFocusItem.Property.Intensity < 2) DrawButton(1550, 610, 200, 55, DialogFindPlayer("High"), "White");
+	if (DialogFocusItem.Property.Intensity > 2) DrawButton(1550, 610, 200, 55, DialogFindPlayer("High"), "White");
+	if (DialogFocusItem.Property.Intensity < 3) DrawButton(1375, 670, 200, 55, DialogFindPlayer("Maximum"), "White");
 }
 
 // Catches the item extension clicks

--- a/BondageClub/Screens/Inventory/ItemVulva/InflatableVibeDildo/InflatableVibeDildo.js
+++ b/BondageClub/Screens/Inventory/ItemVulva/InflatableVibeDildo/InflatableVibeDildo.js
@@ -15,24 +15,24 @@ function InventoryItemVulvaInflatableVibeDildoDraw() {
 		DrawImageResize("Assets/" + DialogFocusItem.Asset.Group.Family + "/" + DialogFocusItem.Asset.Group.Name + "/Preview/" + DialogFocusItem.Asset.Name + ".png", 1389 + Math.floor(Math.random() * 3) - 1, 227 + Math.floor(Math.random() * 3) - 1, 221, 221);
 	else DrawImageResize("Assets/" + DialogFocusItem.Asset.Group.Family + "/" + DialogFocusItem.Asset.Group.Name + "/Preview/" + DialogFocusItem.Asset.Name + ".png", 1389, 227, 221, 221);
 	DrawTextFit(DialogFocusItem.Asset.Description, 1500, 475, 221, "black");
-	DrawText(DialogFind(Player, "InflateLevel" + DialogFocusItem.Property.InflateLevel.toString()), 1500, 750, "White", "Gray");
-	if (DialogFocusItem.Property.InflateLevel > 0) DrawButton(1200, 775, 200, 55, DialogFind(Player, "Empty"), "White");
-	if (DialogFocusItem.Property.InflateLevel < 1) DrawButton(1550, 775, 200, 55, DialogFind(Player, "Light"), "White");
-	if (DialogFocusItem.Property.InflateLevel > 1) DrawButton(1550, 775, 200, 55, DialogFind(Player, "Light"), "White");
-	if (DialogFocusItem.Property.InflateLevel < 2) DrawButton(1200, 835, 200, 55, DialogFind(Player, "Inflated"), "White");
-	if (DialogFocusItem.Property.InflateLevel > 2) DrawButton(1200, 835, 200, 55, DialogFind(Player, "Inflated"), "White");
-	if (DialogFocusItem.Property.InflateLevel < 3) DrawButton(1550, 835, 200, 55, DialogFind(Player, "Bloated"), "White");
-	if (DialogFocusItem.Property.InflateLevel > 3) DrawButton(1550, 835, 200, 55, DialogFind(Player, "Bloated"), "White");
-	if (DialogFocusItem.Property.InflateLevel < 4) DrawButton(1375, 895, 200, 55, DialogFind(Player, "Maximum"), "White");
-	DrawText(DialogFind(Player, "Intensity" + DialogFocusItem.Property.Intensity.toString()), 1500, 525, "White", "Gray");
-	if (DialogFocusItem.Property.Intensity > -1) DrawButton(1200, 550, 200, 55, DialogFind(Player, "TurnOff"), "White");
-	if (DialogFocusItem.Property.Intensity < 0) DrawButton(1550, 550, 200, 55, DialogFind(Player, "Low"), "White");
-	if (DialogFocusItem.Property.Intensity > 0) DrawButton(1550, 550, 200, 55, DialogFind(Player, "Low"), "White");
-	if (DialogFocusItem.Property.Intensity < 1) DrawButton(1200, 610, 200, 55, DialogFind(Player, "Medium"), "White");
-	if (DialogFocusItem.Property.Intensity > 1) DrawButton(1200, 610, 200, 55, DialogFind(Player, "Medium"), "White");
-	if (DialogFocusItem.Property.Intensity < 2) DrawButton(1550, 610, 200, 55, DialogFind(Player, "High"), "White");
-	if (DialogFocusItem.Property.Intensity > 2) DrawButton(1550, 610, 200, 55, DialogFind(Player, "High"), "White");
-	if (DialogFocusItem.Property.Intensity < 3) DrawButton(1375, 670, 200, 55, DialogFind(Player, "Maximum"), "White");
+	DrawText(GetPlayerDialog("InflateLevel" + DialogFocusItem.Property.InflateLevel.toString()), 1500, 750, "White", "Gray");
+	if (DialogFocusItem.Property.InflateLevel > 0) DrawButton(1200, 775, 200, 55, GetPlayerDialog("Empty"), "White");
+	if (DialogFocusItem.Property.InflateLevel < 1) DrawButton(1550, 775, 200, 55, GetPlayerDialog("Light"), "White");
+	if (DialogFocusItem.Property.InflateLevel > 1) DrawButton(1550, 775, 200, 55, GetPlayerDialog("Light"), "White");
+	if (DialogFocusItem.Property.InflateLevel < 2) DrawButton(1200, 835, 200, 55, GetPlayerDialog("Inflated"), "White");
+	if (DialogFocusItem.Property.InflateLevel > 2) DrawButton(1200, 835, 200, 55, GetPlayerDialog("Inflated"), "White");
+	if (DialogFocusItem.Property.InflateLevel < 3) DrawButton(1550, 835, 200, 55, GetPlayerDialog("Bloated"), "White");
+	if (DialogFocusItem.Property.InflateLevel > 3) DrawButton(1550, 835, 200, 55, GetPlayerDialog("Bloated"), "White");
+	if (DialogFocusItem.Property.InflateLevel < 4) DrawButton(1375, 895, 200, 55, GetPlayerDialog("Maximum"), "White");
+	DrawText(GetPlayerDialog("Intensity" + DialogFocusItem.Property.Intensity.toString()), 1500, 525, "White", "Gray");
+	if (DialogFocusItem.Property.Intensity > -1) DrawButton(1200, 550, 200, 55, GetPlayerDialog("TurnOff"), "White");
+	if (DialogFocusItem.Property.Intensity < 0) DrawButton(1550, 550, 200, 55, GetPlayerDialog("Low"), "White");
+	if (DialogFocusItem.Property.Intensity > 0) DrawButton(1550, 550, 200, 55, GetPlayerDialog("Low"), "White");
+	if (DialogFocusItem.Property.Intensity < 1) DrawButton(1200, 610, 200, 55, GetPlayerDialog("Medium"), "White");
+	if (DialogFocusItem.Property.Intensity > 1) DrawButton(1200, 610, 200, 55, GetPlayerDialog("Medium"), "White");
+	if (DialogFocusItem.Property.Intensity < 2) DrawButton(1550, 610, 200, 55, GetPlayerDialog("High"), "White");
+	if (DialogFocusItem.Property.Intensity > 2) DrawButton(1550, 610, 200, 55, GetPlayerDialog("High"), "White");
+	if (DialogFocusItem.Property.Intensity < 3) DrawButton(1375, 670, 200, 55, GetPlayerDialog("Maximum"), "White");
 }
 
 // Catches the item extension clicks

--- a/BondageClub/Screens/Inventory/ItemVulva/LoversVibrator/LoversVibrator.js
+++ b/BondageClub/Screens/Inventory/ItemVulva/LoversVibrator/LoversVibrator.js
@@ -7,7 +7,7 @@ function InventoryItemVulvaLoversVibratorLoad() {
 function InventoryItemVulvaLoversVibratorDraw() {
 	var { Asset, Property } = DialogFocusItem;
 	VibratorModeDrawHeader();
-	var ItemMemberNumber = GetPlayerDialog("ItemMemberNumber").replace("Item", Asset.Description);
+	var ItemMemberNumber = DialogFindPlayer("ItemMemberNumber").replace("Item", Asset.Description);
 	DrawText(ItemMemberNumber + " " + Property.ItemMemberNumber, 1500, 450, "white", "gray");
 	VibratorModeDrawControls([VibratorModeSet.STANDARD, VibratorModeSet.ADVANCED], 525);
 }

--- a/BondageClub/Screens/Inventory/ItemVulva/LoversVibrator/LoversVibrator.js
+++ b/BondageClub/Screens/Inventory/ItemVulva/LoversVibrator/LoversVibrator.js
@@ -7,7 +7,7 @@ function InventoryItemVulvaLoversVibratorLoad() {
 function InventoryItemVulvaLoversVibratorDraw() {
 	var { Asset, Property } = DialogFocusItem;
 	VibratorModeDrawHeader();
-	var ItemMemberNumber = DialogFind(Player, "ItemMemberNumber").replace("Item", Asset.Description);
+	var ItemMemberNumber = GetPlayerDialog("ItemMemberNumber").replace("Item", Asset.Description);
 	DrawText(ItemMemberNumber + " " + Property.ItemMemberNumber, 1500, 450, "white", "gray");
 	VibratorModeDrawControls([VibratorModeSet.STANDARD, VibratorModeSet.ADVANCED], 525);
 }

--- a/BondageClub/Screens/Online/ChatAdmin/ChatAdmin.js
+++ b/BondageClub/Screens/Online/ChatAdmin/ChatAdmin.js
@@ -80,9 +80,9 @@ function ChatAdminRun() {
 
 	// Background selection, block button and game selection
 	DrawImageResize("Backgrounds/" + ChatAdminBackgroundSelect + "Dark.jpg", 1300, 75, 600, 350);
-	DrawBackNextButton(1300, 450, 500, 60, GetPlayerDialog(ChatAdminBackgroundSelect), ChatRoomPlayerIsAdmin() ? "White" : "#ebebe4", null,
-		() => GetPlayerDialog((ChatAdminBackgroundIndex == 0) ? ChatCreateBackgroundList[ChatCreateBackgroundList.length - 1] : ChatCreateBackgroundList[ChatAdminBackgroundIndex - 1]),
-		() => GetPlayerDialog((ChatAdminBackgroundIndex >= ChatCreateBackgroundList.length - 1) ? ChatCreateBackgroundList[0] : ChatCreateBackgroundList[ChatAdminBackgroundIndex + 1]), !ChatRoomPlayerIsAdmin());
+	DrawBackNextButton(1300, 450, 500, 60, DialogFindPlayer(ChatAdminBackgroundSelect), ChatRoomPlayerIsAdmin() ? "White" : "#ebebe4", null,
+		() => DialogFindPlayer((ChatAdminBackgroundIndex == 0) ? ChatCreateBackgroundList[ChatCreateBackgroundList.length - 1] : ChatCreateBackgroundList[ChatAdminBackgroundIndex - 1]),
+		() => DialogFindPlayer((ChatAdminBackgroundIndex >= ChatCreateBackgroundList.length - 1) ? ChatCreateBackgroundList[0] : ChatCreateBackgroundList[ChatAdminBackgroundIndex + 1]), !ChatRoomPlayerIsAdmin());
 	DrawButton(1840, 450, 60, 60, "", ChatRoomPlayerIsAdmin() ? "White" : "#ebebe4", "Icons/Small/Preference.png", null, !ChatRoomPlayerIsAdmin());
 	DrawButton(1300, 575, 275, 60, TextGet("BlockCategory"), ChatRoomPlayerIsAdmin() ? "White" : "#ebebe4", null, null, !ChatRoomPlayerIsAdmin());
 	DrawBackNextButton(1625, 575, 275, 60, TextGet("Game" + ChatAdminGame), ChatRoomPlayerIsAdmin() ? "White" : "#ebebe4", null, () => "", () => "");

--- a/BondageClub/Screens/Online/ChatAdmin/ChatAdmin.js
+++ b/BondageClub/Screens/Online/ChatAdmin/ChatAdmin.js
@@ -80,9 +80,9 @@ function ChatAdminRun() {
 
 	// Background selection, block button and game selection
 	DrawImageResize("Backgrounds/" + ChatAdminBackgroundSelect + "Dark.jpg", 1300, 75, 600, 350);
-	DrawBackNextButton(1300, 450, 500, 60, DialogFind(Player, ChatAdminBackgroundSelect), ChatRoomPlayerIsAdmin() ? "White" : "#ebebe4", null,
-		() => DialogFind(Player, (ChatAdminBackgroundIndex == 0) ? ChatCreateBackgroundList[ChatCreateBackgroundList.length - 1] : ChatCreateBackgroundList[ChatAdminBackgroundIndex - 1]),
-		() => DialogFind(Player, (ChatAdminBackgroundIndex >= ChatCreateBackgroundList.length - 1) ? ChatCreateBackgroundList[0] : ChatCreateBackgroundList[ChatAdminBackgroundIndex + 1]), !ChatRoomPlayerIsAdmin());
+	DrawBackNextButton(1300, 450, 500, 60, GetPlayerDialog(ChatAdminBackgroundSelect), ChatRoomPlayerIsAdmin() ? "White" : "#ebebe4", null,
+		() => GetPlayerDialog((ChatAdminBackgroundIndex == 0) ? ChatCreateBackgroundList[ChatCreateBackgroundList.length - 1] : ChatCreateBackgroundList[ChatAdminBackgroundIndex - 1]),
+		() => GetPlayerDialog((ChatAdminBackgroundIndex >= ChatCreateBackgroundList.length - 1) ? ChatCreateBackgroundList[0] : ChatCreateBackgroundList[ChatAdminBackgroundIndex + 1]), !ChatRoomPlayerIsAdmin());
 	DrawButton(1840, 450, 60, 60, "", ChatRoomPlayerIsAdmin() ? "White" : "#ebebe4", "Icons/Small/Preference.png", null, !ChatRoomPlayerIsAdmin());
 	DrawButton(1300, 575, 275, 60, TextGet("BlockCategory"), ChatRoomPlayerIsAdmin() ? "White" : "#ebebe4", null, null, !ChatRoomPlayerIsAdmin());
 	DrawBackNextButton(1625, 575, 275, 60, TextGet("Game" + ChatAdminGame), ChatRoomPlayerIsAdmin() ? "White" : "#ebebe4", null, () => "", () => "");

--- a/BondageClub/Screens/Online/ChatCreate/ChatCreate.js
+++ b/BondageClub/Screens/Online/ChatCreate/ChatCreate.js
@@ -58,9 +58,9 @@ function ChatCreateRun() {
 	ElementPosition("InputSize", 1400, 560, 150);
 	DrawText(TextGet("RoomBackground"), 650, 672, "White", "Gray");
 	DrawButton(1300, 640, 300, 65, TextGet("ShowAll"), "White");
-	DrawBackNextButton(900, 640, 350, 65, DialogFind(Player, ChatCreateBackgroundSelect), "White", null,
-		() => DialogFind(Player, (ChatCreateBackgroundIndex == 0) ? ChatCreateBackgroundList[ChatCreateBackgroundList.length - 1] : ChatCreateBackgroundList[ChatCreateBackgroundIndex - 1]),
-		() => DialogFind(Player, (ChatCreateBackgroundIndex >= ChatCreateBackgroundList.length - 1) ? ChatCreateBackgroundList[0] : ChatCreateBackgroundList[ChatCreateBackgroundIndex + 1]));
+	DrawBackNextButton(900, 640, 350, 65, GetPlayerDialog(ChatCreateBackgroundSelect), "White", null,
+		() => GetPlayerDialog((ChatCreateBackgroundIndex == 0) ? ChatCreateBackgroundList[ChatCreateBackgroundList.length - 1] : ChatCreateBackgroundList[ChatCreateBackgroundIndex - 1]),
+		() => GetPlayerDialog((ChatCreateBackgroundIndex >= ChatCreateBackgroundList.length - 1) ? ChatCreateBackgroundList[0] : ChatCreateBackgroundList[ChatCreateBackgroundIndex + 1]));
 	DrawButton(850, 775, 300, 65, TextGet("BlockItems"), "White");
 	DrawButton(600, 900, 300, 65, TextGet("Create"), "White");
 	DrawButton(1100, 900, 300, 65, TextGet("Cancel"), "White");

--- a/BondageClub/Screens/Online/ChatCreate/ChatCreate.js
+++ b/BondageClub/Screens/Online/ChatCreate/ChatCreate.js
@@ -58,9 +58,9 @@ function ChatCreateRun() {
 	ElementPosition("InputSize", 1400, 560, 150);
 	DrawText(TextGet("RoomBackground"), 650, 672, "White", "Gray");
 	DrawButton(1300, 640, 300, 65, TextGet("ShowAll"), "White");
-	DrawBackNextButton(900, 640, 350, 65, GetPlayerDialog(ChatCreateBackgroundSelect), "White", null,
-		() => GetPlayerDialog((ChatCreateBackgroundIndex == 0) ? ChatCreateBackgroundList[ChatCreateBackgroundList.length - 1] : ChatCreateBackgroundList[ChatCreateBackgroundIndex - 1]),
-		() => GetPlayerDialog((ChatCreateBackgroundIndex >= ChatCreateBackgroundList.length - 1) ? ChatCreateBackgroundList[0] : ChatCreateBackgroundList[ChatCreateBackgroundIndex + 1]));
+	DrawBackNextButton(900, 640, 350, 65, DialogFindPlayer(ChatCreateBackgroundSelect), "White", null,
+		() => DialogFindPlayer((ChatCreateBackgroundIndex == 0) ? ChatCreateBackgroundList[ChatCreateBackgroundList.length - 1] : ChatCreateBackgroundList[ChatCreateBackgroundIndex - 1]),
+		() => DialogFindPlayer((ChatCreateBackgroundIndex >= ChatCreateBackgroundList.length - 1) ? ChatCreateBackgroundList[0] : ChatCreateBackgroundList[ChatCreateBackgroundIndex + 1]));
 	DrawButton(850, 775, 300, 65, TextGet("BlockItems"), "White");
 	DrawButton(600, 900, 300, 65, TextGet("Create"), "White");
 	DrawButton(1100, 900, 300, 65, TextGet("Cancel"), "White");

--- a/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
+++ b/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
@@ -1282,7 +1282,7 @@ function ChatRoomMessage(data) {
 			// Replace actions by the content of the dictionary
 			if (data.Type && ((data.Type == "Action") || (data.Type == "ServerMessage"))) {
 				if (data.Type == "ServerMessage") msg = "ServerMessage" + msg;
-				msg = DialogFind(Player, msg);
+				msg = GetPlayerDialog(msg);
 				if (data.Dictionary) {
 					var dictionary = data.Dictionary;
 					var SourceCharacter = null;
@@ -1299,15 +1299,15 @@ function ChatRoomMessage(data) {
 
 							// Alters the message displayed in the chat room log, and stores the source & target in case they're required later
 							if ((dictionary[D].Tag == "DestinationCharacter") || (dictionary[D].Tag == "DestinationCharacterName")) {
-								msg = msg.replace(dictionary[D].Tag, ((SenderCharacter.MemberNumber == dictionary[D].MemberNumber) && (dictionary[D].Tag == "DestinationCharacter")) ? DialogFind(Player, "Her") : (PreferenceIsPlayerInSensDep() && dictionary[D].MemberNumber != Player.MemberNumber ? DialogFind(Player, "Someone").toLowerCase() : ChatRoomHTMLEntities(dictionary[D].Text) + DialogFind(Player, "'s")));
+								msg = msg.replace(dictionary[D].Tag, ((SenderCharacter.MemberNumber == dictionary[D].MemberNumber) && (dictionary[D].Tag == "DestinationCharacter")) ? GetPlayerDialog("Her") : (PreferenceIsPlayerInSensDep() && dictionary[D].MemberNumber != Player.MemberNumber ? GetPlayerDialog("Someone").toLowerCase() : ChatRoomHTMLEntities(dictionary[D].Text) + GetPlayerDialog("'s")));
 								TargetMemberNumber = dictionary[D].MemberNumber;
 							}
 							else if ((dictionary[D].Tag == "TargetCharacter") || (dictionary[D].Tag == "TargetCharacterName")) {
-								msg = msg.replace(dictionary[D].Tag, ((SenderCharacter.MemberNumber == dictionary[D].MemberNumber) && (dictionary[D].Tag == "TargetCharacter")) ? DialogFind(Player, "Herself") : (PreferenceIsPlayerInSensDep() && dictionary[D].MemberNumber != Player.MemberNumber ? DialogFind(Player, "Someone").toLowerCase() : ChatRoomHTMLEntities(dictionary[D].Text)));
+								msg = msg.replace(dictionary[D].Tag, ((SenderCharacter.MemberNumber == dictionary[D].MemberNumber) && (dictionary[D].Tag == "TargetCharacter")) ? GetPlayerDialog("Herself") : (PreferenceIsPlayerInSensDep() && dictionary[D].MemberNumber != Player.MemberNumber ? GetPlayerDialog("Someone").toLowerCase() : ChatRoomHTMLEntities(dictionary[D].Text)));
 								TargetMemberNumber = dictionary[D].MemberNumber;
 							}
 							else if (dictionary[D].Tag == "SourceCharacter") {
-								msg = msg.replace(dictionary[D].Tag, (PreferenceIsPlayerInSensDep() && (dictionary[D].MemberNumber != Player.MemberNumber)) ? DialogFind(Player, "Someone") : ChatRoomHTMLEntities(dictionary[D].Text));
+								msg = msg.replace(dictionary[D].Tag, (PreferenceIsPlayerInSensDep() && (dictionary[D].MemberNumber != Player.MemberNumber)) ? GetPlayerDialog("Someone") : ChatRoomHTMLEntities(dictionary[D].Text));
 								for (let T = 0; T < ChatRoomCharacter.length; T++)
 									if (ChatRoomCharacter[T].MemberNumber == dictionary[D].MemberNumber)
 										SourceCharacter = ChatRoomCharacter[T];
@@ -1319,7 +1319,7 @@ function ChatRoomMessage(data) {
 									IsPlayerInvolved = true;
 
 						}
-						else if (dictionary[D].TextToLookUp) msg = msg.replace(dictionary[D].Tag, DialogFind(Player, ChatRoomHTMLEntities(dictionary[D].TextToLookUp)).toLowerCase());
+						else if (dictionary[D].TextToLookUp) msg = msg.replace(dictionary[D].Tag, GetPlayerDialog(ChatRoomHTMLEntities(dictionary[D].TextToLookUp)).toLowerCase());
 						else if (dictionary[D].AssetName) {
 							for (let A = 0; A < Asset.length; A++)
 								if (Asset[A].Name == dictionary[D].AssetName) {
@@ -1381,7 +1381,7 @@ function ChatRoomMessage(data) {
 				else if (data.Type == "Emote") {
 					if (msg.indexOf("*") == 0) msg = msg + "*";
 					else if ((msg.indexOf("'") == 0) || (msg.indexOf(",") == 0)) msg = "*" + SenderCharacter.Name + msg + "*";
-					else if (PreferenceIsPlayerInSensDep() && SenderCharacter.MemberNumber != Player.MemberNumber) msg = "*" + DialogFind(Player, "Someone") + " " + msg + "*";
+					else if (PreferenceIsPlayerInSensDep() && SenderCharacter.MemberNumber != Player.MemberNumber) msg = "*" + GetPlayerDialog("Someone") + " " + msg + "*";
 					else msg = "*" + SenderCharacter.Name + " " + msg + "*";
 				}
 				else if (data.Type == "Action") msg = "(" + msg + ")";
@@ -1401,7 +1401,7 @@ function ChatRoomMessage(data) {
 				var ActivityCounter = 1;
 				if (data.Dictionary != null)
 					for (let D = 0; D < data.Dictionary.length; D++) {
-						if (data.Dictionary[D].MemberNumber != null) msg = msg.replace(data.Dictionary[D].Tag, (PreferenceIsPlayerInSensDep() && (data.Dictionary[D].MemberNumber != Player.MemberNumber)) ? DialogFind(Player, "Someone") : ChatRoomHTMLEntities(data.Dictionary[D].Text));
+						if (data.Dictionary[D].MemberNumber != null) msg = msg.replace(data.Dictionary[D].Tag, (PreferenceIsPlayerInSensDep() && (data.Dictionary[D].MemberNumber != Player.MemberNumber)) ? GetPlayerDialog("Someone") : ChatRoomHTMLEntities(data.Dictionary[D].Text));
 						if ((data.Dictionary[D].MemberNumber != null) && (data.Dictionary[D].Tag == "TargetCharacter")) TargetMemberNumber = data.Dictionary[D].MemberNumber;
 						if (data.Dictionary[D].Tag == "ActivityName") ActivityName = data.Dictionary[D].Text;
 						if (data.Dictionary[D].Tag == "ActivityGroup") ActivityGroup = data.Dictionary[D].Text;

--- a/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
+++ b/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
@@ -1282,7 +1282,7 @@ function ChatRoomMessage(data) {
 			// Replace actions by the content of the dictionary
 			if (data.Type && ((data.Type == "Action") || (data.Type == "ServerMessage"))) {
 				if (data.Type == "ServerMessage") msg = "ServerMessage" + msg;
-				msg = GetPlayerDialog(msg);
+				msg = DialogFindPlayer(msg);
 				if (data.Dictionary) {
 					var dictionary = data.Dictionary;
 					var SourceCharacter = null;
@@ -1299,15 +1299,15 @@ function ChatRoomMessage(data) {
 
 							// Alters the message displayed in the chat room log, and stores the source & target in case they're required later
 							if ((dictionary[D].Tag == "DestinationCharacter") || (dictionary[D].Tag == "DestinationCharacterName")) {
-								msg = msg.replace(dictionary[D].Tag, ((SenderCharacter.MemberNumber == dictionary[D].MemberNumber) && (dictionary[D].Tag == "DestinationCharacter")) ? GetPlayerDialog("Her") : (PreferenceIsPlayerInSensDep() && dictionary[D].MemberNumber != Player.MemberNumber ? GetPlayerDialog("Someone").toLowerCase() : ChatRoomHTMLEntities(dictionary[D].Text) + GetPlayerDialog("'s")));
+								msg = msg.replace(dictionary[D].Tag, ((SenderCharacter.MemberNumber == dictionary[D].MemberNumber) && (dictionary[D].Tag == "DestinationCharacter")) ? DialogFindPlayer("Her") : (PreferenceIsPlayerInSensDep() && dictionary[D].MemberNumber != Player.MemberNumber ? DialogFindPlayer("Someone").toLowerCase() : ChatRoomHTMLEntities(dictionary[D].Text) + DialogFindPlayer("'s")));
 								TargetMemberNumber = dictionary[D].MemberNumber;
 							}
 							else if ((dictionary[D].Tag == "TargetCharacter") || (dictionary[D].Tag == "TargetCharacterName")) {
-								msg = msg.replace(dictionary[D].Tag, ((SenderCharacter.MemberNumber == dictionary[D].MemberNumber) && (dictionary[D].Tag == "TargetCharacter")) ? GetPlayerDialog("Herself") : (PreferenceIsPlayerInSensDep() && dictionary[D].MemberNumber != Player.MemberNumber ? GetPlayerDialog("Someone").toLowerCase() : ChatRoomHTMLEntities(dictionary[D].Text)));
+								msg = msg.replace(dictionary[D].Tag, ((SenderCharacter.MemberNumber == dictionary[D].MemberNumber) && (dictionary[D].Tag == "TargetCharacter")) ? DialogFindPlayer("Herself") : (PreferenceIsPlayerInSensDep() && dictionary[D].MemberNumber != Player.MemberNumber ? DialogFindPlayer("Someone").toLowerCase() : ChatRoomHTMLEntities(dictionary[D].Text)));
 								TargetMemberNumber = dictionary[D].MemberNumber;
 							}
 							else if (dictionary[D].Tag == "SourceCharacter") {
-								msg = msg.replace(dictionary[D].Tag, (PreferenceIsPlayerInSensDep() && (dictionary[D].MemberNumber != Player.MemberNumber)) ? GetPlayerDialog("Someone") : ChatRoomHTMLEntities(dictionary[D].Text));
+								msg = msg.replace(dictionary[D].Tag, (PreferenceIsPlayerInSensDep() && (dictionary[D].MemberNumber != Player.MemberNumber)) ? DialogFindPlayer("Someone") : ChatRoomHTMLEntities(dictionary[D].Text));
 								for (let T = 0; T < ChatRoomCharacter.length; T++)
 									if (ChatRoomCharacter[T].MemberNumber == dictionary[D].MemberNumber)
 										SourceCharacter = ChatRoomCharacter[T];
@@ -1319,7 +1319,7 @@ function ChatRoomMessage(data) {
 									IsPlayerInvolved = true;
 
 						}
-						else if (dictionary[D].TextToLookUp) msg = msg.replace(dictionary[D].Tag, GetPlayerDialog(ChatRoomHTMLEntities(dictionary[D].TextToLookUp)).toLowerCase());
+						else if (dictionary[D].TextToLookUp) msg = msg.replace(dictionary[D].Tag, DialogFindPlayer(ChatRoomHTMLEntities(dictionary[D].TextToLookUp)).toLowerCase());
 						else if (dictionary[D].AssetName) {
 							for (let A = 0; A < Asset.length; A++)
 								if (Asset[A].Name == dictionary[D].AssetName) {
@@ -1381,7 +1381,7 @@ function ChatRoomMessage(data) {
 				else if (data.Type == "Emote") {
 					if (msg.indexOf("*") == 0) msg = msg + "*";
 					else if ((msg.indexOf("'") == 0) || (msg.indexOf(",") == 0)) msg = "*" + SenderCharacter.Name + msg + "*";
-					else if (PreferenceIsPlayerInSensDep() && SenderCharacter.MemberNumber != Player.MemberNumber) msg = "*" + GetPlayerDialog("Someone") + " " + msg + "*";
+					else if (PreferenceIsPlayerInSensDep() && SenderCharacter.MemberNumber != Player.MemberNumber) msg = "*" + DialogFindPlayer("Someone") + " " + msg + "*";
 					else msg = "*" + SenderCharacter.Name + " " + msg + "*";
 				}
 				else if (data.Type == "Action") msg = "(" + msg + ")";
@@ -1401,7 +1401,7 @@ function ChatRoomMessage(data) {
 				var ActivityCounter = 1;
 				if (data.Dictionary != null)
 					for (let D = 0; D < data.Dictionary.length; D++) {
-						if (data.Dictionary[D].MemberNumber != null) msg = msg.replace(data.Dictionary[D].Tag, (PreferenceIsPlayerInSensDep() && (data.Dictionary[D].MemberNumber != Player.MemberNumber)) ? GetPlayerDialog("Someone") : ChatRoomHTMLEntities(data.Dictionary[D].Text));
+						if (data.Dictionary[D].MemberNumber != null) msg = msg.replace(data.Dictionary[D].Tag, (PreferenceIsPlayerInSensDep() && (data.Dictionary[D].MemberNumber != Player.MemberNumber)) ? DialogFindPlayer("Someone") : ChatRoomHTMLEntities(data.Dictionary[D].Text));
 						if ((data.Dictionary[D].MemberNumber != null) && (data.Dictionary[D].Tag == "TargetCharacter")) TargetMemberNumber = data.Dictionary[D].MemberNumber;
 						if (data.Dictionary[D].Tag == "ActivityName") ActivityName = data.Dictionary[D].Text;
 						if (data.Dictionary[D].Tag == "ActivityGroup") ActivityGroup = data.Dictionary[D].Text;

--- a/BondageClub/Screens/Room/MainHall/MainHall.js
+++ b/BondageClub/Screens/Room/MainHall/MainHall.js
@@ -706,7 +706,7 @@ function MainHallMistressExpulsion() {
 function MainHallMaidIntroduction() {
 	if (!LogQuery("IntroductionDone", "MainHall") && Player.CanTalk()) {
 		MainHallMaid.Stage = "1000";
-		MainHallMaid.CurrentDialog = DialogFind(Player, "IntroductionMaidGreetings");
+		MainHallMaid.CurrentDialog = GetPlayerDialog("IntroductionMaidGreetings");
 		CharacterSetCurrent(MainHallMaid);
 		MainHallMaid.AllowItem = false;
 	}

--- a/BondageClub/Screens/Room/MainHall/MainHall.js
+++ b/BondageClub/Screens/Room/MainHall/MainHall.js
@@ -706,7 +706,7 @@ function MainHallMistressExpulsion() {
 function MainHallMaidIntroduction() {
 	if (!LogQuery("IntroductionDone", "MainHall") && Player.CanTalk()) {
 		MainHallMaid.Stage = "1000";
-		MainHallMaid.CurrentDialog = GetPlayerDialog("IntroductionMaidGreetings");
+		MainHallMaid.CurrentDialog = DialogFindPlayer("IntroductionMaidGreetings");
 		CharacterSetCurrent(MainHallMaid);
 		MainHallMaid.AllowItem = false;
 	}

--- a/BondageClub/Screens/Room/Stable/Stable.js
+++ b/BondageClub/Screens/Room/Stable/Stable.js
@@ -957,7 +957,7 @@ function StableGenericProgressStart(Timer, S, S2, Item, Background, Character, S
 		StableProgress = StableProgress + StableProgressAuto;
 		if (StableProgress < 0) StableProgress = 0;
 		DrawProgressBar(1200, 700, 600, 100, StableProgress);
-		DrawText(GetPlayerDialog((CommonIsMobile) ? "ProgressClick" : "ProgressKeys"), 1500, 900, "White", "Black");
+		DrawText(DialogFindPlayer((CommonIsMobile) ? "ProgressClick" : "ProgressKeys"), 1500, 900, "White", "Black");
 		if (StableProgress >= 100) {
 			StableGenericFinished();
 		}
@@ -980,12 +980,12 @@ function StableGenericDrawProgress() {
 			DrawRect(300, 25, 225, 225, "white");
 			DrawImage(StableProgressItem, 302, 27);
 			DrawText(StableProgressOperation, 1000, 50, "White", "Black");
-			DrawText(GetPlayerDialog((CommonIsMobile) ? "ProgressClick" : "ProgressKeys"), 1000, 150, "White", "Black");
+			DrawText(DialogFindPlayer((CommonIsMobile) ? "ProgressClick" : "ProgressKeys"), 1000, 150, "White", "Black");
 			DrawRect(200, 300, 20, 675, "white");
 			DrawRect(1800, 300, 20, 675, "white");
 			DrawCharacter(Player, StableGenericPlayerPosition, 300, 0.7);
 		} else {
-			DrawText(GetPlayerDialog((CommonIsMobile) ? "ProgressClick" : "ProgressKeys"), 600, 25, "White", "Black");
+			DrawText(DialogFindPlayer((CommonIsMobile) ? "ProgressClick" : "ProgressKeys"), 600, 25, "White", "Black");
 			DrawRect(200, 200, 20, 800, "white");
 			DrawRect(1800, 200, 20, 800, "white");
 			DrawCharacter(Player, StableGenericPlayerPosition, 200, 0.4);
@@ -1038,7 +1038,7 @@ function StableGenericRun(Reverse) {
 		StableProgress = StableProgress + StableProgressClick * (Reverse ? -1 : 1) + ((100 - StableProgress) / 50);
 	if (StableProgress < 0) StableProgress = 0;
 	StableProgressStruggleCount++;
-	if ((StableProgressStruggleCount >= 50) && (StableProgressClick == 0)) StableProgressOperation = GetPlayerDialog("Impossible");
+	if ((StableProgressStruggleCount >= 50) && (StableProgressClick == 0)) StableProgressOperation = DialogFindPlayer("Impossible");
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////

--- a/BondageClub/Screens/Room/Stable/Stable.js
+++ b/BondageClub/Screens/Room/Stable/Stable.js
@@ -957,7 +957,7 @@ function StableGenericProgressStart(Timer, S, S2, Item, Background, Character, S
 		StableProgress = StableProgress + StableProgressAuto;
 		if (StableProgress < 0) StableProgress = 0;
 		DrawProgressBar(1200, 700, 600, 100, StableProgress);
-		DrawText(DialogFind(Player, (CommonIsMobile) ? "ProgressClick" : "ProgressKeys"), 1500, 900, "White", "Black");
+		DrawText(GetPlayerDialog((CommonIsMobile) ? "ProgressClick" : "ProgressKeys"), 1500, 900, "White", "Black");
 		if (StableProgress >= 100) {
 			StableGenericFinished();
 		}
@@ -980,12 +980,12 @@ function StableGenericDrawProgress() {
 			DrawRect(300, 25, 225, 225, "white");
 			DrawImage(StableProgressItem, 302, 27);
 			DrawText(StableProgressOperation, 1000, 50, "White", "Black");
-			DrawText(DialogFind(Player, (CommonIsMobile) ? "ProgressClick" : "ProgressKeys"), 1000, 150, "White", "Black");
+			DrawText(GetPlayerDialog((CommonIsMobile) ? "ProgressClick" : "ProgressKeys"), 1000, 150, "White", "Black");
 			DrawRect(200, 300, 20, 675, "white");
 			DrawRect(1800, 300, 20, 675, "white");
 			DrawCharacter(Player, StableGenericPlayerPosition, 300, 0.7);
 		} else {
-			DrawText(DialogFind(Player, (CommonIsMobile) ? "ProgressClick" : "ProgressKeys"), 600, 25, "White", "Black");
+			DrawText(GetPlayerDialog((CommonIsMobile) ? "ProgressClick" : "ProgressKeys"), 600, 25, "White", "Black");
 			DrawRect(200, 200, 20, 800, "white");
 			DrawRect(1800, 200, 20, 800, "white");
 			DrawCharacter(Player, StableGenericPlayerPosition, 200, 0.4);
@@ -1038,7 +1038,7 @@ function StableGenericRun(Reverse) {
 		StableProgress = StableProgress + StableProgressClick * (Reverse ? -1 : 1) + ((100 - StableProgress) / 50);
 	if (StableProgress < 0) StableProgress = 0;
 	StableProgressStruggleCount++;
-	if ((StableProgressStruggleCount >= 50) && (StableProgressClick == 0)) StableProgressOperation = DialogFind(Player, "Impossible");
+	if ((StableProgressStruggleCount >= 50) && (StableProgressClick == 0)) StableProgressOperation = GetPlayerDialog("Impossible");
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////

--- a/BondageClub/Scripts/Character.js
+++ b/BondageClub/Scripts/Character.js
@@ -167,14 +167,14 @@ function CharacterRandomName(C) {
  */
 function CharacterBuildDialog(C, CSV) {
 
-	var OnlinePlayer = C.AccountName.indexOf("Online-") >= 0;
+	const OnlinePlayer = C.AccountName.indexOf("Online-") >= 0;
 	C.Dialog = [];
 	// For each lines in the file
 	for (let L = 0; L < CSV.length; L++)
 		if ((CSV[L][0] != null) && (CSV[L][0] != "")) {
 
 			// Creates a dialog object
-			var D = {};
+			const D = {};
 			D.Stage = CSV[L][0];
 			if ((CSV[L][1] != null) && (CSV[L][1].trim() != "")) D.NextStage = CSV[L][1];
 			if ((CSV[L][2] != null) && (CSV[L][2].trim() != "")) D.Option = CSV[L][2].replace("DialogCharacterName", C.Name).replace("DialogPlayerName", Player.Name);
@@ -190,6 +190,12 @@ function CharacterBuildDialog(C, CSV) {
 	// Translate the dialog if needed
 	TranslationDialog(C);
 
+	if (C === Player) {
+		for (const D of C.Dialog) {
+			if (typeof D.Result === "string")
+				PlayerDialog.set(D.Stage, D.Result);
+		}
+	}
 }
 
 /**
@@ -1126,7 +1132,7 @@ function CharacterIsEdged(C) {
 		                && Array.isArray(Item.Property.Effect)
 		                && Item.Property.Effect.includes("Vibrating")
 		                && typeof Item.Property.Intensity === "number"
-		                && Item.Property.Intensity >= 0,
+		                && Item.Property.Intensity >= 0
 		);
 
 	// Return true if every vibrating item on an orgasm zone has the "Edged" effect

--- a/BondageClub/Scripts/Dialog.js
+++ b/BondageClub/Scripts/Dialog.js
@@ -66,6 +66,8 @@ var DialogLockMenu = false
 var DialogLentLockpicks = false
 var DialogLockPickTotalTries = 0
 
+/** @type {Map<string, string>} */
+var PlayerDialog = new Map();
 
 
 /**
@@ -845,17 +847,17 @@ function DialogActivePoseMenuBuild() {
  * @returns {string} - The appropriate dialog option
  */
 function DialogProgressGetOperation(C, PrevItem, NextItem) {
-	if ((PrevItem != null) && (NextItem != null)) return DialogFind(Player, "Swapping");
-	if ((C.ID == 0) && (PrevItem != null) && (SkillGetRatio("Evasion") != 1)) return DialogFind(Player, "Using" + (SkillGetRatio("Evasion") * 100).toString());
-	if (InventoryItemHasEffect(PrevItem, "Lock", true) && !DialogCanUnlock(C, PrevItem)) return DialogFind(Player, "Struggling");
-	if ((PrevItem != null) && !Player.CanInteract() && !InventoryItemHasEffect(PrevItem, "Block", true)) return DialogFind(Player, "Struggling");
-	if (InventoryItemHasEffect(PrevItem, "Lock", true)) return DialogFind(Player, "Unlocking");
-	if ((PrevItem != null) && InventoryItemHasEffect(PrevItem, "Mounted", true)) return DialogFind(Player, "Dismounting");
-	if ((PrevItem != null) && InventoryItemHasEffect(PrevItem, "Enclose", true)) return DialogFind(Player, "Escaping");
-	if (PrevItem != null) return DialogFind(Player, "Removing");
-	if ((PrevItem == null) && (NextItem != null) && (SkillGetRatio("Bondage") != 1)) return DialogFind(Player, "Using" + (SkillGetRatio("Bondage") * 100).toString());
-	if (InventoryItemHasEffect(NextItem, "Lock", true)) return DialogFind(Player, "Locking");
-	if ((PrevItem == null) && (NextItem != null)) return DialogFind(Player, "Adding");
+	if ((PrevItem != null) && (NextItem != null)) return GetPlayerDialog("Swapping");
+	if ((C.ID == 0) && (PrevItem != null) && (SkillGetRatio("Evasion") != 1)) return GetPlayerDialog("Using" + (SkillGetRatio("Evasion") * 100).toString());
+	if (InventoryItemHasEffect(PrevItem, "Lock", true) && !DialogCanUnlock(C, PrevItem)) return GetPlayerDialog("Struggling");
+	if ((PrevItem != null) && !Player.CanInteract() && !InventoryItemHasEffect(PrevItem, "Block", true)) return GetPlayerDialog("Struggling");
+	if (InventoryItemHasEffect(PrevItem, "Lock", true)) return GetPlayerDialog("Unlocking");
+	if ((PrevItem != null) && InventoryItemHasEffect(PrevItem, "Mounted", true)) return GetPlayerDialog("Dismounting");
+	if ((PrevItem != null) && InventoryItemHasEffect(PrevItem, "Enclose", true)) return GetPlayerDialog("Escaping");
+	if (PrevItem != null) return GetPlayerDialog("Removing");
+	if ((PrevItem == null) && (NextItem != null) && (SkillGetRatio("Bondage") != 1)) return GetPlayerDialog("Using" + (SkillGetRatio("Bondage") * 100).toString());
+	if (InventoryItemHasEffect(NextItem, "Lock", true)) return GetPlayerDialog("Locking");
+	if ((PrevItem == null) && (NextItem != null)) return GetPlayerDialog("Adding");
 	return "...";
 }
 
@@ -869,9 +871,9 @@ function DialogProgressGetOperation(C, PrevItem, NextItem) {
 function DialogLockPickProgressGetOperation(C, Item) {
 	var lock = InventoryGetLock(Item)
 	if ((Item != null && lock != null)) {
-		if (lock.Name == "CombinationPadlock" || lock.Name == "PasswordPadlock") return DialogFind(Player, "Decoding");
-		if (Item.Asset.Name.indexOf("Futuristic") >= 0 || Item.Asset.Name.indexOf("Interactive") >= 0) return DialogFind(Player, "Hacking");
-		return DialogFind(Player, "Picking");
+		if (lock.Name == "CombinationPadlock" || lock.Name == "PasswordPadlock") return GetPlayerDialog("Decoding");
+		if (Item.Asset.Name.indexOf("Futuristic") >= 0 || Item.Asset.Name.indexOf("Interactive") >= 0) return GetPlayerDialog("Hacking");
+		return GetPlayerDialog("Picking");
 	}
 	return "...";
 }
@@ -895,7 +897,7 @@ function DialogStruggle(Reverse) {
 	if (DialogProgress < 0) DialogProgress = 0;
 	if ((DialogProgress >= 100) && (DialogProgressChallenge > 6) && (DialogProgressAuto < 0)) DialogProgress = 99;
 	if (!Reverse) DialogProgressStruggleCount++;
-	if ((DialogProgressStruggleCount >= 50) && (DialogProgressChallenge > 6) && (DialogProgressAuto < 0)) DialogProgressOperation = DialogFind(Player, "Impossible");
+	if ((DialogProgressStruggleCount >= 50) && (DialogProgressChallenge > 6) && (DialogProgressAuto < 0)) DialogProgressOperation = GetPlayerDialog("Impossible");
 
 	// At 15 hit: low blush, 50: Medium and 125: High
 	if (DialogAllowBlush && !Reverse) {
@@ -1373,7 +1375,7 @@ function DialogPublishAction(C, ClickItem) {
 			}
 			else {
 				var intensity = TargetItem.Property ? TargetItem.Property.Intensity : 0;
-				var D = (DialogFind(Player, TargetItem.Asset.Name + "Trigger" + intensity)).replace("DestinationCharacterName", C.Name);
+				var D = (GetPlayerDialog(TargetItem.Asset.Name + "Trigger" + intensity)).replace("DestinationCharacterName", C.Name);
 				if (D != "") {
 					InventoryExpressionTrigger(C, ClickItem);
 					C.CurrentDialog = "(" + D + ")";
@@ -1705,7 +1707,7 @@ function DialogFindNextSubMenu() {
  */
 function DialogSetText(NewText) {
 	DialogTextDefaultTimer = CommonTime() + 5000;
-	DialogText = DialogFind(Player, NewText);
+	DialogText = GetPlayerDialog(NewText);
 }
 
 /**
@@ -1761,14 +1763,14 @@ function DialogDrawActivityMenu(C) {
 
 	// Gets the default text that will reset after 5 seconds
 	var SelectedGroup = (Player.FocusGroup != null) ? Player.FocusGroup.Description : CurrentCharacter.FocusGroup.Description;
-	if (DialogTextDefault == "") DialogTextDefault = DialogFind(Player, "SelectActivityGroup").replace("GroupName", SelectedGroup.toLowerCase());
+	if (DialogTextDefault == "") DialogTextDefault = GetPlayerDialog("SelectActivityGroup").replace("GroupName", SelectedGroup.toLowerCase());
 	if (DialogTextDefaultTimer < CommonTime()) DialogText = DialogTextDefault;
 
 	// Draws the top menu text & icons
 	if (DialogMenuButton == null) DialogMenuButtonBuild((Player.FocusGroup != null) ? Player : CurrentCharacter);
 	if (DialogMenuButton.length < 8) DrawTextWrap(DialogText, 1000, 0, 975 - DialogMenuButton.length * 110, 125, "White");
 	for (let I = DialogMenuButton.length - 1; I >= 0; I--)
-		DrawButton(1885 - I * 110, 15, 90, 90, "", "White", "Icons/" + DialogMenuButton[I] + ".png", DialogFind(Player, DialogMenuButton[I]));
+		DrawButton(1885 - I * 110, 15, 90, 90, "", "White", "Icons/" + DialogMenuButton[I] + ".png", GetPlayerDialog(DialogMenuButton[I]));
 
 	// Prepares a 4x3 square selection with all activities in the buffer
 	var X = 1000;
@@ -1816,10 +1818,10 @@ function DialogDrawStruggleProgress(C) {
 	}
 
 	// Draw the current operation and progress
-	if (DialogProgressAuto < 0) DrawText(DialogFind(Player, "Challenge") + " " + ((DialogProgressStruggleCount >= 50) ? DialogProgressChallenge.toString() : "???"), 1500, 150, "White", "Black");
+	if (DialogProgressAuto < 0) DrawText(GetPlayerDialog("Challenge") + " " + ((DialogProgressStruggleCount >= 50) ? DialogProgressChallenge.toString() : "???"), 1500, 150, "White", "Black");
 	DrawText(DialogProgressOperation, 1500, 650, "White", "Black");
 	DrawProgressBar(1200, 700, 600, 100, DialogProgress);
-	DrawText(DialogFind(Player, (CommonIsMobile) ? "ProgressClick" : "ProgressKeys"), 1500, 900, "White", "Black");
+	DrawText(GetPlayerDialog((CommonIsMobile) ? "ProgressClick" : "ProgressKeys"), 1500, 900, "White", "Black");
 
 	// If the operation is completed
 	if (DialogProgress >= 100) {
@@ -1992,10 +1994,10 @@ function DialogDrawLockpickProgress(C) {
 			DrawImageResize("Screens/MiniGame/Lockpick/Arrow.png", XX, Y + 25, PinWidth, PinWidth);
 	}
 
-	
-	DrawText(DialogFind(Player, "LockpickTriesRemaining") + (DialogLockPickProgressMaxTries - DialogLockPickProgressCurrentTries), X, 212, "white");
+
+	DrawText(GetPlayerDialog("LockpickTriesRemaining") + (DialogLockPickProgressMaxTries - DialogLockPickProgressCurrentTries), X, 212, "white");
 	if (LogValue("FailedLockPick", "LockPick") > CurrentTime)
-		DrawText(DialogFind(Player, "LockpickFailedTimeout") + TimerToString(LogValue("FailedLockPick", "LockPick") - CurrentTime), X, 262, "red");
+		DrawText(GetPlayerDialog("LockpickFailedTimeout") + TimerToString(LogValue("FailedLockPick", "LockPick") - CurrentTime), X, 262, "red");
 	else {
 		if (DialogLockPickProgressCurrentTries >= DialogLockPickProgressMaxTries && DialogLockPickSuccessTime == 0) {
 			if (DialogLockPickFailTime > 0) {
@@ -2006,7 +2008,7 @@ function DialogDrawLockpickProgress(C) {
 					
 				}
 				else {
-					DrawText(DialogFind(Player, "LockpickFailed"), X, 262, "red");
+					DrawText(GetPlayerDialog("LockpickFailed"), X, 262, "red");
 				}
 			} else if (Math.random() < 0.25 && DialogLockPickTotalTries > 5) { // DialogLockPickTotalTries is meant to give players a bit of breathing room so they don't get tired right away
 				LogAdd("FailedLockPick", "LockPick", CurrentTime + DialogLockPickFailTimeout);
@@ -2019,11 +2021,11 @@ function DialogDrawLockpickProgress(C) {
 			DrawText(DialogLockPickArousalText, X, 170, "pink");
 		}
 	}
-		
 
-	DrawText(DialogFind(Player, "LockpickIntro"), X, 800, "white");
-	DrawText(DialogFind(Player, "LockpickIntro2"), X, 850, "white");
-	
+
+	DrawText(GetPlayerDialog("LockpickIntro"), X, 800, "white");
+	DrawText(GetPlayerDialog("LockpickIntro2"), X, 850, "white");
+
 	if (DialogLockPickSuccessTime != 0) {
 		if (CurrentTime > DialogLockPickSuccessTime) {
 			DialogLockPickSuccessTime = 0
@@ -2058,9 +2060,9 @@ function DialogDrawLockpickProgress(C) {
 				if (DialogLockPickArousalTick - CurrentTime > CurrentTime + DialogLockPickArousalTickTime*arousalmaxtime) {
 					DialogLockPickArousalTick = CurrentTime + DialogLockPickArousalTickTime*arousalmaxtime // In case it gets set out way too far
 				}
-				
+
 				if (DialogLockPickArousalTick > 0 && DialogLockPickSet.filter(x => x==true).length > 0) {
-					DialogLockPickArousalText = DialogFind(Player, "LockPickArousal")
+					DialogLockPickArousalText = GetPlayerDialog("LockPickArousal")
 					if (DialogLockPickSet.filter(x => x==true).length < DialogLockPickSet.length) {
 						for (let P = DialogLockPickOrder.length; P >= 0; P--) {
 							if (DialogLockPickSet[DialogLockPickOrder[P]] == true) {
@@ -2102,16 +2104,16 @@ function DialogDrawItemMenu(C) {
 	}
 
 	// Gets the default text that will reset after 5 seconds
-	if (DialogTextDefault == "") DialogTextDefault = DialogFind(Player, "SelectItemGroup").replace("GroupName", C.FocusGroup.Description.toLowerCase());
+	if (DialogTextDefault == "") DialogTextDefault = GetPlayerDialog("SelectItemGroup").replace("GroupName", C.FocusGroup.Description.toLowerCase());
 	if (DialogTextDefaultTimer < CommonTime()) DialogText = DialogTextDefault;
 
 	// Draws the top menu text & icons
 	if (DialogMenuButton == null) DialogMenuButtonBuild(CharacterGetCurrent());
-	if ((DialogColor == null) && Player.CanInteract() && (DialogProgress < 0 && !DialogLockPickOrder) && !InventoryGroupIsBlocked(C) && DialogMenuButton.length < 8) DrawTextWrap((!DialogItemPermissionMode) ? DialogText : DialogFind(Player, "DialogPermissionMode"), 1000, 0, 975 - DialogMenuButton.length * 110, 125, "White", null, 3);
+	if ((DialogColor == null) && Player.CanInteract() && (DialogProgress < 0 && !DialogLockPickOrder) && !InventoryGroupIsBlocked(C) && DialogMenuButton.length < 8) DrawTextWrap((!DialogItemPermissionMode) ? DialogText : GetPlayerDialog("DialogPermissionMode"), 1000, 0, 975 - DialogMenuButton.length * 110, 125, "White", null, 3);
 	for (let I = DialogMenuButton.length - 1; I >= 0; I--) {
 		let ButtonColor = (DialogMenuButton[I] == "ColorPick") && (DialogColorSelect != null) ? DialogColorSelect : "White";
 		let ButtonImage = DialogMenuButton[I] == "ColorPick" && !ItemColorIsSimple(FocusItem) ? "MultiColorPick" : DialogMenuButton[I];
-		let ButtonHoverText = (DialogColor == null) ? DialogFind(Player, DialogMenuButton[I]) : null;
+		let ButtonHoverText = (DialogColor == null) ? GetPlayerDialog(DialogMenuButton[I]) : null;
 		DrawButton(1885 - I * 110, 15, 90, 90, "", ButtonColor, "Icons/" + ButtonImage + ".png", ButtonHoverText);
 	}
 	
@@ -2171,7 +2173,7 @@ function DialogDrawItemMenu(C) {
 		}
 
 		if (DialogInventory.length > 0) {
-			if (InventoryGroupIsBlocked(C)) DrawText(DialogFind(Player, "ZoneBlocked"), 1500, 700, "White", "Black");
+			if (InventoryGroupIsBlocked(C)) DrawText(GetPlayerDialog("ZoneBlocked"), 1500, 700, "White", "Black");
 			return;
 		}
 	}
@@ -2203,9 +2205,19 @@ function DialogDrawItemMenu(C) {
 	}
 
 	// Show the no access text
-	if (InventoryGroupIsBlocked(C)) DrawText(DialogFind(Player, "ZoneBlocked"), 1500, 700, "White", "Black");
-	else DrawText(DialogFind(Player, "AccessBlocked"), 1500, 700, "White", "Black");
+	if (InventoryGroupIsBlocked(C)) DrawText(GetPlayerDialog("ZoneBlocked"), 1500, 700, "White", "Black");
+	else DrawText(GetPlayerDialog("AccessBlocked"), 1500, 700, "White", "Black");
 
+}
+
+/**
+ * Searches in the dialog for a specific stage keyword and returns that dialog option if we find it, error otherwise
+ * @param {string} KeyWord - The key word to search for
+ * @returns {string}
+ */
+function GetPlayerDialog(KeyWord) {
+	const res = PlayerDialog.get(KeyWord);
+	return res !== undefined ? res : `MISSING PLAYER DIALOG: ${KeyWord}`;
 }
 
 /**
@@ -2261,7 +2273,7 @@ function DialogDraw() {
 
 	// Draw the menu for facial expressions if the player clicked on herself
 	if (CurrentCharacter.ID == 0) {
-		if (DialogSelfMenuOptions.filter(SMO => SMO.IsAvailable()).length > 1) DrawButton(420, 50, 90, 90, "", "White", "Icons/Next.png", DialogFind(Player, "NextPage"));
+		if (DialogSelfMenuOptions.filter(SMO => SMO.IsAvailable()).length > 1) DrawButton(420, 50, 90, 90, "", "White", "Icons/Next.png", GetPlayerDialog("NextPage"));
 		if (!DialogSelfMenuSelected)
 			DialogDrawExpressionMenu();
 		else
@@ -2284,7 +2296,7 @@ function DialogDraw() {
 
 		// Draw the 'Up' reposition button if some zones are offscreen
 		if (CurrentCharacter != null && CurrentCharacter.HeightModifier != null && CurrentCharacter.HeightModifier < -90 && CurrentCharacter.FocusGroup != null)
-			DrawButton(510, 50, 90, 90, "", "White", "Icons/Up.png", DialogFind(Player, "UpPosition"));
+			DrawButton(510, 50, 90, 90, "", "White", "Icons/Up.png", GetPlayerDialog("UpPosition"));
 
 	} else {
 
@@ -2316,11 +2328,11 @@ function DialogDraw() {
 function DialogDrawExpressionMenu() {
 
 	// Draw the expression groups
-	DrawText(DialogFind(Player, "FacialExpression"), 165, 25, "White", "Black");
+	DrawText(GetPlayerDialog("FacialExpression"), 165, 25, "White", "Black");
 	if (typeof DialogFacialExpressionsSelected === 'number' && DialogFacialExpressionsSelected >= 0 && DialogFacialExpressionsSelected < DialogFacialExpressions.length && DialogFacialExpressions[DialogFacialExpressionsSelected].Appearance.Asset.Group.AllowColorize && DialogFacialExpressions[DialogFacialExpressionsSelected].Group !== "Eyes") {
-		DrawButton(320, 50, 90, 90, "", "White", "Icons/ColorPick.png", DialogFind(Player, "ColorChange"));
+		DrawButton(320, 50, 90, 90, "", "White", "Icons/ColorPick.png", GetPlayerDialog("ColorChange"));
 	}
-	DrawButton(220, 50, 90, 90, "", "White", "Icons/BlindToggle" + DialogFacialExpressionsSelectedBlindnessLevel + ".png", DialogFind(Player, "BlindToggleFacialExpressions"));
+	DrawButton(220, 50, 90, 90, "", "White", "Icons/BlindToggle" + DialogFacialExpressionsSelectedBlindnessLevel + ".png", GetPlayerDialog("BlindToggleFacialExpressions"));
 	const Expression = WardrobeGetExpression(Player);
 	const Eye1Closed = Expression.Eyes === "Closed";
 	const Eye2Closed = Expression.Eyes2 === "Closed";
@@ -2328,8 +2340,8 @@ function DialogDrawExpressionMenu() {
 	if (Eye1Closed && Eye2Closed) WinkIcon = "WinkBoth";
 	else if (Eye1Closed) WinkIcon = "WinkR";
 	else if (Eye2Closed) WinkIcon = "WinkL";
-	DrawButton(120, 50, 90, 90, "", "White", `Icons/${WinkIcon}.png`, DialogFind(Player, "WinkFacialExpressions"));
-	DrawButton(20, 50, 90, 90, "", "White", "Icons/Reset.png", DialogFind(Player, "ClearFacialExpressions"));
+	DrawButton(120, 50, 90, 90, "", "White", `Icons/${WinkIcon}.png`, GetPlayerDialog("WinkFacialExpressions"));
+	DrawButton(20, 50, 90, 90, "", "White", "Icons/Reset.png", GetPlayerDialog("ClearFacialExpressions"));
 	if (!DialogFacialExpressions || !DialogFacialExpressions.length) DialogFacialExpressionsBuild();
 	for (let I = 0; I < DialogFacialExpressions.length; I++) {
 		const FE = DialogFacialExpressions[I];
@@ -2423,7 +2435,7 @@ function DialogClickExpressionMenu() {
  */
 function DialogDrawPoseMenu() { 
 	// Draw the pose groups
-	DrawText(DialogFind(Player, "PoseMenu"), 250, 100, "White", "Black");
+	DrawText(GetPlayerDialog("PoseMenu"), 250, 100, "White", "Black");
 
 	if (!DialogActivePoses || !DialogActivePoses.length) DialogActivePoseMenuBuild();
 	
@@ -2492,7 +2504,7 @@ function DialogViewOwnerRules() {
  */
 function DialogDrawOwnerRulesMenu() { 
 	// Draw the pose groups
-	DrawText(DialogFind(Player, "OwnerRulesMenu"), 230, 100, "White", "Black");
+	DrawText(GetPlayerDialog("OwnerRulesMenu"), 230, 100, "White", "Black");
 
 	var ToDisplay = [];
 	
@@ -2507,7 +2519,7 @@ function DialogDrawOwnerRulesMenu() {
 	
 	for (let I = 0; I < ToDisplay.length; I++) { 
 		var OffsetY = 230 + 100 * I;
-		DrawText(DialogFind(Player, "OwnerRulesMenu" + ToDisplay[I].Tag) + (ToDisplay[I].Value ?  " " + TimerToString(ToDisplay[I].Value - CurrentTime) : ""), 250, OffsetY, "White", "Black");
+		DrawText(GetPlayerDialog("OwnerRulesMenu" + ToDisplay[I].Tag) + (ToDisplay[I].Value ?  " " + TimerToString(ToDisplay[I].Value - CurrentTime) : ""), 250, OffsetY, "White", "Black");
 	}
 }
 

--- a/BondageClub/Scripts/Dialog.js
+++ b/BondageClub/Scripts/Dialog.js
@@ -847,17 +847,17 @@ function DialogActivePoseMenuBuild() {
  * @returns {string} - The appropriate dialog option
  */
 function DialogProgressGetOperation(C, PrevItem, NextItem) {
-	if ((PrevItem != null) && (NextItem != null)) return GetPlayerDialog("Swapping");
-	if ((C.ID == 0) && (PrevItem != null) && (SkillGetRatio("Evasion") != 1)) return GetPlayerDialog("Using" + (SkillGetRatio("Evasion") * 100).toString());
-	if (InventoryItemHasEffect(PrevItem, "Lock", true) && !DialogCanUnlock(C, PrevItem)) return GetPlayerDialog("Struggling");
-	if ((PrevItem != null) && !Player.CanInteract() && !InventoryItemHasEffect(PrevItem, "Block", true)) return GetPlayerDialog("Struggling");
-	if (InventoryItemHasEffect(PrevItem, "Lock", true)) return GetPlayerDialog("Unlocking");
-	if ((PrevItem != null) && InventoryItemHasEffect(PrevItem, "Mounted", true)) return GetPlayerDialog("Dismounting");
-	if ((PrevItem != null) && InventoryItemHasEffect(PrevItem, "Enclose", true)) return GetPlayerDialog("Escaping");
-	if (PrevItem != null) return GetPlayerDialog("Removing");
-	if ((PrevItem == null) && (NextItem != null) && (SkillGetRatio("Bondage") != 1)) return GetPlayerDialog("Using" + (SkillGetRatio("Bondage") * 100).toString());
-	if (InventoryItemHasEffect(NextItem, "Lock", true)) return GetPlayerDialog("Locking");
-	if ((PrevItem == null) && (NextItem != null)) return GetPlayerDialog("Adding");
+	if ((PrevItem != null) && (NextItem != null)) return DialogFindPlayer("Swapping");
+	if ((C.ID == 0) && (PrevItem != null) && (SkillGetRatio("Evasion") != 1)) return DialogFindPlayer("Using" + (SkillGetRatio("Evasion") * 100).toString());
+	if (InventoryItemHasEffect(PrevItem, "Lock", true) && !DialogCanUnlock(C, PrevItem)) return DialogFindPlayer("Struggling");
+	if ((PrevItem != null) && !Player.CanInteract() && !InventoryItemHasEffect(PrevItem, "Block", true)) return DialogFindPlayer("Struggling");
+	if (InventoryItemHasEffect(PrevItem, "Lock", true)) return DialogFindPlayer("Unlocking");
+	if ((PrevItem != null) && InventoryItemHasEffect(PrevItem, "Mounted", true)) return DialogFindPlayer("Dismounting");
+	if ((PrevItem != null) && InventoryItemHasEffect(PrevItem, "Enclose", true)) return DialogFindPlayer("Escaping");
+	if (PrevItem != null) return DialogFindPlayer("Removing");
+	if ((PrevItem == null) && (NextItem != null) && (SkillGetRatio("Bondage") != 1)) return DialogFindPlayer("Using" + (SkillGetRatio("Bondage") * 100).toString());
+	if (InventoryItemHasEffect(NextItem, "Lock", true)) return DialogFindPlayer("Locking");
+	if ((PrevItem == null) && (NextItem != null)) return DialogFindPlayer("Adding");
 	return "...";
 }
 
@@ -871,9 +871,9 @@ function DialogProgressGetOperation(C, PrevItem, NextItem) {
 function DialogLockPickProgressGetOperation(C, Item) {
 	var lock = InventoryGetLock(Item)
 	if ((Item != null && lock != null)) {
-		if (lock.Name == "CombinationPadlock" || lock.Name == "PasswordPadlock") return GetPlayerDialog("Decoding");
-		if (Item.Asset.Name.indexOf("Futuristic") >= 0 || Item.Asset.Name.indexOf("Interactive") >= 0) return GetPlayerDialog("Hacking");
-		return GetPlayerDialog("Picking");
+		if (lock.Name == "CombinationPadlock" || lock.Name == "PasswordPadlock") return DialogFindPlayer("Decoding");
+		if (Item.Asset.Name.indexOf("Futuristic") >= 0 || Item.Asset.Name.indexOf("Interactive") >= 0) return DialogFindPlayer("Hacking");
+		return DialogFindPlayer("Picking");
 	}
 	return "...";
 }
@@ -897,7 +897,7 @@ function DialogStruggle(Reverse) {
 	if (DialogProgress < 0) DialogProgress = 0;
 	if ((DialogProgress >= 100) && (DialogProgressChallenge > 6) && (DialogProgressAuto < 0)) DialogProgress = 99;
 	if (!Reverse) DialogProgressStruggleCount++;
-	if ((DialogProgressStruggleCount >= 50) && (DialogProgressChallenge > 6) && (DialogProgressAuto < 0)) DialogProgressOperation = GetPlayerDialog("Impossible");
+	if ((DialogProgressStruggleCount >= 50) && (DialogProgressChallenge > 6) && (DialogProgressAuto < 0)) DialogProgressOperation = DialogFindPlayer("Impossible");
 
 	// At 15 hit: low blush, 50: Medium and 125: High
 	if (DialogAllowBlush && !Reverse) {
@@ -1375,7 +1375,7 @@ function DialogPublishAction(C, ClickItem) {
 			}
 			else {
 				var intensity = TargetItem.Property ? TargetItem.Property.Intensity : 0;
-				var D = (GetPlayerDialog(TargetItem.Asset.Name + "Trigger" + intensity)).replace("DestinationCharacterName", C.Name);
+				var D = (DialogFindPlayer(TargetItem.Asset.Name + "Trigger" + intensity)).replace("DestinationCharacterName", C.Name);
 				if (D != "") {
 					InventoryExpressionTrigger(C, ClickItem);
 					C.CurrentDialog = "(" + D + ")";
@@ -1707,7 +1707,7 @@ function DialogFindNextSubMenu() {
  */
 function DialogSetText(NewText) {
 	DialogTextDefaultTimer = CommonTime() + 5000;
-	DialogText = GetPlayerDialog(NewText);
+	DialogText = DialogFindPlayer(NewText);
 }
 
 /**
@@ -1763,14 +1763,14 @@ function DialogDrawActivityMenu(C) {
 
 	// Gets the default text that will reset after 5 seconds
 	var SelectedGroup = (Player.FocusGroup != null) ? Player.FocusGroup.Description : CurrentCharacter.FocusGroup.Description;
-	if (DialogTextDefault == "") DialogTextDefault = GetPlayerDialog("SelectActivityGroup").replace("GroupName", SelectedGroup.toLowerCase());
+	if (DialogTextDefault == "") DialogTextDefault = DialogFindPlayer("SelectActivityGroup").replace("GroupName", SelectedGroup.toLowerCase());
 	if (DialogTextDefaultTimer < CommonTime()) DialogText = DialogTextDefault;
 
 	// Draws the top menu text & icons
 	if (DialogMenuButton == null) DialogMenuButtonBuild((Player.FocusGroup != null) ? Player : CurrentCharacter);
 	if (DialogMenuButton.length < 8) DrawTextWrap(DialogText, 1000, 0, 975 - DialogMenuButton.length * 110, 125, "White");
 	for (let I = DialogMenuButton.length - 1; I >= 0; I--)
-		DrawButton(1885 - I * 110, 15, 90, 90, "", "White", "Icons/" + DialogMenuButton[I] + ".png", GetPlayerDialog(DialogMenuButton[I]));
+		DrawButton(1885 - I * 110, 15, 90, 90, "", "White", "Icons/" + DialogMenuButton[I] + ".png", DialogFindPlayer(DialogMenuButton[I]));
 
 	// Prepares a 4x3 square selection with all activities in the buffer
 	var X = 1000;
@@ -1818,10 +1818,10 @@ function DialogDrawStruggleProgress(C) {
 	}
 
 	// Draw the current operation and progress
-	if (DialogProgressAuto < 0) DrawText(GetPlayerDialog("Challenge") + " " + ((DialogProgressStruggleCount >= 50) ? DialogProgressChallenge.toString() : "???"), 1500, 150, "White", "Black");
+	if (DialogProgressAuto < 0) DrawText(DialogFindPlayer("Challenge") + " " + ((DialogProgressStruggleCount >= 50) ? DialogProgressChallenge.toString() : "???"), 1500, 150, "White", "Black");
 	DrawText(DialogProgressOperation, 1500, 650, "White", "Black");
 	DrawProgressBar(1200, 700, 600, 100, DialogProgress);
-	DrawText(GetPlayerDialog((CommonIsMobile) ? "ProgressClick" : "ProgressKeys"), 1500, 900, "White", "Black");
+	DrawText(DialogFindPlayer((CommonIsMobile) ? "ProgressClick" : "ProgressKeys"), 1500, 900, "White", "Black");
 
 	// If the operation is completed
 	if (DialogProgress >= 100) {
@@ -1995,9 +1995,9 @@ function DialogDrawLockpickProgress(C) {
 	}
 
 
-	DrawText(GetPlayerDialog("LockpickTriesRemaining") + (DialogLockPickProgressMaxTries - DialogLockPickProgressCurrentTries), X, 212, "white");
+	DrawText(DialogFindPlayer("LockpickTriesRemaining") + (DialogLockPickProgressMaxTries - DialogLockPickProgressCurrentTries), X, 212, "white");
 	if (LogValue("FailedLockPick", "LockPick") > CurrentTime)
-		DrawText(GetPlayerDialog("LockpickFailedTimeout") + TimerToString(LogValue("FailedLockPick", "LockPick") - CurrentTime), X, 262, "red");
+		DrawText(DialogFindPlayer("LockpickFailedTimeout") + TimerToString(LogValue("FailedLockPick", "LockPick") - CurrentTime), X, 262, "red");
 	else {
 		if (DialogLockPickProgressCurrentTries >= DialogLockPickProgressMaxTries && DialogLockPickSuccessTime == 0) {
 			if (DialogLockPickFailTime > 0) {
@@ -2008,7 +2008,7 @@ function DialogDrawLockpickProgress(C) {
 					
 				}
 				else {
-					DrawText(GetPlayerDialog("LockpickFailed"), X, 262, "red");
+					DrawText(DialogFindPlayer("LockpickFailed"), X, 262, "red");
 				}
 			} else if (Math.random() < 0.25 && DialogLockPickTotalTries > 5) { // DialogLockPickTotalTries is meant to give players a bit of breathing room so they don't get tired right away
 				LogAdd("FailedLockPick", "LockPick", CurrentTime + DialogLockPickFailTimeout);
@@ -2023,8 +2023,8 @@ function DialogDrawLockpickProgress(C) {
 	}
 
 
-	DrawText(GetPlayerDialog("LockpickIntro"), X, 800, "white");
-	DrawText(GetPlayerDialog("LockpickIntro2"), X, 850, "white");
+	DrawText(DialogFindPlayer("LockpickIntro"), X, 800, "white");
+	DrawText(DialogFindPlayer("LockpickIntro2"), X, 850, "white");
 
 	if (DialogLockPickSuccessTime != 0) {
 		if (CurrentTime > DialogLockPickSuccessTime) {
@@ -2062,7 +2062,7 @@ function DialogDrawLockpickProgress(C) {
 				}
 
 				if (DialogLockPickArousalTick > 0 && DialogLockPickSet.filter(x => x==true).length > 0) {
-					DialogLockPickArousalText = GetPlayerDialog("LockPickArousal")
+					DialogLockPickArousalText = DialogFindPlayer("LockPickArousal")
 					if (DialogLockPickSet.filter(x => x==true).length < DialogLockPickSet.length) {
 						for (let P = DialogLockPickOrder.length; P >= 0; P--) {
 							if (DialogLockPickSet[DialogLockPickOrder[P]] == true) {
@@ -2104,16 +2104,16 @@ function DialogDrawItemMenu(C) {
 	}
 
 	// Gets the default text that will reset after 5 seconds
-	if (DialogTextDefault == "") DialogTextDefault = GetPlayerDialog("SelectItemGroup").replace("GroupName", C.FocusGroup.Description.toLowerCase());
+	if (DialogTextDefault == "") DialogTextDefault = DialogFindPlayer("SelectItemGroup").replace("GroupName", C.FocusGroup.Description.toLowerCase());
 	if (DialogTextDefaultTimer < CommonTime()) DialogText = DialogTextDefault;
 
 	// Draws the top menu text & icons
 	if (DialogMenuButton == null) DialogMenuButtonBuild(CharacterGetCurrent());
-	if ((DialogColor == null) && Player.CanInteract() && (DialogProgress < 0 && !DialogLockPickOrder) && !InventoryGroupIsBlocked(C) && DialogMenuButton.length < 8) DrawTextWrap((!DialogItemPermissionMode) ? DialogText : GetPlayerDialog("DialogPermissionMode"), 1000, 0, 975 - DialogMenuButton.length * 110, 125, "White", null, 3);
+	if ((DialogColor == null) && Player.CanInteract() && (DialogProgress < 0 && !DialogLockPickOrder) && !InventoryGroupIsBlocked(C) && DialogMenuButton.length < 8) DrawTextWrap((!DialogItemPermissionMode) ? DialogText : DialogFindPlayer("DialogPermissionMode"), 1000, 0, 975 - DialogMenuButton.length * 110, 125, "White", null, 3);
 	for (let I = DialogMenuButton.length - 1; I >= 0; I--) {
 		let ButtonColor = (DialogMenuButton[I] == "ColorPick") && (DialogColorSelect != null) ? DialogColorSelect : "White";
 		let ButtonImage = DialogMenuButton[I] == "ColorPick" && !ItemColorIsSimple(FocusItem) ? "MultiColorPick" : DialogMenuButton[I];
-		let ButtonHoverText = (DialogColor == null) ? GetPlayerDialog(DialogMenuButton[I]) : null;
+		let ButtonHoverText = (DialogColor == null) ? DialogFindPlayer(DialogMenuButton[I]) : null;
 		DrawButton(1885 - I * 110, 15, 90, 90, "", ButtonColor, "Icons/" + ButtonImage + ".png", ButtonHoverText);
 	}
 	
@@ -2173,7 +2173,7 @@ function DialogDrawItemMenu(C) {
 		}
 
 		if (DialogInventory.length > 0) {
-			if (InventoryGroupIsBlocked(C)) DrawText(GetPlayerDialog("ZoneBlocked"), 1500, 700, "White", "Black");
+			if (InventoryGroupIsBlocked(C)) DrawText(DialogFindPlayer("ZoneBlocked"), 1500, 700, "White", "Black");
 			return;
 		}
 	}
@@ -2205,8 +2205,8 @@ function DialogDrawItemMenu(C) {
 	}
 
 	// Show the no access text
-	if (InventoryGroupIsBlocked(C)) DrawText(GetPlayerDialog("ZoneBlocked"), 1500, 700, "White", "Black");
-	else DrawText(GetPlayerDialog("AccessBlocked"), 1500, 700, "White", "Black");
+	if (InventoryGroupIsBlocked(C)) DrawText(DialogFindPlayer("ZoneBlocked"), 1500, 700, "White", "Black");
+	else DrawText(DialogFindPlayer("AccessBlocked"), 1500, 700, "White", "Black");
 
 }
 
@@ -2215,7 +2215,7 @@ function DialogDrawItemMenu(C) {
  * @param {string} KeyWord - The key word to search for
  * @returns {string}
  */
-function GetPlayerDialog(KeyWord) {
+function DialogFindPlayer(KeyWord) {
 	const res = PlayerDialog.get(KeyWord);
 	return res !== undefined ? res : `MISSING PLAYER DIALOG: ${KeyWord}`;
 }
@@ -2273,7 +2273,7 @@ function DialogDraw() {
 
 	// Draw the menu for facial expressions if the player clicked on herself
 	if (CurrentCharacter.ID == 0) {
-		if (DialogSelfMenuOptions.filter(SMO => SMO.IsAvailable()).length > 1) DrawButton(420, 50, 90, 90, "", "White", "Icons/Next.png", GetPlayerDialog("NextPage"));
+		if (DialogSelfMenuOptions.filter(SMO => SMO.IsAvailable()).length > 1) DrawButton(420, 50, 90, 90, "", "White", "Icons/Next.png", DialogFindPlayer("NextPage"));
 		if (!DialogSelfMenuSelected)
 			DialogDrawExpressionMenu();
 		else
@@ -2296,7 +2296,7 @@ function DialogDraw() {
 
 		// Draw the 'Up' reposition button if some zones are offscreen
 		if (CurrentCharacter != null && CurrentCharacter.HeightModifier != null && CurrentCharacter.HeightModifier < -90 && CurrentCharacter.FocusGroup != null)
-			DrawButton(510, 50, 90, 90, "", "White", "Icons/Up.png", GetPlayerDialog("UpPosition"));
+			DrawButton(510, 50, 90, 90, "", "White", "Icons/Up.png", DialogFindPlayer("UpPosition"));
 
 	} else {
 
@@ -2328,11 +2328,11 @@ function DialogDraw() {
 function DialogDrawExpressionMenu() {
 
 	// Draw the expression groups
-	DrawText(GetPlayerDialog("FacialExpression"), 165, 25, "White", "Black");
+	DrawText(DialogFindPlayer("FacialExpression"), 165, 25, "White", "Black");
 	if (typeof DialogFacialExpressionsSelected === 'number' && DialogFacialExpressionsSelected >= 0 && DialogFacialExpressionsSelected < DialogFacialExpressions.length && DialogFacialExpressions[DialogFacialExpressionsSelected].Appearance.Asset.Group.AllowColorize && DialogFacialExpressions[DialogFacialExpressionsSelected].Group !== "Eyes") {
-		DrawButton(320, 50, 90, 90, "", "White", "Icons/ColorPick.png", GetPlayerDialog("ColorChange"));
+		DrawButton(320, 50, 90, 90, "", "White", "Icons/ColorPick.png", DialogFindPlayer("ColorChange"));
 	}
-	DrawButton(220, 50, 90, 90, "", "White", "Icons/BlindToggle" + DialogFacialExpressionsSelectedBlindnessLevel + ".png", GetPlayerDialog("BlindToggleFacialExpressions"));
+	DrawButton(220, 50, 90, 90, "", "White", "Icons/BlindToggle" + DialogFacialExpressionsSelectedBlindnessLevel + ".png", DialogFindPlayer("BlindToggleFacialExpressions"));
 	const Expression = WardrobeGetExpression(Player);
 	const Eye1Closed = Expression.Eyes === "Closed";
 	const Eye2Closed = Expression.Eyes2 === "Closed";
@@ -2340,8 +2340,8 @@ function DialogDrawExpressionMenu() {
 	if (Eye1Closed && Eye2Closed) WinkIcon = "WinkBoth";
 	else if (Eye1Closed) WinkIcon = "WinkR";
 	else if (Eye2Closed) WinkIcon = "WinkL";
-	DrawButton(120, 50, 90, 90, "", "White", `Icons/${WinkIcon}.png`, GetPlayerDialog("WinkFacialExpressions"));
-	DrawButton(20, 50, 90, 90, "", "White", "Icons/Reset.png", GetPlayerDialog("ClearFacialExpressions"));
+	DrawButton(120, 50, 90, 90, "", "White", `Icons/${WinkIcon}.png`, DialogFindPlayer("WinkFacialExpressions"));
+	DrawButton(20, 50, 90, 90, "", "White", "Icons/Reset.png", DialogFindPlayer("ClearFacialExpressions"));
 	if (!DialogFacialExpressions || !DialogFacialExpressions.length) DialogFacialExpressionsBuild();
 	for (let I = 0; I < DialogFacialExpressions.length; I++) {
 		const FE = DialogFacialExpressions[I];
@@ -2435,7 +2435,7 @@ function DialogClickExpressionMenu() {
  */
 function DialogDrawPoseMenu() { 
 	// Draw the pose groups
-	DrawText(GetPlayerDialog("PoseMenu"), 250, 100, "White", "Black");
+	DrawText(DialogFindPlayer("PoseMenu"), 250, 100, "White", "Black");
 
 	if (!DialogActivePoses || !DialogActivePoses.length) DialogActivePoseMenuBuild();
 	
@@ -2504,7 +2504,7 @@ function DialogViewOwnerRules() {
  */
 function DialogDrawOwnerRulesMenu() { 
 	// Draw the pose groups
-	DrawText(GetPlayerDialog("OwnerRulesMenu"), 230, 100, "White", "Black");
+	DrawText(DialogFindPlayer("OwnerRulesMenu"), 230, 100, "White", "Black");
 
 	var ToDisplay = [];
 	
@@ -2519,7 +2519,7 @@ function DialogDrawOwnerRulesMenu() {
 	
 	for (let I = 0; I < ToDisplay.length; I++) { 
 		var OffsetY = 230 + 100 * I;
-		DrawText(GetPlayerDialog("OwnerRulesMenu" + ToDisplay[I].Tag) + (ToDisplay[I].Value ?  " " + TimerToString(ToDisplay[I].Value - CurrentTime) : ""), 250, OffsetY, "White", "Black");
+		DrawText(DialogFindPlayer("OwnerRulesMenu" + ToDisplay[I].Tag) + (ToDisplay[I].Value ?  " " + TimerToString(ToDisplay[I].Value - CurrentTime) : ""), 250, OffsetY, "White", "Black");
 	}
 }
 

--- a/BondageClub/Scripts/ExtendedItem.js
+++ b/BondageClub/Scripts/ExtendedItem.js
@@ -112,7 +112,7 @@ function ExtendedItemLoad(Options, DialogKey) {
 
 	if (ExtendedItemOffsets[ExtendedItemOffsetKey()] == null) ExtendedItemSetOffset(0);
 
-	DialogExtendedMessage = GetPlayerDialog(DialogKey);
+	DialogExtendedMessage = DialogFindPlayer(DialogKey);
 }
 
 /**
@@ -165,14 +165,14 @@ function ExtendedItemDraw(Options, DialogPrefix, OptionsPerPage, ShowImages = tr
 
 		DrawButton(X, Y, 225, 55 + ImageHeight, "", Color, null, null, IsSelected);
 		if (ShowImages) DrawImage("Screens/Inventory/" + Asset.Group.Name + "/" + Asset.Name + "/" + Option.Name + ".png", X + 2, Y);
-		DrawTextFit(GetPlayerDialog(DialogPrefix + Option.Name), X + 112, Y + 30 + ImageHeight, 225, "black");
+		DrawTextFit(DialogFindPlayer(DialogPrefix + Option.Name), X + 112, Y + 30 + ImageHeight, 225, "black");
 		if (ControllerActive == true) {
 			setButton(X + 112, Y + 30 + ImageHeight);
 		}
 	}
 	
 	// Permission mode toggle is always available
-	DrawButton(1775, 25, 90, 90, "", "White", ExtendedItemPermissionMode ? "Icons/DialogNormalMode.png" : "Icons/DialogPermissionMode.png", GetPlayerDialog(ExtendedItemPermissionMode ? "DialogNormalMode" : "DialogPermissionMode"));
+	DrawButton(1775, 25, 90, 90, "", "White", ExtendedItemPermissionMode ? "Icons/DialogNormalMode.png" : "Icons/DialogPermissionMode.png", DialogFindPlayer(ExtendedItemPermissionMode ? "DialogNormalMode" : "DialogPermissionMode"));
 }
 
 /**
@@ -344,12 +344,12 @@ function ExtendedItemRequirementCheckMessage(Option, IsSelfBondage) {
 	if (IsSelfBondage) {
 		let RequiredLevel = Option.SelfBondageLevel || Math.max(DialogFocusItem.Asset.SelfBondage, Option.BondageLevel);
 		if (SkillGetLevelReal(Player, "SelfBondage") < RequiredLevel) {
-			return GetPlayerDialog("RequireSelfBondage" + RequiredLevel);
+			return DialogFindPlayer("RequireSelfBondage" + RequiredLevel);
 		}
 	} else {
 		let RequiredLevel = Option.BondageLevel;
 		if (SkillGetLevelReal(Player, "Bondage") < RequiredLevel) {
-			return GetPlayerDialog("RequireBondageLevel").replace("ReqLevel", RequiredLevel);
+			return DialogFindPlayer("RequireBondageLevel").replace("ReqLevel", RequiredLevel);
 		}
 	}
 
@@ -368,7 +368,7 @@ function ExtendedItemRequirementCheckMessage(Option, IsSelfBondage) {
 	} else {
 		const OldEffect= DialogFocusItem && DialogFocusItem.Property && DialogFocusItem.Property.Effect;
 		if (OldEffect && OldEffect.includes("Lock") && Option.Property.AllowLock === false) {
-			DialogExtendedMessage = GetPlayerDialog("ExtendedItemUnlockBeforeChange");
+			DialogExtendedMessage = DialogFindPlayer("ExtendedItemUnlockBeforeChange");
 			return DialogExtendedMessage;
 		}
 	}

--- a/BondageClub/Scripts/ExtendedItem.js
+++ b/BondageClub/Scripts/ExtendedItem.js
@@ -112,7 +112,7 @@ function ExtendedItemLoad(Options, DialogKey) {
 
 	if (ExtendedItemOffsets[ExtendedItemOffsetKey()] == null) ExtendedItemSetOffset(0);
 
-	DialogExtendedMessage = DialogFind(Player, DialogKey);
+	DialogExtendedMessage = GetPlayerDialog(DialogKey);
 }
 
 /**
@@ -165,14 +165,14 @@ function ExtendedItemDraw(Options, DialogPrefix, OptionsPerPage, ShowImages = tr
 
 		DrawButton(X, Y, 225, 55 + ImageHeight, "", Color, null, null, IsSelected);
 		if (ShowImages) DrawImage("Screens/Inventory/" + Asset.Group.Name + "/" + Asset.Name + "/" + Option.Name + ".png", X + 2, Y);
-		DrawTextFit(DialogFind(Player, DialogPrefix + Option.Name), X + 112, Y + 30 + ImageHeight, 225, "black");
+		DrawTextFit(GetPlayerDialog(DialogPrefix + Option.Name), X + 112, Y + 30 + ImageHeight, 225, "black");
 		if (ControllerActive == true) {
 			setButton(X + 112, Y + 30 + ImageHeight);
 		}
 	}
 	
 	// Permission mode toggle is always available
-	DrawButton(1775, 25, 90, 90, "", "White", ExtendedItemPermissionMode ? "Icons/DialogNormalMode.png" : "Icons/DialogPermissionMode.png", DialogFind(Player, ExtendedItemPermissionMode ? "DialogNormalMode" : "DialogPermissionMode"));
+	DrawButton(1775, 25, 90, 90, "", "White", ExtendedItemPermissionMode ? "Icons/DialogNormalMode.png" : "Icons/DialogPermissionMode.png", GetPlayerDialog(ExtendedItemPermissionMode ? "DialogNormalMode" : "DialogPermissionMode"));
 }
 
 /**
@@ -344,12 +344,12 @@ function ExtendedItemRequirementCheckMessage(Option, IsSelfBondage) {
 	if (IsSelfBondage) {
 		let RequiredLevel = Option.SelfBondageLevel || Math.max(DialogFocusItem.Asset.SelfBondage, Option.BondageLevel);
 		if (SkillGetLevelReal(Player, "SelfBondage") < RequiredLevel) {
-			return DialogFind(Player, "RequireSelfBondage" + RequiredLevel);
+			return GetPlayerDialog("RequireSelfBondage" + RequiredLevel);
 		}
 	} else {
 		let RequiredLevel = Option.BondageLevel;
 		if (SkillGetLevelReal(Player, "Bondage") < RequiredLevel) {
-			return DialogFind(Player, "RequireBondageLevel").replace("ReqLevel", RequiredLevel);
+			return GetPlayerDialog("RequireBondageLevel").replace("ReqLevel", RequiredLevel);
 		}
 	}
 
@@ -368,7 +368,7 @@ function ExtendedItemRequirementCheckMessage(Option, IsSelfBondage) {
 	} else {
 		const OldEffect= DialogFocusItem && DialogFocusItem.Property && DialogFocusItem.Property.Effect;
 		if (OldEffect && OldEffect.includes("Lock") && Option.Property.AllowLock === false) {
-			DialogExtendedMessage = DialogFind(Player, "ExtendedItemUnlockBeforeChange");
+			DialogExtendedMessage = GetPlayerDialog("ExtendedItemUnlockBeforeChange");
 			return DialogExtendedMessage;
 		}
 	}

--- a/BondageClub/Scripts/Server.js
+++ b/BondageClub/Scripts/Server.js
@@ -707,9 +707,9 @@ function ServerAccountBeep(data) {
 				ServerBeepAudio.volume = Player.AudioSettings.Volume;
 				ServerBeepAudio.play();
 			}
-			ServerBeep.Message = DialogFind(Player, "BeepFrom") + " " + ServerBeep.MemberName + " (" + ServerBeep.MemberNumber.toString() + ")";
+			ServerBeep.Message = GetPlayerDialog("BeepFrom") + " " + ServerBeep.MemberName + " (" + ServerBeep.MemberNumber.toString() + ")";
 			if (ServerBeep.ChatRoomName != null)
-				ServerBeep.Message = ServerBeep.Message + " " + DialogFind(Player, "InRoom") + " \"" + ServerBeep.ChatRoomName + "\" " + (data.ChatRoomSpace === "Asylum" ? DialogFind(Player, "InAsylum") : '');
+				ServerBeep.Message = ServerBeep.Message + " " + GetPlayerDialog("InRoom") + " \"" + ServerBeep.ChatRoomName + "\" " + (data.ChatRoomSpace === "Asylum" ? GetPlayerDialog("InAsylum") : '');
 			FriendListBeepLog.push({ MemberNumber: data.MemberNumber, MemberName: data.MemberName, ChatRoomName: data.ChatRoomName, ChatRoomSpace: data.ChatRoomSpace, Sent: false, Time: new Date() });
 			if (CurrentScreen == "FriendList") ServerSend("AccountQuery", { Query: "OnlineFriends" });
 			if (Player.NotificationSettings.Beeps && !document.hasFocus()) CommonNotificationIncrement("Beep");

--- a/BondageClub/Scripts/Server.js
+++ b/BondageClub/Scripts/Server.js
@@ -707,9 +707,9 @@ function ServerAccountBeep(data) {
 				ServerBeepAudio.volume = Player.AudioSettings.Volume;
 				ServerBeepAudio.play();
 			}
-			ServerBeep.Message = GetPlayerDialog("BeepFrom") + " " + ServerBeep.MemberName + " (" + ServerBeep.MemberNumber.toString() + ")";
+			ServerBeep.Message = DialogFindPlayer("BeepFrom") + " " + ServerBeep.MemberName + " (" + ServerBeep.MemberNumber.toString() + ")";
 			if (ServerBeep.ChatRoomName != null)
-				ServerBeep.Message = ServerBeep.Message + " " + GetPlayerDialog("InRoom") + " \"" + ServerBeep.ChatRoomName + "\" " + (data.ChatRoomSpace === "Asylum" ? GetPlayerDialog("InAsylum") : '');
+				ServerBeep.Message = ServerBeep.Message + " " + DialogFindPlayer("InRoom") + " \"" + ServerBeep.ChatRoomName + "\" " + (data.ChatRoomSpace === "Asylum" ? DialogFindPlayer("InAsylum") : '');
 			FriendListBeepLog.push({ MemberNumber: data.MemberNumber, MemberName: data.MemberName, ChatRoomName: data.ChatRoomName, ChatRoomSpace: data.ChatRoomSpace, Sent: false, Time: new Date() });
 			if (CurrentScreen == "FriendList") ServerSend("AccountQuery", { Query: "OnlineFriends" });
 			if (Player.NotificationSettings.Beeps && !document.hasFocus()) CommonNotificationIncrement("Beep");

--- a/BondageClub/Scripts/Timer.js
+++ b/BondageClub/Scripts/Timer.js
@@ -129,10 +129,10 @@ function TimerPrivateOwnerBeep() {
 	if ((Player.Owner != "") && (Player.Ownership == null) && (CurrentScreen != "Private") && (CurrentScreen != "ChatRoom") && (CurrentScreen != "InformationSheet") && (CurrentScreen != "FriendList") && (CurrentScreen != "Cell") && PrivateOwnerInRoom())
 		if ((Math.floor(Math.random() * 500) == 1) && !LogQuery("OwnerBeepActive", "PrivateRoom") && !LogQuery("OwnerBeepTimer", "PrivateRoom") && !LogQuery("LockOutOfPrivateRoom", "Rule") && !LogQuery("Committed", "Asylum")) {
 			ServerBeep.Timer = CurrentTime + 15000;
-			ServerBeep.Message = DialogFind(Player, "BeepFromOwner");
+			ServerBeep.Message = GetPlayerDialog("BeepFromOwner");
 			LogAdd("OwnerBeepActive", "PrivateRoom");
 			LogAdd("OwnerBeepTimer", "PrivateRoom", CurrentTime + 120000);
-			FriendListBeepLog.push({ MemberName: Player.Owner, ChatRoomName: DialogFind(Player, "YourRoom"), Sent: false, Time: new Date() });
+			FriendListBeepLog.push({ MemberName: Player.Owner, ChatRoomName: GetPlayerDialog("YourRoom"), Sent: false, Time: new Date() });
 		}
 }
 

--- a/BondageClub/Scripts/Timer.js
+++ b/BondageClub/Scripts/Timer.js
@@ -129,10 +129,10 @@ function TimerPrivateOwnerBeep() {
 	if ((Player.Owner != "") && (Player.Ownership == null) && (CurrentScreen != "Private") && (CurrentScreen != "ChatRoom") && (CurrentScreen != "InformationSheet") && (CurrentScreen != "FriendList") && (CurrentScreen != "Cell") && PrivateOwnerInRoom())
 		if ((Math.floor(Math.random() * 500) == 1) && !LogQuery("OwnerBeepActive", "PrivateRoom") && !LogQuery("OwnerBeepTimer", "PrivateRoom") && !LogQuery("LockOutOfPrivateRoom", "Rule") && !LogQuery("Committed", "Asylum")) {
 			ServerBeep.Timer = CurrentTime + 15000;
-			ServerBeep.Message = GetPlayerDialog("BeepFromOwner");
+			ServerBeep.Message = DialogFindPlayer("BeepFromOwner");
 			LogAdd("OwnerBeepActive", "PrivateRoom");
 			LogAdd("OwnerBeepTimer", "PrivateRoom", CurrentTime + 120000);
-			FriendListBeepLog.push({ MemberName: Player.Owner, ChatRoomName: GetPlayerDialog("YourRoom"), Sent: false, Time: new Date() });
+			FriendListBeepLog.push({ MemberName: Player.Owner, ChatRoomName: DialogFindPlayer("YourRoom"), Sent: false, Time: new Date() });
 		}
 }
 

--- a/BondageClub/Scripts/VibratorMode.js
+++ b/BondageClub/Scripts/VibratorMode.js
@@ -199,7 +199,7 @@ function VibratorModeDrawControls(Options, Y) {
 	Options = Options || [VibratorModeSet.STANDARD];
 	var Property = DialogFocusItem.Property;
 	if (Property == null) return;
-	var ItemIntensity = DialogFind(Player, "Intensity" + Property.Intensity.toString()).replace("Item", DialogFocusItem.Asset.Description);
+	var ItemIntensity = GetPlayerDialog("Intensity" + Property.Intensity.toString()).replace("Item", DialogFocusItem.Asset.Description);
 	DrawText(ItemIntensity, 1500, Y, "white", "gray");
 
 	Options.forEach((OptionName) => {
@@ -208,7 +208,7 @@ function VibratorModeDrawControls(Options, Y) {
 			var X = 1175 + (I % 3) * 225;
 			if (I % 3 === 0) Y += 75;
 			var Color = Property.Mode === Option.Property.Mode ? "#888" : "White";
-			DrawButton(X, Y, 200, 55, DialogFind(Player, Option.Name), Color);
+			DrawButton(X, Y, 200, 55, GetPlayerDialog(Option.Name), Color);
 		});
 		Y += 40;
 	});

--- a/BondageClub/Scripts/VibratorMode.js
+++ b/BondageClub/Scripts/VibratorMode.js
@@ -199,7 +199,7 @@ function VibratorModeDrawControls(Options, Y) {
 	Options = Options || [VibratorModeSet.STANDARD];
 	var Property = DialogFocusItem.Property;
 	if (Property == null) return;
-	var ItemIntensity = GetPlayerDialog("Intensity" + Property.Intensity.toString()).replace("Item", DialogFocusItem.Asset.Description);
+	var ItemIntensity = DialogFindPlayer("Intensity" + Property.Intensity.toString()).replace("Item", DialogFocusItem.Asset.Description);
 	DrawText(ItemIntensity, 1500, Y, "white", "gray");
 
 	Options.forEach((OptionName) => {
@@ -208,7 +208,7 @@ function VibratorModeDrawControls(Options, Y) {
 			var X = 1175 + (I % 3) * 225;
 			if (I % 3 === 0) Y += 75;
 			var Color = Property.Mode === Option.Property.Mode ? "#888" : "White";
-			DrawButton(X, Y, 200, 55, GetPlayerDialog(Option.Name), Color);
+			DrawButton(X, Y, 200, 55, DialogFindPlayer(Option.Name), Color);
 		});
 		Y += 40;
 	});


### PR DESCRIPTION
Creates new function `GetPlayerDialog`, that works in similar way to heavily used `DialogFind(Player, ...)`, but is lot faster and if text is not found, it returns error instead of last dialog.
Error is in format `MISSING PLAYER DIALOG: ${KeyWord}` similar to `TextGet`'s `MISSING VALUE FOR TAG: ${TextTag}`

Also replaces all appropriate calls with new function.

I didn't test every change, but this change will make errors easily visible.