### PR TITLE
Height Function Fix

### DIFF
--- a/BondageClub/Scripts/Dialog.js
+++ b/BondageClub/Scripts/Dialog.js
@@ -423,7 +423,7 @@ function DialogLeave() {
 	if (CurrentCharacter) {
 		if (CharacterAppearanceForceUpCharacter == CurrentCharacter.MemberNumber) {
 			CharacterAppearanceForceUpCharacter = 0;
-			CharacterApperanceSetHeightModifier(CurrentCharacter);
+			CharacterAppearanceSetHeightModifiers(CurrentCharacter);
 		}
 		CurrentCharacter.FocusGroup = null;
 	}


### PR DESCRIPTION
A function in the dialog leave was not renamed properly. Probably due to merge conflicts.