### PR TITLE
Futuristic Collar Permission

### DIFF
--- a/BondageClub/Screens/Inventory/ItemNeck/FuturisticCollar/FuturisticCollar.js
+++ b/BondageClub/Screens/Inventory/ItemNeck/FuturisticCollar/FuturisticCollar.js
@@ -81,7 +81,7 @@ function InventoryItemNeckFuturisticCollarClick() {
 	} else {
 		
 		if ((MouseX >= 1885) && (MouseX <= 1975) && (MouseY >= 25) && (MouseY <= 110)) InventoryItemNeckFuturisticCollarExit();
-		else if (MouseIn(1125, 395, 64, 64)) InventoryItemNeckFuturisticCollarTogglePermission(C, DialogFocusItem);
+		else if (MouseIn(1125, 395, 64, 64) && InventoryItemMouthFuturisticPanelGagValidate(C) == "") InventoryItemNeckFuturisticCollarTogglePermission(C, DialogFocusItem);
 		else if (MouseIn(1125, 465, 64, 64)) InventoryItemNeckFuturisticCollarToggleRemotes(C, DialogFocusItem);
 		else {
 		

--- a/BondageClub/Screens/Inventory/ItemNeck/FuturisticCollar/FuturisticCollar.js
+++ b/BondageClub/Screens/Inventory/ItemNeck/FuturisticCollar/FuturisticCollar.js
@@ -81,7 +81,7 @@ function InventoryItemNeckFuturisticCollarClick() {
 	} else {
 		
 		if ((MouseX >= 1885) && (MouseX <= 1975) && (MouseY >= 25) && (MouseY <= 110)) InventoryItemNeckFuturisticCollarExit();
-		else if (MouseIn(1125, 395, 64, 64) && InventoryItemMouthFuturisticPanelGagValidate(C) == "") InventoryItemNeckFuturisticCollarTogglePermission(C, DialogFocusItem);
+		else if (MouseIn(1125, 395, 64, 64) && !(DialogFocusItem && DialogFocusItem.Property && DialogFocusItem.Property.LockedBy && !DialogCanUnlock(C, DialogFocusItem))) InventoryItemNeckFuturisticCollarTogglePermission(C, DialogFocusItem);
 		else if (MouseIn(1125, 465, 64, 64)) InventoryItemNeckFuturisticCollarToggleRemotes(C, DialogFocusItem);
 		else {
 		


### PR DESCRIPTION
Makes it so you need to be able to unlock the collar in order to toggle whether or not permissions are open on the collar. This is to prevent trolling where someone changes your settings and leaves you stuck with them until your owner helps you.