### PR TITLE
Wardrobe Compresses & Decompresses Properties (FIX)

### DIFF
--- a/BondageClub/Scripts/Character.js
+++ b/BondageClub/Scripts/Character.js
@@ -1066,7 +1066,7 @@ function CharacterCompressWardrobe(Wardrobe) {
 			var Arr = [];
 			if (Wardrobe[W] != null)
 				for (let A = 0; A < Wardrobe[W].length; A++)
-					Arr.push([Wardrobe[W][A].Name, Wardrobe[W][A].Group, Wardrobe[W][A].Color]);
+					Arr.push([Wardrobe[W][A].Name, Wardrobe[W][A].Group, Wardrobe[W][A].Color, Wardrobe[W][A].Property]);
 			CompressedWardrobe.push(Arr);
 		}
 		return LZString.compressToUTF16(JSON.stringify(CompressedWardrobe));
@@ -1087,7 +1087,7 @@ function CharacterDecompressWardrobe(Wardrobe) {
 			for (let W = 0; W < CompressedWardrobe.length; W++) {
 				var Arr = [];
 				for (let A = 0; A < CompressedWardrobe[W].length; A++)
-					Arr.push({ Name: CompressedWardrobe[W][A][0], Group: CompressedWardrobe[W][A][1], Color: CompressedWardrobe[W][A][2] });
+					Arr.push({ Name: CompressedWardrobe[W][A][0], Group: CompressedWardrobe[W][A][1], Color: CompressedWardrobe[W][A][2], Property: CompressedWardrobe[W][A][3]});
 				DecompressedWardrobe.push(Arr);
 			}
 		}


### PR DESCRIPTION
Added code so that the properties of the saved outfits in the wardrobe are compressed and decompress.

Currently when saving an outfit the properties of an outfit will be saved such as if a Latex Corset has garters or not. But upon logging out and logging back in, as the properties are not compressed or decompressed when loading that same outfit it will default to it's default state.

I believe that this is unintended and just slipt through the cracks due to the low amount of clothing items with properties. I did do some testing and it did seem to work fine with no adverse effects.