### PR TITLE
In Sensory deprivation, player names in emotes get replaced with Someone

### DIFF
--- a/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
+++ b/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
@@ -1566,7 +1566,14 @@ function ChatRoomMessage(data) {
 				else if (data.Type == "Emote") {
 					if (msg.indexOf("*") == 0) msg = msg + "*";
 					else if ((msg.indexOf("'") == 0) || (msg.indexOf(",") == 0)) msg = "*" + SenderCharacter.Name + msg + "*";
-					else if (PreferenceIsPlayerInSensDep() && SenderCharacter.MemberNumber != Player.MemberNumber) msg = "*" + DialogFindPlayer("Someone") + " " + msg + "*";
+					else if (PreferenceIsPlayerInSensDep() && SenderCharacter.MemberNumber != Player.MemberNumber) {
+						msg = "*" + DialogFindPlayer("Someone") + " " + msg + "*";
+						
+						for (let C = 0; C < ChatRoomCharacter.length; C++) {
+							if (ChatRoomCharacter[C] && ChatRoomCharacter[C].Name && ChatRoomCharacter[C].ID != 0)
+								msg = msg.replace(ChatRoomCharacter[C].Name, DialogFindPlayer("Someone"))
+						}
+					}
 					else msg = "*" + SenderCharacter.Name + " " + msg + "*";
 				}
 				else if (data.Type == "Action") msg = "(" + msg + ")";

--- a/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
+++ b/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
@@ -1571,7 +1571,7 @@ function ChatRoomMessage(data) {
 						
 						for (let C = 0; C < ChatRoomCharacter.length; C++) {
 							if (ChatRoomCharacter[C] && ChatRoomCharacter[C].Name && ChatRoomCharacter[C].ID != 0)
-								msg = msg.replace(ChatRoomCharacter[C].Name, DialogFindPlayer("Someone"))
+								msg = msg.replace(ChatRoomCharacter[C].Name.charAt(0).toUpperCase() + ChatRoomCharacter[C].Name.slice(1), DialogFindPlayer("Someone"))
 						}
 					}
 					else msg = "*" + SenderCharacter.Name + " " + msg + "*";


### PR DESCRIPTION
E.g.

"Ada laughs at Bob"

becomes "Someone laughs at Someone"

This does not replace the player's name, however, so "Charlie tickles Ada" becomes "Someone tickles Ada," assuming I am Ada.

This may be an issue if someone's name is a common word, like slave. For now, it only works if the first letter of the name is capitalized, so if someone types "Charlie tickles slave" and slave is in the room, then slave will not get replaced.
