### PR TITLE
Bugfix: Fixed limited permission check for individual spanking toys

### DIFF
--- a/BondageClub/Scripts/Inventory.js
+++ b/BondageClub/Scripts/Inventory.js
@@ -916,7 +916,7 @@ function InventoryIsPermissionLimited(C, AssetName, AssetGroup, AssetType) {
  * @returns {Boolean} - TRUE if item is allowed
  */
 function InventoryCheckLimitedPermission(C, Item, ItemType) {
-	if (!InventoryIsPermissionLimited(C, Item.Asset.Name, Item.Asset.Group.Name, ItemType)) return true;
+	if (!InventoryIsPermissionLimited(C, Item.Asset.DynamicName(Player), Item.Asset.DynamicGroupName, ItemType)) return true;
 	if ((C.ID == 0) || C.IsLoverOfPlayer() || C.IsOwnedByPlayer()) return true;
 	if ((C.ItemPermission < 3) && !(C.WhiteList.indexOf(Player.MemberNumber) < 0)) return true;
 	return false;


### PR DESCRIPTION
## Summary

This fixes an issue with limited permission checks against handheld toys. the `InventoryCheckLimitedPermission` function wasn't using the dynamic asset/group names when running the check for whether an item's permission was limited.

## Steps to reproduce

1. On character A, set an individual spanking toy's item permission to limited (e.g. the cane)
2. Set character A's global item permission to "Everyone, no exceptions", "Everyone, except blacklist", or "Owner, Lover, whitelist & Dominants"
3. On character B (who should not be on character A's whitelist, or their lover/owner), equip the spanking toy selected in step 1
4. Note that character B can still use the spanking toy on character A