### PR TITLE
Bugfix: Rebuilds appearance inventory when selecting an item

### DIFF
--- a/BondageClub/Screens/Character/Appearance/Appearance.js
+++ b/BondageClub/Screens/Character/Appearance/Appearance.js
@@ -989,6 +989,7 @@ function AppearanceClick() {
 					if (InventoryBlockedOrLimited(C, Item)) return;
 					if (InventoryAllow(C, Item.Asset.Prerequisite)) {
 						CharacterAppearanceSetItem(C, C.FocusGroup.Name, DialogInventory[I].Asset);
+						DialogInventoryBuild(C, DialogInventoryOffset);
 						AppearanceMenuBuild(C);
 					} else {
 						CharacterAppearanceHeaderTextTime = DialogTextDefaultTimer;


### PR DESCRIPTION
## Summary

I haven't quite traced back to exactly what caused this, but it was a while ago (before Nina's appearance menu changes at least). When the appearance screen is in the `Cloth` subscreen, clicking on an item no longer displays that item in pink as the first item in the list. This adds a call to `DialogInventoryBuild` after selecting an item, which restores that functionality.