### PR TITLE
Bugfix: Fixes a click handler ordering issue in the appearance menu

### DIFF
--- a/BondageClub/Screens/Character/Appearance/Appearance.js
+++ b/BondageClub/Screens/Character/Appearance/Appearance.js
@@ -887,9 +887,14 @@ function AppearanceClick() {
 		CommonDynamicFunction("Inventory" + DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Click()");
 	}
 
+	// In item coloring mode
+	else if (CharacterAppearanceMode == "Color") {
+		ItemColorClick(CharacterAppearanceSelection, CharacterAppearanceColorPickerGroupName, 1200, 25, 775, 950, true);
+	}
+
 	// Selecting a button in the row at the top
 	else if (MouseYIn(25, 90)) AppearanceMenuClick(C);
-	
+
 	// In regular dress-up mode
 	else if (CharacterAppearanceMode == "") {
 
@@ -960,11 +965,6 @@ function AppearanceClick() {
 					}
 				}
 		return;
-	}
-
-	// In item coloring mode
-	else if (CharacterAppearanceMode == "Color") {
-		ItemColorClick(CharacterAppearanceSelection, CharacterAppearanceColorPickerGroupName, 1200, 25, 775, 950, true);
 	}
 
 	// In cloth selection mode


### PR DESCRIPTION
Follow-up to #1999 - the addition of `else if`s in that PR causes an issue with the `ItemColor` click handler not being called for clicks in the top menu. This increases the priority of the click handling for color mode, which fixes the issue.