### PR TITLE
Bugfix: Fixes double clicks on the appearance screen

### DIFF
--- a/BondageClub/Screens/Character/Appearance/Appearance.js
+++ b/BondageClub/Screens/Character/Appearance/Appearance.js
@@ -911,6 +911,7 @@ function AppearanceClick() {
 							DialogInventoryBuild(C);
 							CharacterAppearanceCloth = InventoryGet(C, C.FocusGroup.Name);
 							CharacterAppearanceMode = "Cloth";
+							return;
 						} else CharacterAppearanceNextItem(C, AssetGroup[A].Name, (MouseX > 1500));
 		}
 

--- a/BondageClub/Screens/Character/Appearance/Appearance.js
+++ b/BondageClub/Screens/Character/Appearance/Appearance.js
@@ -885,14 +885,13 @@ function AppearanceClick() {
 	// When there is an extended item
 	if (DialogFocusItem != null) {
 		CommonDynamicFunction("Inventory" + DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Click()");
-		return;
 	}
 
 	// Selecting a button in the row at the top
-	if (MouseYIn(25, 90)) AppearanceMenuClick(C);
+	else if (MouseYIn(25, 90)) AppearanceMenuClick(C);
 	
 	// In regular dress-up mode
-	if (CharacterAppearanceMode == "") {
+	else if (CharacterAppearanceMode == "") {
 
 		// If we must remove/restore to default the item
 		if ((MouseX >= 1210) && (MouseX < 1275) && (MouseY >= 145) && (MouseY < 975))
@@ -939,7 +938,7 @@ function AppearanceClick() {
 	}
 
 	// In wardrobe mode
-	if (CharacterAppearanceMode == "Wardrobe") {
+	else if (CharacterAppearanceMode == "Wardrobe") {
 
 		// In warehouse mode, we draw the 12 possible warehouse slots for the character to save & load
 		if ((MouseX >= 1300) && (MouseX < 1800) && (MouseY >= 430) && (MouseY < 970))
@@ -963,12 +962,12 @@ function AppearanceClick() {
 	}
 
 	// In item coloring mode
-	if (CharacterAppearanceMode == "Color") {
+	else if (CharacterAppearanceMode == "Color") {
 		ItemColorClick(CharacterAppearanceSelection, CharacterAppearanceColorPickerGroupName, 1200, 25, 775, 950, true);
 	}
 
 	// In cloth selection mode
-	if (CharacterAppearanceMode == "Cloth") {
+	else if (CharacterAppearanceMode == "Cloth") {
 
 		// Prepares a 3x3 square of clothes to present all the possible options
 		var X = 1250;


### PR DESCRIPTION
## Summary

This fixes an issue with the `AppearanceClick` function that would cause an extra click to appear to be registered when transitioning between the default mode and the cloth selection mode. It changes the handling of each appearance mode to be in its own `else if` block, so click handling should only happen for one mode per click. 

Previously, the click handler for the default `""` appearance mode contained this line:
```js
CharacterAppearanceMode = "Cloth";
```
However, the click handler would then proceed into the `if (CharacterAppearanceMode == "Cloth")` statement, causing the `"Cloth"` mode handling code to be run.

## Steps to reproduce

1. Enter the appearance screen
2. Click one of the appearance groups
3. This takes you into the item submenu as usual, but also seems to register a click on whichever item happened to be under the mouse pointer when I clicked on the group.

See the below gif for an example of the issue:

![double-click](https://user-images.githubusercontent.com/62729616/106359816-d1781f80-630c-11eb-9310-c2dd32e2f361.gif)
