### PR TITLE
Refactor: DrawAssetPreview

### DIFF
--- a/BondageClub/Screens/Character/Appearance/Appearance.js
+++ b/BondageClub/Screens/Character/Appearance/Appearance.js
@@ -25,6 +25,12 @@ const CanvasUpperOverflow = 700;
 const CanvasLowerOverflow = 150;
 const CanvasDrawHeight = 1000 + CanvasUpperOverflow + CanvasLowerOverflow;
 
+const AppearancePermissionColors = {
+	red: ["pink", "red"],
+	amber: ["#fed8b1", "orange"],
+	green: ["lime", "green"],
+};
+
 /**
  * Builds all the assets that can be used to dress up the character
  * @param {Character} C - The character whose appearance is modified
@@ -659,21 +665,15 @@ function AppearanceRun() {
 	if (CharacterAppearanceMode == "Cloth") {
 
 		// Prepares a 3x3 square of clothes to present all the possible options
-		var X = 1250;
-		var Y = 125;
+		let X = 1250;
+		let Y = 125;
 		for (let I = DialogInventoryOffset; (I < DialogInventory.length) && (I < DialogInventoryOffset + 9); I++) {
 			var Item = DialogInventory[I];
-			var Hover = (MouseX >= X) && (MouseX < X + 225) && (MouseY >= Y) && (MouseY < Y + 275) && !CommonIsMobile;
-			var Block = InventoryIsPermissionBlocked(C, Item.Asset.DynamicName(Player), Item.Asset.DynamicGroupName);
-			var Limit = InventoryIsPermissionLimited(C, Item.Asset.Name, Item.Asset.Group.Name);
-			var Unusable = DialogInventory[I].SortOrder.startsWith(DialogSortOrderUnusable.toString());
-			var Blocked = DialogInventory[I].SortOrder.startsWith(DialogSortOrderBlocked.toString());
-			DrawRect(X, Y, 225, 275, (DialogItemPermissionMode && C.ID == 0) ?
-				(Item.Worn ? "gray" : Block ? Hover ? "red" : "pink" : Limit ? Hover ? "orange" : "#fed8b1" : Hover ? "green" : "lime") :
-				((Hover && !Blocked) ? "cyan" : Item.Worn ? "pink" : Blocked ? "red" : Unusable ? "gray" : "white"));
-			if (Item.Worn && InventoryItemHasEffect(InventoryGet(C, Item.Asset.Group.Name), "Vibrating", true)) DrawImageResize("Assets/" + Item.Asset.Group.Family + "/" + Item.Asset.Group.Name + "/Preview/" + Item.Asset.Name + ".png", X + Math.floor(Math.random() * 3) + 1, Y + Math.floor(Math.random() * 3) + 1, 221, 221);
-			else DrawImageResize("Assets/" + Item.Asset.Group.Family + "/" + Item.Asset.DynamicGroupName + "/Preview/" + Item.Asset.Name + Item.Asset.DynamicPreviewIcon(CharacterGetCurrent()) + ".png", X + 2, Y + 2, 221, 221);
-			DrawTextFit(Item.Asset.DynamicDescription(Player), X + 112, Y + 250, 221, "black");
+			var Hover = MouseIn(X, Y, 225, 275);
+
+			const BackgroundColor = AppearanceGetPreviewImageColor(C, Item, Hover);
+			const IsVibrating = Item.Worn && InventoryItemHasEffect(InventoryGet(C, Item.Asset.Group.Name), "Vibrating", true);
+			DrawAssetPreview(X, Y, Item.Asset, BackgroundColor, IsVibrating);
 			if (Item.Icon != "") DrawImage("Icons/" + Item.Icon + ".png", X + 2, Y + 110);
 			X = X + 250;
 			if (X > 1800) {
@@ -684,6 +684,30 @@ function AppearanceRun() {
 
 	}
 
+}
+
+/**
+ * Calculates the background color of the preview image for and item
+ * @param {Character} C - The character whose appearance we are viewing
+ * @param {Item} item - The item to calculate the color for
+ * @param {boolean} hover - Whether or not the item is currently hovering over the preview image
+ * @returns {string} - A CSS color string determining the color that the preview icon should be drawn in
+ */
+function AppearanceGetPreviewImageColor(C, item, hover) {
+	if (DialogItemPermissionMode && C.ID === 0) {
+		let permission = "green";
+		if (InventoryIsPermissionBlocked(C, item.Asset.DynamicName(Player), item.Asset.DynamicGroupName)) permission = "red";
+		else if (InventoryIsPermissionLimited(C, item.Asset.Name, item.Asset.Group.Name)) permission = "amber";
+		return item.Worn ? "gray" : AppearancePermissionColors[permission][hover ? 1 : 0];
+	} else {
+		const Unusable = item.SortOrder.startsWith(DialogSortOrderUnusable.toString());
+		const Blocked = item.SortOrder.startsWith(DialogSortOrderBlocked.toString());
+		if (hover && !Blocked) return "cyan";
+		else if (item.Worn) return "pink";
+		else if (Blocked) return "red";
+		else if (Unusable) return "gray";
+		else return "white";
+	}
 }
 
 /**

--- a/BondageClub/Screens/Character/Appearance/Appearance.js
+++ b/BondageClub/Screens/Character/Appearance/Appearance.js
@@ -671,12 +671,12 @@ function AppearanceRun() {
 		for (let I = DialogInventoryOffset; (I < DialogInventory.length) && (I < DialogInventoryOffset + 9); I++) {
 			const Item = DialogInventory[I];
 			const Hover = MouseIn(X, Y, 225, 275) && !CommonIsMobile;
-			const BackgroundColor = AppearanceGetPreviewImageColor(C, Item, Hover);
+			const Background = AppearanceGetPreviewImageColor(C, Item, Hover);
 			const Vibrating = Item.Worn && InventoryItemHasEffect(InventoryGet(C, Item.Asset.Group.Name), "Vibrating", true);
 			const Hidden = CharacterAppearanceItemIsHidden(Item.Asset.Name, Item.Asset.Group.Name);
 
-			if (Hidden) DrawPreviewBox(X, Y, "Icons/HiddenItem.png", Item.Asset.Description, BackgroundColor);
-			else DrawAssetPreview(X, Y, Item.Asset, null, null, BackgroundColor, null, Vibrating);
+			if (Hidden) DrawPreviewBox(X, Y, "Icons/HiddenItem.png", Item.Asset.Description, { Background });
+			else DrawAssetPreview(X, Y, Item.Asset, null, null, Background, null, Vibrating);
 
 			if (Item.Icon != "") DrawImage("Icons/" + Item.Icon + ".png", X + 2, Y + 110);
 			X = X + 250;

--- a/BondageClub/Screens/Character/Appearance/Appearance.js
+++ b/BondageClub/Screens/Character/Appearance/Appearance.js
@@ -353,7 +353,8 @@ function CharacterAppearanceSortLayers(C) {
  * @param {Character} C - The character whose assets are checked
  * @param {string} AssetName - The name of the asset to check
  * @param {string} GroupName - The name of the item group to check
- * @param {boolean} Recursive - If TRUE, then other items which are themselves hidden will not hide this item. Parameterising this prevents infinite loops.
+ * @param {boolean} Recursive - If TRUE, then other items which are themselves hidden will not hide this item. Parameterising this prevents
+ *     infinite loops.
  * @returns {boolean} - Returns TRUE if we can show the item or the item group
  */
 function CharacterAppearanceVisible(C, AssetName, GroupName, Recursive = true) {
@@ -507,8 +508,9 @@ function CharacterAppearanceXOffset(C, HeightRatio) {
 }
 
 /**
- * Repositions the character vertically towards the bottom of the canvas (the 'floor'), since shorter characters will be shrunk towards the top
- * HeightRatioProportion controls how much of this offset applies with 1 (max) positioning them on the "floor" and 0 (min) leaving them up at the 'ceiling'
+ * Repositions the character vertically towards the bottom of the canvas (the 'floor'), since shorter characters will be shrunk towards the
+ * top HeightRatioProportion controls how much of this offset applies with 1 (max) positioning them on the "floor" and 0 (min) leaving them
+ * up at the 'ceiling'
  * @param {Character} C - The character to reposition
  * @param {number} HeightRatio - The character's height ratio
  * @returns {number} - The amounnt to move the character along the Y co-ordinate
@@ -663,17 +665,19 @@ function AppearanceRun() {
 
 	// In cloth selection mode
 	if (CharacterAppearanceMode == "Cloth") {
-
 		// Prepares a 3x3 square of clothes to present all the possible options
 		let X = 1250;
 		let Y = 125;
 		for (let I = DialogInventoryOffset; (I < DialogInventory.length) && (I < DialogInventoryOffset + 9); I++) {
-			var Item = DialogInventory[I];
-			var Hover = MouseIn(X, Y, 225, 275);
-
+			const Item = DialogInventory[I];
+			const Hover = MouseIn(X, Y, 225, 275) && !CommonIsMobile;
 			const BackgroundColor = AppearanceGetPreviewImageColor(C, Item, Hover);
-			const IsVibrating = Item.Worn && InventoryItemHasEffect(InventoryGet(C, Item.Asset.Group.Name), "Vibrating", true);
-			DrawAssetPreview(X, Y, Item.Asset, null, BackgroundColor, null, IsVibrating);
+			const Vibrating = Item.Worn && InventoryItemHasEffect(InventoryGet(C, Item.Asset.Group.Name), "Vibrating", true);
+			const Hidden = CharacterAppearanceItemIsHidden(Item.Asset.Name, Item.Asset.Group.Name);
+
+			if (Hidden) DrawPreviewBox(X, Y, "Icons/HiddenItem.png", Item.Asset.Description, BackgroundColor);
+			else DrawAssetPreview(X, Y, Item.Asset, null, null, BackgroundColor, null, Vibrating);
+
 			if (Item.Icon != "") DrawImage("Icons/" + Item.Icon + ".png", X + 2, Y + 110);
 			X = X + 250;
 			if (X > 1800) {
@@ -681,9 +685,7 @@ function AppearanceRun() {
 				Y = Y + 300;
 			}
 		}
-
 	}
-
 }
 
 /**

--- a/BondageClub/Screens/Character/Appearance/Appearance.js
+++ b/BondageClub/Screens/Character/Appearance/Appearance.js
@@ -676,7 +676,7 @@ function AppearanceRun() {
 			const Hidden = CharacterAppearanceItemIsHidden(Item.Asset.Name, Item.Asset.Group.Name);
 
 			if (Hidden) DrawPreviewBox(X, Y, "Icons/HiddenItem.png", Item.Asset.Description, { Background });
-			else DrawAssetPreview(X, Y, Item.Asset, null, null, Background, null, Vibrating);
+			else DrawAssetPreview(X, Y, Item.Asset, {Background, Vibrating});
 
 			if (Item.Icon != "") DrawImage("Icons/" + Item.Icon + ".png", X + 2, Y + 110);
 			X = X + 250;

--- a/BondageClub/Screens/Character/Appearance/Appearance.js
+++ b/BondageClub/Screens/Character/Appearance/Appearance.js
@@ -673,7 +673,7 @@ function AppearanceRun() {
 
 			const BackgroundColor = AppearanceGetPreviewImageColor(C, Item, Hover);
 			const IsVibrating = Item.Worn && InventoryItemHasEffect(InventoryGet(C, Item.Asset.Group.Name), "Vibrating", true);
-			DrawAssetPreview(X, Y, Item.Asset, BackgroundColor, IsVibrating);
+			DrawAssetPreview(X, Y, Item.Asset, null, BackgroundColor, null, IsVibrating);
 			if (Item.Icon != "") DrawImage("Icons/" + Item.Icon + ".png", X + 2, Y + 110);
 			X = X + 250;
 			if (X > 1800) {

--- a/BondageClub/Screens/Character/Preference/Preference.js
+++ b/BondageClub/Screens/Character/Preference/Preference.js
@@ -1152,7 +1152,7 @@ function PreferenceSubscreenVisibilityRun() {
 		DrawButton(500, PreferenceVisibilityResetClicked ? 780 : 700, 300, 64, TextGet("VisibilityReset"), "White", "");
 
 		// Preview icon
-		if (PreferenceVisibilityHideChecked) DrawPreviewBox(1200, 193, "Icons/HiddenItem.png", "", null, null, null, true);
+		if (PreferenceVisibilityHideChecked) DrawPreviewBox(1200, 193, "Icons/HiddenItem.png", "", { Border: true });
 		else DrawAssetPreview(1200, 193, PreferenceVisibilityPreviewAsset, "", null, null, null, true);
 	} else {
 		MainCanvas.textAlign = "center";

--- a/BondageClub/Screens/Character/Preference/Preference.js
+++ b/BondageClub/Screens/Character/Preference/Preference.js
@@ -1153,7 +1153,8 @@ function PreferenceSubscreenVisibilityRun() {
 
 		// Preview icon
 		if (PreferenceVisibilityHideChecked) DrawPreviewBox(1200, 193, "Icons/HiddenItem.png", "", { Border: true });
-		else DrawAssetPreview(1200, 193, PreferenceVisibilityPreviewAsset, "", null, null, null, true);
+
+		else DrawAssetPreview(1200, 193, PreferenceVisibilityPreviewAsset, {Description: "", Border: true});
 	} else {
 		MainCanvas.textAlign = "center";
 		DrawText(TextGet("VisibilityLocked"), 1200, 500, "Red", "Gray");

--- a/BondageClub/Screens/Character/Preference/Preference.js
+++ b/BondageClub/Screens/Character/Preference/Preference.js
@@ -46,7 +46,7 @@ var PreferenceVisibilityAssetIndex = 0;
 var PreferenceVisibilityHideChecked = false;
 var PreferenceVisibilityBlockChecked = false;
 var PreferenceVisibilityCanBlock = true;
-var PreferenceVisibilityPreviewImg = null;
+var PreferenceVisibilityPreviewAsset = null;
 var PreferenceVisibilityHiddenList = [];
 var PreferenceVisibilityBlockList = [];
 var PreferenceVisibilityResetClicked = false;
@@ -1152,10 +1152,8 @@ function PreferenceSubscreenVisibilityRun() {
 		DrawButton(500, PreferenceVisibilityResetClicked ? 780 : 700, 300, 64, TextGet("VisibilityReset"), "White", "");
 
 		// Preview icon
-		DrawEmptyRect(1200, 193, 225, 225, "Black");
-		if (PreferenceVisibilityPreviewImg == null) DrawRect(1203, 196, 219, 219, "LightGray");
-		else DrawImageResize(PreferenceVisibilityPreviewImg, 1202, 195, 221, 221);
-
+		if (PreferenceVisibilityHideChecked) DrawPreviewBox(1200, 193, "Icons/HiddenItem.png", "", null, null, null, true);
+		else DrawAssetPreview(1200, 193, PreferenceVisibilityPreviewAsset, "", null, null, null, true);
 	} else {
 		MainCanvas.textAlign = "center";
 		DrawText(TextGet("VisibilityLocked"), 1200, 500, "Red", "Gray");
@@ -1593,8 +1591,7 @@ function PreferenceVisibilityAssetChanged(RefreshCheckboxes) {
 	PreferenceVisibilityCanBlock = (WornItem == null || WornItem.Asset.Name != CurrAsset.Asset.Name) && !CurrAsset.Limited;
 
 	// Get the preview image path
-	if (PreferenceVisibilityHideChecked) PreferenceVisibilityPreviewImg = "Icons/HiddenItem.png";
-	else PreferenceVisibilityPreviewImg = "Assets/" + CurrAsset.Asset.Group.Family + "/" + CurrAsset.Asset.DynamicGroupName + "/Preview/" + CurrAsset.Asset.Name + ".png";
+	PreferenceVisibilityPreviewAsset = CurrAsset.Asset;
 
 	PreferenceVisibilityResetClicked = false;
 }

--- a/BondageClub/Screens/MiniGame/Kidnap/Kidnap.js
+++ b/BondageClub/Screens/MiniGame/Kidnap/Kidnap.js
@@ -412,8 +412,8 @@ function KidnapShowItem() {
 	for (let I = 0; I < DialogInventory.length; I++) {
 		const Item = DialogInventory[I];
 		const Hover = MouseIn(X, Y, 225, 275) && !CommonIsMobile;
-		const BackgroundColor = Hover ? "cyan" : DialogInventory[I].Worn ? "pink" : "#fff";
-		DrawAssetPreview(X, Y, Item.Asset, null, null, BackgroundColor);
+		const Background = Hover ? "cyan" : DialogInventory[I].Worn ? "pink" : "#fff";
+		DrawAssetPreview(X, Y, Item.Asset, { Background });
 
 		X = X + 250;
 		if (X > 1800) {

--- a/BondageClub/Screens/MiniGame/Kidnap/Kidnap.js
+++ b/BondageClub/Screens/MiniGame/Kidnap/Kidnap.js
@@ -410,10 +410,11 @@ function KidnapShowItem() {
 	var X = 1000;
 	var Y = 125;
 	for (let I = 0; I < DialogInventory.length; I++) {
-		DrawRect(X, Y, 225, 275, ((MouseX >= X) && (MouseX < X + 225) && (MouseY >= Y) && (MouseY < Y + 275) && !CommonIsMobile) ? "cyan" : DialogInventory[I].Worn ? "pink" : "white");
-		DrawImageResize("Assets/" + DialogInventory[I].Asset.Group.Family + "/" + DialogInventory[I].Asset.DynamicGroupName + "/Preview/" + DialogInventory[I].Asset.Name + ".png", X + 2, Y + 2, 221, 221);
-		DrawTextFit(DialogInventory[I].Asset.Description, X + 112, Y + 250, 221, "black");
-		if (DialogInventory[I].Icon != "") DrawImage("Icons/" + DialogInventory[I].Icon + ".png", X + 2, Y + 110);
+		const Item = DialogInventory[I];
+		const Hover = MouseIn(X, Y, 225, 275) && !CommonIsMobile;
+		const BackgroundColor = Hover ? "cyan" : DialogInventory[I].Worn ? "pink" : "#fff";
+		DrawAssetPreview(X, Y, Item.Asset, null, null, BackgroundColor);
+
 		X = X + 250;
 		if (X > 1800) {
 			X = 1000;

--- a/BondageClub/Screens/Online/GameLARP/GameLARP.js
+++ b/BondageClub/Screens/Online/GameLARP/GameLARP.js
@@ -151,9 +151,11 @@ function GameLARPRunProcess() {
 			var X = 15;
 			var Y = 110;
 			for (let A = GameLARPInventoryOffset; (A < GameLARPInventory.length) && (A < GameLARPInventoryOffset + 12); A++) {
-				DrawRect(X, Y, 225, 275, ((MouseX >= X) && (MouseX < X + 225) && (MouseY >= Y) && (MouseY < Y + 275) && !CommonIsMobile) ? "cyan" : "white");
-				DrawImageResize("Assets/" + Player.AssetFamily + "/" + GameLARPInventory[A].DynamicGroupName + "/Preview/" + GameLARPInventory[A].Name + ".png", X + 2, Y + 2, 221, 221);
-				DrawTextFit(GameLARPInventory[A].Description, X + 112, Y + 250, 221, "black");
+				const Item = GameLARPInventory[A];
+				const Hover = MouseIn(X, Y, 225, 275) && !CommonIsMobile;
+				const Hidden = CharacterAppearanceItemIsHidden(Item.Asset.Name, Item.Asset.Group.Name);
+				if (Hidden) DrawPreviewBox(X, Y, "Icons/HiddenItem.png", Item.Asset.Description, Hover ? "cyan" : "#fff");
+
 				X = X + 250;
 				if (X > 800) {
 					X = 15;

--- a/BondageClub/Screens/Online/GameLARP/GameLARP.js
+++ b/BondageClub/Screens/Online/GameLARP/GameLARP.js
@@ -154,7 +154,7 @@ function GameLARPRunProcess() {
 				const Item = GameLARPInventory[A];
 				const Hover = MouseIn(X, Y, 225, 275) && !CommonIsMobile;
 				const Hidden = CharacterAppearanceItemIsHidden(Item.Asset.Name, Item.Asset.Group.Name);
-				if (Hidden) DrawPreviewBox(X, Y, "Icons/HiddenItem.png", Item.Asset.Description, Hover ? "cyan" : "#fff");
+				if (Hidden) DrawPreviewBox(X, Y, "Icons/HiddenItem.png", Item.Asset.Description, { Background: Hover ? "cyan" : "#fff" });
 
 				X = X + 250;
 				if (X > 800) {

--- a/BondageClub/Screens/Room/Shop/Shop.js
+++ b/BondageClub/Screens/Room/Shop/Shop.js
@@ -81,7 +81,7 @@ function ShopRun() {
 			const Background = MouseIn(X, Y, 225, 275) && !CommonIsMobile ? "cyan" : "#fff";
 			const Foreground = InventoryAvailable(Player, ShopCart[A].Name, ShopCart[A].Group.Name) ? "green" : "red";
 			if (Hidden) DrawPreviewBox(X, Y, "Icons/HiddenItem.png", Description, { Background, Foreground });
-			else DrawAssetPreview(X, Y, ShopCart[A], null, Description, Background, Foreground);
+			else DrawAssetPreview(X, Y, ShopCart[A], { Description, Background, Foreground });
 			X = X + 250;
 			if (X > 1800) {
 				X = 1000;

--- a/BondageClub/Screens/Room/Shop/Shop.js
+++ b/BondageClub/Screens/Room/Shop/Shop.js
@@ -81,7 +81,7 @@ function ShopRun() {
 			const BackgroundColor = MouseIn(X, Y, 225, 275) && !CommonIsMobile ? "cyan" : "#fff";
 			const ForegroundColor = InventoryAvailable(Player, ShopCart[A].Name, ShopCart[A].Group.Name) ? "green" : "red";
 			if (Hidden) DrawPreviewBox(X, Y, "Icons/HiddenItem.png", Description, BackgroundColor, ForegroundColor);
-			else DrawAssetPreview(X, Y, ShopCart[A], Description, BackgroundColor, ForegroundColor);
+			else DrawAssetPreview(X, Y, ShopCart[A], null, Description, BackgroundColor, ForegroundColor);
 			X = X + 250;
 			if (X > 1800) {
 				X = 1000;
@@ -99,7 +99,8 @@ function ShopRun() {
 }
 
 /**
- * Checks if an asset is from the focus group and if it can be bought. An asset can be shown if it has a value greater than 0. (0 is a default item, -1 is a non-purchasable item)
+ * Checks if an asset is from the focus group and if it can be bought. An asset can be shown if it has a value greater than 0. (0 is a
+ * default item, -1 is a non-purchasable item)
  * @param {Asset} Asset - The asset to check for availability
  * @returns {boolean} - Returns TRUE if the item is purchasable and part of the focus group.
  */
@@ -108,7 +109,8 @@ function ShopAssetFocusGroup(Asset) {
 }
 
 /**
- * Checks if an asset can be bought. An asset is considered missing if it is not owned and has a value greater than 0. (0 is a default item, -1 is a non-purchasable item)
+ * Checks if an asset can be bought. An asset is considered missing if it is not owned and has a value greater than 0. (0 is a default
+ * item, -1 is a non-purchasable item)
  * @param {Asset} Asset - The asset to check for availability
  * @returns {boolean} - Returns TRUE if the item is purchasable and unowned.
  */
@@ -288,7 +290,8 @@ function ShopVendorBondage() {
 }
 
 /**
- * Restrains the player with a random shop item before the shop demo job starts. The customer will have a 50/50 chance of being willing to release the player
+ * Restrains the player with a random shop item before the shop demo job starts. The customer will have a 50/50 chance of being willing to
+ * release the player
  * @returns {void} - Nothing
  */
 function ShopJobRestrain() {

--- a/BondageClub/Screens/Room/Shop/Shop.js
+++ b/BondageClub/Screens/Room/Shop/Shop.js
@@ -78,10 +78,10 @@ function ShopRun() {
 		for (let A = ShopItemOffset; (A < ShopCart.length && A < ShopItemOffset + 12); A++) {
 			const Hidden = CharacterAppearanceItemIsHidden(ShopCart[A].Name, ShopCart[A].Group.Name);
 			const Description = ShopCart[A].Description + " " + ShopCart[A].Value.toString() + " $";
-			const BackgroundColor = MouseIn(X, Y, 225, 275) && !CommonIsMobile ? "cyan" : "#fff";
-			const ForegroundColor = InventoryAvailable(Player, ShopCart[A].Name, ShopCart[A].Group.Name) ? "green" : "red";
-			if (Hidden) DrawPreviewBox(X, Y, "Icons/HiddenItem.png", Description, BackgroundColor, ForegroundColor);
-			else DrawAssetPreview(X, Y, ShopCart[A], null, Description, BackgroundColor, ForegroundColor);
+			const Background = MouseIn(X, Y, 225, 275) && !CommonIsMobile ? "cyan" : "#fff";
+			const Foreground = InventoryAvailable(Player, ShopCart[A].Name, ShopCart[A].Group.Name) ? "green" : "red";
+			if (Hidden) DrawPreviewBox(X, Y, "Icons/HiddenItem.png", Description, { Background, Foreground });
+			else DrawAssetPreview(X, Y, ShopCart[A], null, Description, Background, Foreground);
 			X = X + 250;
 			if (X > 1800) {
 				X = 1000;

--- a/BondageClub/Screens/Room/Shop/Shop.js
+++ b/BondageClub/Screens/Room/Shop/Shop.js
@@ -76,12 +76,12 @@ function ShopRun() {
 		var X = 1000;
 		var Y = 125;
 		for (let A = ShopItemOffset; (A < ShopCart.length && A < ShopItemOffset + 12); A++) {
-			DrawRect(X, Y, 225, 275, ((MouseX >= X) && (MouseX < X + 225) && (MouseY >= Y) && (MouseY < Y + 275) && !CommonIsMobile) ? "cyan" : "white");
-			if (!CharacterAppearanceItemIsHidden(ShopCart[A].Name, ShopCart[A].Group.Name)) 
-                DrawImageResize("Assets/" + ShopCart[A].Group.Family + "/" + ShopCart[A].DynamicGroupName + "/Preview/" + ShopCart[A].Name + ".png", X + 2, Y + 2, 221, 221);
-			else 
-                DrawImageResize("Icons/HiddenItem.png", X + 2, Y + 2, 221, 221);
-			DrawTextFit(ShopCart[A].Description + " " + ShopCart[A].Value.toString() + " $", X + 112, Y + 250, 221, (InventoryAvailable(Player, ShopCart[A].Name, ShopCart[A].Group.Name)) ? "green" : "red");
+			const Hidden = CharacterAppearanceItemIsHidden(ShopCart[A].Name, ShopCart[A].Group.Name);
+			const Description = ShopCart[A].Description + " " + ShopCart[A].Value.toString() + " $";
+			const BackgroundColor = MouseIn(X, Y, 225, 275) && !CommonIsMobile ? "cyan" : "#fff";
+			const ForegroundColor = InventoryAvailable(Player, ShopCart[A].Name, ShopCart[A].Group.Name) ? "green" : "red";
+			if (Hidden) DrawPreviewBox(X, Y, "Icons/HiddenItem.png", Description, BackgroundColor, ForegroundColor);
+			else DrawAssetPreview(X, Y, ShopCart[A], Description, BackgroundColor, ForegroundColor);
 			X = X + 250;
 			if (X > 1800) {
 				X = 1000;

--- a/BondageClub/Scripts/Dialog.js
+++ b/BondageClub/Scripts/Dialog.js
@@ -1796,9 +1796,9 @@ function DialogDrawActivityMenu(C) {
 function DialogDrawStruggleProgress(C) {
 	// Draw one or both items
 	if ((DialogProgressPrevItem != null) && (DialogProgressNextItem != null)) {
-		DrawAssetPreview(1200, 250, DialogProgressPrevItem.Asset);
-		DrawAssetPreview(1575, 250, DialogProgressNextItem.Asset);
-	} else DrawAssetPreview(1387, 250, (DialogProgressPrevItem != null) ? DialogProgressPrevItem.Asset : DialogProgressNextItem.Asset);
+		DrawAssetPreview(1200, 250, DialogProgressPrevItem.Asset, null);
+		DrawAssetPreview(1575, 250, DialogProgressNextItem.Asset, null);
+	} else DrawAssetPreview(1387, 250, (DialogProgressPrevItem != null) ? DialogProgressPrevItem.Asset : DialogProgressNextItem.Asset, null);
 
 	// Add or subtract to the automatic progression, doesn't move in color picking mode
 	DialogProgress = DialogProgress + DialogProgressAuto;
@@ -2146,22 +2146,15 @@ function DialogDrawItemMenu(C) {
 		var X = 1000;
 		var Y = 125;
 		for (let I = DialogInventoryOffset; (I < DialogInventory.length) && (I < DialogInventoryOffset + 12); I++) {
-			var Item = DialogInventory[I];
-			var Hover = (MouseX >= X) && (MouseX < X + 225) && (MouseY >= Y) && (MouseY < Y + 275) && !CommonIsMobile;
-			var Block = InventoryIsPermissionBlocked(C, Item.Asset.DynamicName(Player), Item.Asset.DynamicGroupName);
-			var Limit = InventoryIsPermissionLimited(C, Item.Asset.Name, Item.Asset.Group.Name);
-			var Unusable = DialogInventory[I].SortOrder.startsWith(DialogSortOrderUnusable.toString());
-			var Blocked = DialogInventory[I].SortOrder.startsWith(DialogSortOrderBlocked.toString());
-			DrawRect(X, Y, 225, 275, (DialogItemPermissionMode && C.ID == 0) ?
-				(Item.Worn ? "gray" : Block ? Hover ? "red" : "pink" : Limit ? Hover ? "orange" : "#fed8b1" : Hover ? "green" : "lime") :
-				((Hover && !Blocked) ? "cyan" : Item.Worn ? "pink" : Blocked ? "red" : Unusable ? "gray" : "white"));
-			if (!CharacterAppearanceItemIsHidden(Item.Asset.Name, Item.Asset.Group.Name)) {
-				if (ControllerActive == true) setButton(X + 2, Y + 2);
-				if (Item.Worn && InventoryItemHasEffect(InventoryGet(C, Item.Asset.Group.Name), "Vibrating", true)) DrawImageResize("Assets/" + Item.Asset.Group.Family + "/" + Item.Asset.DynamicGroupName + "/Preview/" + Item.Asset.Name + ".png", X + Math.floor(Math.random() * 3) + 1, Y + Math.floor(Math.random() * 3) + 1, 221, 221);
-				else DrawImageResize("Assets/" + Item.Asset.Group.Family + "/" + Item.Asset.DynamicGroupName + "/Preview/" + Item.Asset.Name + Item.Asset.DynamicPreviewIcon(CharacterGetCurrent()) + ".png", X + 2, Y + 2, 221, 221);
-			}
-			else DrawImageResize("Icons/HiddenItem.png", X + 2, Y + 2, 221, 221);
-			DrawTextFit(Item.Asset.DynamicDescription(Player), X + 112, Y + 250, 221, "black");
+			const Item = DialogInventory[I];
+			const Hover = MouseIn(X, Y, 225, 275) && !CommonIsMobile;
+			const BackgroundColor = AppearanceGetPreviewImageColor(C, Item, Hover);
+			const Vibrating = Item.Worn && InventoryItemHasEffect(InventoryGet(C, Item.Asset.Group.Name), "Vibrating", true);
+			const Hidden = CharacterAppearanceItemIsHidden(Item.Asset.Name, Item.Asset.Group.Name);
+
+			if (Hidden) DrawPreviewBox(X, Y, "Icons/HiddenItem.png", Item.Asset.DynamicDescription(Player), BackgroundColor);
+			else DrawAssetPreview(X, Y, Item.Asset, Player, null, BackgroundColor, null, Vibrating);
+
 			if (Item.Icon != "") DrawImage("Icons/" + Item.Icon + ".png", X + 2, Y + 110);
 			X = X + 250;
 			if (X > 1800) {
@@ -2187,19 +2180,15 @@ function DialogDrawItemMenu(C) {
 		return;
 	}
 
-	
-	
-	
-	
+
+
+
+
 
 	// If we must draw the current item from the group
 	if (FocusItem != null) {
-		if (InventoryItemHasEffect(FocusItem, "Vibrating", true)) {
-			DrawRect(1387, 250, 225, 275, "white");
-			DrawImageResize("Assets/" + FocusItem.Asset.Group.Family + "/" + FocusItem.Asset.DynamicGroupName + "/Preview/" + FocusItem.Asset.Name + ".png", 1389 + Math.floor(Math.random() * 3) - 2, 252 + Math.floor(Math.random() * 3) - 2, 221, 221);
-			DrawTextFit(FocusItem.Asset.Description, 1497, 500, 221, "black");
-		}
-		else DrawAssetPreview(1387, 250, FocusItem.Asset);
+		const Vibrating = InventoryItemHasEffect(FocusItem, "Vibrating", true);
+		DrawAssetPreview(1387, 250, FocusItem.Asset, C, null, null, null, Vibrating);
 	}
 
 	// Show the no access text

--- a/BondageClub/Scripts/Dialog.js
+++ b/BondageClub/Scripts/Dialog.js
@@ -1796,9 +1796,9 @@ function DialogDrawActivityMenu(C) {
 function DialogDrawStruggleProgress(C) {
 	// Draw one or both items
 	if ((DialogProgressPrevItem != null) && (DialogProgressNextItem != null)) {
-		DrawAssetPreview(1200, 250, DialogProgressPrevItem.Asset, null);
-		DrawAssetPreview(1575, 250, DialogProgressNextItem.Asset, null);
-	} else DrawAssetPreview(1387, 250, (DialogProgressPrevItem != null) ? DialogProgressPrevItem.Asset : DialogProgressNextItem.Asset, null);
+		DrawAssetPreview(1200, 250, DialogProgressPrevItem.Asset);
+		DrawAssetPreview(1575, 250, DialogProgressNextItem.Asset);
+	} else DrawAssetPreview(1387, 250, (DialogProgressPrevItem != null) ? DialogProgressPrevItem.Asset : DialogProgressNextItem.Asset);
 
 	// Add or subtract to the automatic progression, doesn't move in color picking mode
 	DialogProgress = DialogProgress + DialogProgressAuto;
@@ -2153,7 +2153,7 @@ function DialogDrawItemMenu(C) {
 			const Hidden = CharacterAppearanceItemIsHidden(Item.Asset.Name, Item.Asset.Group.Name);
 
 			if (Hidden) DrawPreviewBox(X, Y, "Icons/HiddenItem.png", Item.Asset.DynamicDescription(Player), { Background });
-			else DrawAssetPreview(X, Y, Item.Asset, Player, null, Background, null, Vibrating);
+			else DrawAssetPreview(X, Y, Item.Asset, { C: Player, Background, Vibrating });
 
 			if (Item.Icon != "") DrawImage("Icons/" + Item.Icon + ".png", X + 2, Y + 110);
 			X = X + 250;
@@ -2188,7 +2188,7 @@ function DialogDrawItemMenu(C) {
 	// If we must draw the current item from the group
 	if (FocusItem != null) {
 		const Vibrating = InventoryItemHasEffect(FocusItem, "Vibrating", true);
-		DrawAssetPreview(1387, 250, FocusItem.Asset, C, null, null, null, Vibrating);
+		DrawAssetPreview(1387, 250, FocusItem.Asset, { C, Vibrating });
 	}
 
 	// Show the no access text

--- a/BondageClub/Scripts/Dialog.js
+++ b/BondageClub/Scripts/Dialog.js
@@ -1796,9 +1796,9 @@ function DialogDrawActivityMenu(C) {
 function DialogDrawStruggleProgress(C) {
 	// Draw one or both items
 	if ((DialogProgressPrevItem != null) && (DialogProgressNextItem != null)) {
-		DrawItemPreview(1200, 250, DialogProgressPrevItem);
-		DrawItemPreview(1575, 250, DialogProgressNextItem);
-	} else DrawItemPreview(1387, 250, (DialogProgressPrevItem != null) ? DialogProgressPrevItem : DialogProgressNextItem);
+		DrawAssetPreview(1200, 250, DialogProgressPrevItem.Asset);
+		DrawAssetPreview(1575, 250, DialogProgressNextItem.Asset);
+	} else DrawAssetPreview(1387, 250, (DialogProgressPrevItem != null) ? DialogProgressPrevItem.Asset : DialogProgressNextItem.Asset);
 
 	// Add or subtract to the automatic progression, doesn't move in color picking mode
 	DialogProgress = DialogProgress + DialogProgressAuto;
@@ -2199,7 +2199,7 @@ function DialogDrawItemMenu(C) {
 			DrawImageResize("Assets/" + FocusItem.Asset.Group.Family + "/" + FocusItem.Asset.DynamicGroupName + "/Preview/" + FocusItem.Asset.Name + ".png", 1389 + Math.floor(Math.random() * 3) - 2, 252 + Math.floor(Math.random() * 3) - 2, 221, 221);
 			DrawTextFit(FocusItem.Asset.Description, 1497, 500, 221, "black");
 		}
-		else DrawItemPreview(1387, 250, FocusItem);
+		else DrawAssetPreview(1387, 250, FocusItem.Asset);
 	}
 
 	// Show the no access text

--- a/BondageClub/Scripts/Dialog.js
+++ b/BondageClub/Scripts/Dialog.js
@@ -2148,12 +2148,12 @@ function DialogDrawItemMenu(C) {
 		for (let I = DialogInventoryOffset; (I < DialogInventory.length) && (I < DialogInventoryOffset + 12); I++) {
 			const Item = DialogInventory[I];
 			const Hover = MouseIn(X, Y, 225, 275) && !CommonIsMobile;
-			const BackgroundColor = AppearanceGetPreviewImageColor(C, Item, Hover);
+			const Background = AppearanceGetPreviewImageColor(C, Item, Hover);
 			const Vibrating = Item.Worn && InventoryItemHasEffect(InventoryGet(C, Item.Asset.Group.Name), "Vibrating", true);
 			const Hidden = CharacterAppearanceItemIsHidden(Item.Asset.Name, Item.Asset.Group.Name);
 
-			if (Hidden) DrawPreviewBox(X, Y, "Icons/HiddenItem.png", Item.Asset.DynamicDescription(Player), BackgroundColor);
-			else DrawAssetPreview(X, Y, Item.Asset, Player, null, BackgroundColor, null, Vibrating);
+			if (Hidden) DrawPreviewBox(X, Y, "Icons/HiddenItem.png", Item.Asset.DynamicDescription(Player), { Background });
+			else DrawAssetPreview(X, Y, Item.Asset, Player, null, Background, null, Vibrating);
 
 			if (Item.Icon != "") DrawImage("Icons/" + Item.Icon + ".png", X + 2, Y + 110);
 			X = X + 250;

--- a/BondageClub/Scripts/Drawing.js
+++ b/BondageClub/Scripts/Drawing.js
@@ -1078,7 +1078,7 @@ function DrawProcess() {
  * @returns {void} - Nothing
  */
 function DrawAssetPreview(X, Y, Asset) {
-	DrawRect(X, Y, 225, 275, "white");
+	DrawRect(X, Y, 225, 275, "#fff");
 	DrawImageResize("Assets/" + Asset.Group.Family + "/" + Asset.DynamicGroupName + "/Preview/" + Asset.Name + Asset.DynamicPreviewIcon(CharacterGetCurrent()) + ".png", X + 2, Y + 2, 221, 221);
-	DrawTextFit(Asset.Description, X + 110, Y + 250, 221, "black");
+	DrawTextFit(Asset.Description, X + 110, Y + 250, 221, "#000");
 }

--- a/BondageClub/Scripts/Drawing.js
+++ b/BondageClub/Scripts/Drawing.js
@@ -1074,11 +1074,11 @@ function DrawProcess() {
  * Draws the item preview box
  * @param {number} X - Position of the item on the X axis
  * @param {number} Y - Position of the item on the Y axis
- * @param {Item} Item - The item to draw the preview for
+ * @param {Asset} Asset - The asset to draw the preview for
  * @returns {void} - Nothing
  */
-function DrawItemPreview(X, Y, Item) {
+function DrawAssetPreview(X, Y, Asset) {
 	DrawRect(X, Y, 225, 275, "white");
-	DrawImageResize("Assets/" + Item.Asset.Group.Family + "/" + Item.Asset.DynamicGroupName + "/Preview/" + Item.Asset.Name + Item.Asset.DynamicPreviewIcon(CharacterGetCurrent()) + ".png", X + 2, Y + 2, 221, 221);
-	DrawTextFit(Item.Asset.Description, X + 110, Y + 250, 221, "black");
+	DrawImageResize("Assets/" + Asset.Group.Family + "/" + Asset.DynamicGroupName + "/Preview/" + Asset.Name + Asset.DynamicPreviewIcon(CharacterGetCurrent()) + ".png", X + 2, Y + 2, 221, 221);
+	DrawTextFit(Asset.Description, X + 110, Y + 250, 221, "black");
 }

--- a/BondageClub/Scripts/Drawing.js
+++ b/BondageClub/Scripts/Drawing.js
@@ -1077,11 +1077,11 @@ function DrawProcess() {
  * @param {Asset} Asset - The asset to draw the preview for
  * @returns {void} - Nothing
  */
-function DrawAssetPreview(X, Y, Asset) {
+function DrawAssetPreview(X, Y, Asset, Background, Vibrating) {
 	const C = CharacterGetCurrent();
 	const DynamicPreviewIcon = C ? Asset.DynamicPreviewIcon(C) : "";
-	const Path = `Asset/${Asset.Group.Family}/${Asset.DynamicGroupName}/Preview/${Asset.Name}${DynamicPreviewIcon}.png`;
-	DrawPreviewBox(Path);
+	const Path = `Assets/${Asset.Group.Family}/${Asset.DynamicGroupName}/Preview/${Asset.Name}${DynamicPreviewIcon}.png`;
+	DrawPreviewBox(X, Y, Path, Asset.Description, Background, Vibrating);
 }
 
 /**
@@ -1089,10 +1089,16 @@ function DrawAssetPreview(X, Y, Asset) {
  * @param {number} X - Position of the preview box on the X axis
  * @param {number} Y - Position of the preview box on the Y axis
  * @param {string} Path - The path of the image to draw
+ * @param {string} Description - The preview box description
+ * @param {string} [Background] - The background color to draw the preview box in - defaults to white
+ * @param {boolean} [Vibrating] - Whether or not to add vibration effects to the item - defaults to false
  * @returns {void} - Nothing
  */
-function DrawPreviewBox(X, Y, Path) {
-	DrawRect(X, Y, 225, 275, "#fff");
-	DrawImageResize(Path, X + 2, Y + 2, 221, 221);
-	DrawTextFit(Asset.Description, X + 110, Y + 250, 221, "#000");
+function DrawPreviewBox(X, Y, Path, Description, Background, Vibrating) {
+	Background = Background || "#fff";
+	DrawRect(X, Y, 225, 275, Background);
+	const ImageX = Vibrating ? X + 1 + Math.floor(Math.random() * 3) : X + 2;
+	const ImageY = Vibrating ? Y + 1 + Math.floor(Math.random() * 3) : Y + 2;
+	DrawImageResize(Path, ImageX, ImageY, 221, 221);
+	DrawTextFit(Description, X + 110, Y + 250, 221, "#000");
 }

--- a/BondageClub/Scripts/Drawing.js
+++ b/BondageClub/Scripts/Drawing.js
@@ -1071,14 +1071,28 @@ function DrawProcess() {
 }
 
 /**
- * Draws the item preview box
- * @param {number} X - Position of the item on the X axis
- * @param {number} Y - Position of the item on the Y axis
+ * Draws an asset's preview box
+ * @param {number} X - Position of the preview box on the X axis
+ * @param {number} Y - Position of the preview box on the Y axis
  * @param {Asset} Asset - The asset to draw the preview for
  * @returns {void} - Nothing
  */
 function DrawAssetPreview(X, Y, Asset) {
+	const C = CharacterGetCurrent();
+	const DynamicPreviewIcon = C ? Asset.DynamicPreviewIcon(C) : "";
+	const Path = `Asset/${Asset.Group.Family}/${Asset.DynamicGroupName}/Preview/${Asset.Name}${DynamicPreviewIcon}.png`;
+	DrawPreviewBox(Path);
+}
+
+/**
+ * Draws an item preview box for the provided image path
+ * @param {number} X - Position of the preview box on the X axis
+ * @param {number} Y - Position of the preview box on the Y axis
+ * @param {string} Path - The path of the image to draw
+ * @returns {void} - Nothing
+ */
+function DrawPreviewBox(X, Y, Path) {
 	DrawRect(X, Y, 225, 275, "#fff");
-	DrawImageResize("Assets/" + Asset.Group.Family + "/" + Asset.DynamicGroupName + "/Preview/" + Asset.Name + Asset.DynamicPreviewIcon(CharacterGetCurrent()) + ".png", X + 2, Y + 2, 221, 221);
+	DrawImageResize(Path, X + 2, Y + 2, 221, 221);
 	DrawTextFit(Asset.Description, X + 110, Y + 250, 221, "#000");
 }

--- a/BondageClub/Scripts/Drawing.js
+++ b/BondageClub/Scripts/Drawing.js
@@ -1075,15 +1075,17 @@ function DrawProcess() {
  * @param {number} X - Position of the preview box on the X axis
  * @param {number} Y - Position of the preview box on the Y axis
  * @param {Asset} Asset - The asset to draw the preview for
- * @param {Character} [C] - The character using the item (used to calculate dynamic item descriptions/previews)
- * @param {string} Description - The preview box description
- * @param {string} [Background] - The background color to draw the preview box in - defaults to white
- * @param {string} [Foreground] - The foreground (text) color to draw the description in - defaults to black
- * @param {boolean} [Vibrating] - Whether or not to add vibration effects to the item - defaults to false
- * @param {boolean} [Border] - Whether or not to draw a border around the preview box
+ * @Param {object} [Options] - Additional drawing options
+ * @param {Character} Options.[C] - The character using the item (used to calculate dynamic item descriptions/previews)
+ * @param {string} Options.Description - The preview box description
+ * @param {string} Options.[Background] - The background color to draw the preview box in - defaults to white
+ * @param {string} Options.[Foreground] - The foreground (text) color to draw the description in - defaults to black
+ * @param {boolean} Options.[Vibrating] - Whether or not to add vibration effects to the item - defaults to false
+ * @param {boolean} Options.[Border] - Whether or not to draw a border around the preview box
  * @returns {void} - Nothing
  */
-function DrawAssetPreview(X, Y, Asset, C, Description, Background, Foreground, Vibrating, Border) {
+function DrawAssetPreview(X, Y, Asset, Options) {
+	let {C, Description, Background, Foreground, Vibrating, Border} = (Options || {});
 	const DynamicPreviewIcon = C ? Asset.DynamicPreviewIcon(C) : "";
 	const Path = `Assets/${Asset.Group.Family}/${Asset.DynamicGroupName}/Preview/${Asset.Name}${DynamicPreviewIcon}.png`;
 	if (Description == null) Description = C ? Asset.DynamicDescription(C) : Asset.Description;
@@ -1096,7 +1098,7 @@ function DrawAssetPreview(X, Y, Asset, C, Description, Background, Foreground, V
  * @param {number} Y - Position of the preview box on the Y axis
  * @param {string} Path - The path of the image to draw
  * @param {string} Description - The preview box description
- * @param {object} Options - Additional drawing options
+ * @param {object} [Options] - Additional drawing options
  * @param {string} Options.[Background] - The background color to draw the preview box in - defaults to white
  * @param {string} Options.[Foreground] - The foreground (text) color to draw the description in - defaults to black
  * @param {boolean} Options.[Vibrating] - Whether or not to add vibration effects to the item - defaults to false
@@ -1109,7 +1111,7 @@ function DrawPreviewBox(X, Y, Path, Description, Options) {
 	Foreground = Foreground || "#000";
 	const Height = Description ? 275 : 225;
 	DrawRect(X, Y, 225, Height, Background);
-	if (Border) DrawEmptyRect(X, Y, 225, Height, "#000");
+	if (Border) DrawEmptyRect(X, Y, 225, Height, Foreground);
 	const ImageX = Vibrating ? X + 1 + Math.floor(Math.random() * 3) : X + 2;
 	const ImageY = Vibrating ? Y + 1 + Math.floor(Math.random() * 3) : Y + 2;
 	DrawImageResize(Path, ImageX, ImageY, 221, 221);

--- a/BondageClub/Scripts/Drawing.js
+++ b/BondageClub/Scripts/Drawing.js
@@ -1075,7 +1075,7 @@ function DrawProcess() {
  * @param {number} X - Position of the preview box on the X axis
  * @param {number} Y - Position of the preview box on the Y axis
  * @param {Asset} Asset - The asset to draw the preview for
- * @Param {object} [Options] - Additional drawing options
+ * @Param {object} [Options] - Additional optional drawing options
  * @param {Character} Options.[C] - The character using the item (used to calculate dynamic item descriptions/previews)
  * @param {string} Options.Description - The preview box description
  * @param {string} Options.[Background] - The background color to draw the preview box in - defaults to white
@@ -1098,7 +1098,7 @@ function DrawAssetPreview(X, Y, Asset, Options) {
  * @param {number} Y - Position of the preview box on the Y axis
  * @param {string} Path - The path of the image to draw
  * @param {string} Description - The preview box description
- * @param {object} [Options] - Additional drawing options
+ * @param {object} [Options] - Additional optional drawing options
  * @param {string} Options.[Background] - The background color to draw the preview box in - defaults to white
  * @param {string} Options.[Foreground] - The foreground (text) color to draw the description in - defaults to black
  * @param {boolean} Options.[Vibrating] - Whether or not to add vibration effects to the item - defaults to false

--- a/BondageClub/Scripts/Drawing.js
+++ b/BondageClub/Scripts/Drawing.js
@@ -1075,14 +1075,19 @@ function DrawProcess() {
  * @param {number} X - Position of the preview box on the X axis
  * @param {number} Y - Position of the preview box on the Y axis
  * @param {Asset} Asset - The asset to draw the preview for
+ * @param {string} Description - The preview box description
+ * @param {string} [Background] - The background color to draw the preview box in - defaults to white
+ * @param {string} [Foreground] - The foreground (text) color to draw the description in - defaults to black
+ * @param {boolean} [Vibrating] - Whether or not to add vibration effects to the item - defaults to false
+ * @param {boolean} [DrawBorder] - Whether or not to draw a border around the preview box
  * @returns {void} - Nothing
  */
-function DrawAssetPreview(X, Y, Asset, Description, Background, Foreground, Vibrating) {
+function DrawAssetPreview(X, Y, Asset, Description, Background, Foreground, Vibrating, DrawBorder) {
 	const C = CharacterGetCurrent();
 	const DynamicPreviewIcon = C ? Asset.DynamicPreviewIcon(C) : "";
 	const Path = `Assets/${Asset.Group.Family}/${Asset.DynamicGroupName}/Preview/${Asset.Name}${DynamicPreviewIcon}.png`;
-	Description = Description || Asset.Description;
-	DrawPreviewBox(X, Y, Path, Description, Background, Foreground, Vibrating);
+	Description = Description == null ? Asset.Description : "";
+	DrawPreviewBox(X, Y, Path, Description, Background, Foreground, Vibrating, DrawBorder);
 }
 
 /**
@@ -1094,14 +1099,17 @@ function DrawAssetPreview(X, Y, Asset, Description, Background, Foreground, Vibr
  * @param {string} [Background] - The background color to draw the preview box in - defaults to white
  * @param {string} [Foreground] - The foreground (text) color to draw the description in - defaults to black
  * @param {boolean} [Vibrating] - Whether or not to add vibration effects to the item - defaults to false
+ * @param {boolean} [DrawBorder] - Whether or not to draw a border around the preview box
  * @returns {void} - Nothing
  */
-function DrawPreviewBox(X, Y, Path, Description, Background, Foreground, Vibrating) {
+function DrawPreviewBox(X, Y, Path, Description, Background, Foreground, Vibrating, DrawBorder) {
 	Background = Background || "#fff";
 	Foreground = Foreground || "#000";
-	DrawRect(X, Y, 225, 275, Background);
+	const Height = Description ? 275 : 225;
+	DrawRect(X, Y, 225, Height, Background);
+	if (DrawBorder) DrawEmptyRect(X, Y, 225, Height, "#000");
 	const ImageX = Vibrating ? X + 1 + Math.floor(Math.random() * 3) : X + 2;
 	const ImageY = Vibrating ? Y + 1 + Math.floor(Math.random() * 3) : Y + 2;
 	DrawImageResize(Path, ImageX, ImageY, 221, 221);
-	DrawTextFit(Description, X + 110, Y + 250, 221, Foreground);
+	if (Description) DrawTextFit(Description, X + 110, Y + 250, 221, Foreground);
 }

--- a/BondageClub/Scripts/Drawing.js
+++ b/BondageClub/Scripts/Drawing.js
@@ -1077,11 +1077,12 @@ function DrawProcess() {
  * @param {Asset} Asset - The asset to draw the preview for
  * @returns {void} - Nothing
  */
-function DrawAssetPreview(X, Y, Asset, Background, Vibrating) {
+function DrawAssetPreview(X, Y, Asset, Description, Background, Foreground, Vibrating) {
 	const C = CharacterGetCurrent();
 	const DynamicPreviewIcon = C ? Asset.DynamicPreviewIcon(C) : "";
 	const Path = `Assets/${Asset.Group.Family}/${Asset.DynamicGroupName}/Preview/${Asset.Name}${DynamicPreviewIcon}.png`;
-	DrawPreviewBox(X, Y, Path, Asset.Description, Background, Vibrating);
+	Description = Description || Asset.Description;
+	DrawPreviewBox(X, Y, Path, Description, Background, Foreground, Vibrating);
 }
 
 /**
@@ -1091,14 +1092,16 @@ function DrawAssetPreview(X, Y, Asset, Background, Vibrating) {
  * @param {string} Path - The path of the image to draw
  * @param {string} Description - The preview box description
  * @param {string} [Background] - The background color to draw the preview box in - defaults to white
+ * @param {string} [Foreground] - The foreground (text) color to draw the description in - defaults to black
  * @param {boolean} [Vibrating] - Whether or not to add vibration effects to the item - defaults to false
  * @returns {void} - Nothing
  */
-function DrawPreviewBox(X, Y, Path, Description, Background, Vibrating) {
+function DrawPreviewBox(X, Y, Path, Description, Background, Foreground, Vibrating) {
 	Background = Background || "#fff";
+	Foreground = Foreground || "#000";
 	DrawRect(X, Y, 225, 275, Background);
 	const ImageX = Vibrating ? X + 1 + Math.floor(Math.random() * 3) : X + 2;
 	const ImageY = Vibrating ? Y + 1 + Math.floor(Math.random() * 3) : Y + 2;
 	DrawImageResize(Path, ImageX, ImageY, 221, 221);
-	DrawTextFit(Description, X + 110, Y + 250, 221, "#000");
+	DrawTextFit(Description, X + 110, Y + 250, 221, Foreground);
 }

--- a/BondageClub/Scripts/Drawing.js
+++ b/BondageClub/Scripts/Drawing.js
@@ -1082,11 +1082,10 @@ function DrawProcess() {
  * @param {boolean} [DrawBorder] - Whether or not to draw a border around the preview box
  * @returns {void} - Nothing
  */
-function DrawAssetPreview(X, Y, Asset, Description, Background, Foreground, Vibrating, DrawBorder) {
-	const C = CharacterGetCurrent();
+function DrawAssetPreview(X, Y, Asset, C, Description, Background, Foreground, Vibrating, DrawBorder) {
 	const DynamicPreviewIcon = C ? Asset.DynamicPreviewIcon(C) : "";
 	const Path = `Assets/${Asset.Group.Family}/${Asset.DynamicGroupName}/Preview/${Asset.Name}${DynamicPreviewIcon}.png`;
-	Description = Description == null ? Asset.Description : "";
+	if (Description == null) Description = C ? Asset.DynamicDescription(C) : Asset.Description;
 	DrawPreviewBox(X, Y, Path, Description, Background, Foreground, Vibrating, DrawBorder);
 }
 

--- a/BondageClub/Scripts/Drawing.js
+++ b/BondageClub/Scripts/Drawing.js
@@ -1075,6 +1075,7 @@ function DrawProcess() {
  * @param {number} X - Position of the preview box on the X axis
  * @param {number} Y - Position of the preview box on the Y axis
  * @param {Asset} Asset - The asset to draw the preview for
+ * @param {Character} [C] - The character using the item (used to calculate dynamic item descriptions/previews)
  * @param {string} Description - The preview box description
  * @param {string} [Background] - The background color to draw the preview box in - defaults to white
  * @param {string} [Foreground] - The foreground (text) color to draw the description in - defaults to black

--- a/BondageClub/Scripts/Drawing.js
+++ b/BondageClub/Scripts/Drawing.js
@@ -1080,14 +1080,14 @@ function DrawProcess() {
  * @param {string} [Background] - The background color to draw the preview box in - defaults to white
  * @param {string} [Foreground] - The foreground (text) color to draw the description in - defaults to black
  * @param {boolean} [Vibrating] - Whether or not to add vibration effects to the item - defaults to false
- * @param {boolean} [DrawBorder] - Whether or not to draw a border around the preview box
+ * @param {boolean} [Border] - Whether or not to draw a border around the preview box
  * @returns {void} - Nothing
  */
-function DrawAssetPreview(X, Y, Asset, C, Description, Background, Foreground, Vibrating, DrawBorder) {
+function DrawAssetPreview(X, Y, Asset, C, Description, Background, Foreground, Vibrating, Border) {
 	const DynamicPreviewIcon = C ? Asset.DynamicPreviewIcon(C) : "";
 	const Path = `Assets/${Asset.Group.Family}/${Asset.DynamicGroupName}/Preview/${Asset.Name}${DynamicPreviewIcon}.png`;
 	if (Description == null) Description = C ? Asset.DynamicDescription(C) : Asset.Description;
-	DrawPreviewBox(X, Y, Path, Description, Background, Foreground, Vibrating, DrawBorder);
+	DrawPreviewBox(X, Y, Path, Description, { Background, Foreground, Vibrating, Border });
 }
 
 /**
@@ -1096,18 +1096,20 @@ function DrawAssetPreview(X, Y, Asset, C, Description, Background, Foreground, V
  * @param {number} Y - Position of the preview box on the Y axis
  * @param {string} Path - The path of the image to draw
  * @param {string} Description - The preview box description
- * @param {string} [Background] - The background color to draw the preview box in - defaults to white
- * @param {string} [Foreground] - The foreground (text) color to draw the description in - defaults to black
- * @param {boolean} [Vibrating] - Whether or not to add vibration effects to the item - defaults to false
- * @param {boolean} [DrawBorder] - Whether or not to draw a border around the preview box
+ * @param {object} Options - Additional drawing options
+ * @param {string} Options.[Background] - The background color to draw the preview box in - defaults to white
+ * @param {string} Options.[Foreground] - The foreground (text) color to draw the description in - defaults to black
+ * @param {boolean} Options.[Vibrating] - Whether or not to add vibration effects to the item - defaults to false
+ * @param {boolean} Options.[Border] - Whether or not to draw a border around the preview box
  * @returns {void} - Nothing
  */
-function DrawPreviewBox(X, Y, Path, Description, Background, Foreground, Vibrating, DrawBorder) {
+function DrawPreviewBox(X, Y, Path, Description, Options) {
+	let {Background, Foreground, Vibrating, Border} = (Options || {});
 	Background = Background || "#fff";
 	Foreground = Foreground || "#000";
 	const Height = Description ? 275 : 225;
 	DrawRect(X, Y, 225, Height, Background);
-	if (DrawBorder) DrawEmptyRect(X, Y, 225, Height, "#000");
+	if (Border) DrawEmptyRect(X, Y, 225, Height, "#000");
 	const ImageX = Vibrating ? X + 1 + Math.floor(Math.random() * 3) : X + 2;
 	const ImageY = Vibrating ? Y + 1 + Math.floor(Math.random() * 3) : Y + 2;
 	DrawImageResize(Path, ImageX, ImageY, 221, 221);

--- a/BondageClub/Scripts/ExtendedItem.js
+++ b/BondageClub/Scripts/ExtendedItem.js
@@ -142,9 +142,7 @@ function ExtendedItemDraw(Options, DialogPrefix, OptionsPerPage, ShowImages = tr
 	}
 	
 	// Draw the header and item
-	DrawRect(1387, 55, 225, 275, "white");
-	DrawImageResize("Assets/" + Asset.Group.Family + "/" + Asset.DynamicGroupName + "/Preview/" + Asset.Name + ".png", 1389, 57, 221, 221);
-	DrawTextFit(Asset.Description, 1500, 310, 221, "black");
+	DrawAssetPreview(1387, 55, Asset);
 	DrawText(DialogExtendedMessage, 1500, 375, "white", "gray");
 
 	// Draw the possible variants and their requirements, arranged based on the number per page

--- a/BondageClub/Scripts/VibratorMode.js
+++ b/BondageClub/Scripts/VibratorMode.js
@@ -174,18 +174,9 @@ function VibratorModeDraw(Options) {
  * @returns {void} - Nothing
  */
 function VibratorModeDrawHeader() {
-	var Asset = DialogFocusItem.Asset;
-	var AssetPath = "Assets/" + Asset.Group.Family + "/" + Asset.DynamicGroupName + "/Preview/" + Asset.Name + ".png";
-
-	var X = 1389;
-	var Y = 102;
-	if ((DialogFocusItem != null) && (DialogFocusItem.Property != null) && (DialogFocusItem.Property.Intensity != null) && (DialogFocusItem.Property.Intensity >= 0)) {
-		X += Math.floor(Math.random() * 3) - 1;
-		Y += Math.floor(Math.random() * 3) - 1;
-	}
-	DrawRect(1387, 100, 225, 275, "white");
-	DrawImageResize(AssetPath, X, Y, 221, 221);
-	DrawTextFit(Asset.Description, 1500, 350, 221, "black");
+	const Asset = DialogFocusItem.Asset;
+	const Vibrating = DialogFocusItem.Property && DialogFocusItem.Property.Intensity != null && DialogFocusItem.Property.Intensity >= 0;
+	DrawAssetPreview(1387, 100, Asset, null, null, null, Vibrating);
 }
 
 /**

--- a/BondageClub/Scripts/VibratorMode.js
+++ b/BondageClub/Scripts/VibratorMode.js
@@ -176,7 +176,7 @@ function VibratorModeDraw(Options) {
 function VibratorModeDrawHeader() {
 	const Asset = DialogFocusItem.Asset;
 	const Vibrating = DialogFocusItem.Property && DialogFocusItem.Property.Intensity != null && DialogFocusItem.Property.Intensity >= 0;
-	DrawAssetPreview(1387, 100, Asset, null, null, null, Vibrating);
+	DrawAssetPreview(1387, 100, Asset, null, null, null, null, Vibrating);
 }
 
 /**

--- a/BondageClub/Scripts/VibratorMode.js
+++ b/BondageClub/Scripts/VibratorMode.js
@@ -176,7 +176,7 @@ function VibratorModeDraw(Options) {
 function VibratorModeDrawHeader() {
 	const Asset = DialogFocusItem.Asset;
 	const Vibrating = DialogFocusItem.Property && DialogFocusItem.Property.Intensity != null && DialogFocusItem.Property.Intensity >= 0;
-	DrawAssetPreview(1387, 100, Asset, null, null, null, null, Vibrating);
+	DrawAssetPreview(1387, 100, Asset, { Vibrating });
 }
 
 /**


### PR DESCRIPTION
## Summary

The game uses asset previews in several locations, and despite the existence of a `DrawItemPreview` function, it is only used in a couple of places. This made it a lot harder to chase down all of the preview images when reworking for #1936.

This PR reworks the `DrawItemPreview` function into two new functions: `DrawAssetPreview` and `DrawPreviewBox`, and changes all preview images across the core game to use them. It also breaks the horrible ternary operator in `Appearance.js` for determining the preview color into its own slightly more efficient and much more readable `AppearanceGetPreviewImageColor` function.

After this, the `DrawAssetPreview` and `DrawPreviewBox` functions could be used across most extended item screens, but I've not done that here to keep the scope of this PR down.

All refactors have been manually tested and confirmed to still be working as before.