### PR TITLE
Notifications Enhancements

### DIFF
--- a/BondageClub/Screens/Character/FriendList/FriendList.js
+++ b/BondageClub/Screens/Character/FriendList/FriendList.js
@@ -152,7 +152,7 @@ function FriendListLoadFriendList(data) {
 			FriendListContent += "<div class='FriendListTextColumn'>" + ((FriendListBeepLog[B].Sent) ? SentCaption : ReceivedCaption) + " " + TimerHourToString(FriendListBeepLog[B].Time) + "</div>";
 			FriendListContent += "</div>";
 		}
-		CommonNotificationReset("Beep");
+		NotificationsReset("Beep");
 	} else if (mode === "Delete") {
 		// In Delete mode, we show the friend list and allow the user to remove them
 		for (const [k, v] of Array.from(Player.FriendNames).sort((a, b) => a[1].localeCompare(b[1]))) {

--- a/BondageClub/Screens/Character/Preference/Preference.js
+++ b/BondageClub/Screens/Character/Preference/Preference.js
@@ -659,12 +659,8 @@ function PreferenceSubscreenRestrictionRun() {
 		DrawCheckbox(500, 425, 64, 64, TextGet("RestrictionSlowImmunity"), Player.RestrictionSettings.SlowImmunity);
 	} else {
 		DrawText(TextGet("RestrictionNoAccess"), 500, 225, "Black", "Gray");
-		DrawRect(500, 325, 64, 64, "#ebebe4");
-		DrawEmptyRect(500, 325, 64, 64, "Black");
-		DrawText(TextGet("RestrictionBypassStruggle"), 600, 355, "Black", "Gray");
-		DrawRect(500, 425, 64, 64, "#ebebe4");
-		DrawEmptyRect(500, 425, 64, 64, "Black");
-		DrawText(TextGet("RestrictionSlowImmunity"), 600, 455, "Black", "Gray");
+		DrawCheckboxDisabled(500, 325, 64, 64, TextGet("RestrictionBypassStruggle"));
+		DrawCheckboxDisabled(500, 425, 64, 64, TextGet("RestrictionSlowImmunity"));
 	}
 
 }
@@ -1718,13 +1714,22 @@ function PreferenceSubscreenNotificationsRun() {
 	DrawText(TextGet("NotificationsChatRooms"), 500, 225, "Black", "Gray");
 	DrawCheckbox(500, 270, 64, 64, TextGet("NotificationsBeeps"), Player.NotificationSettings.Beeps);
 	DrawCheckbox(500, 350, 64, 64, TextGet("NotificationsChat"), Player.NotificationSettings.Chat);
-	DrawCheckbox(600, 430, 64, 64, TextGet("NotificationsChatActions"), Player.NotificationSettings.ChatActions);
+	if (Player.NotificationSettings.Chat) {
+		DrawCheckbox(600, 430, 64, 64, TextGet("NotificationsChatActions"), Player.NotificationSettings.ChatActions);
+	} else {
+		DrawCheckboxDisabled(600, 430, 64, 64, TextGet("NotificationsChatActions"));
+	}
 	DrawCheckbox(500, 510, 64, 64, TextGet("NotificationsChatJoin"), Player.NotificationSettings.ChatJoin.Enabled);
 	DrawText("Only:", 600, 622, "Black", "Gray");
-	DrawCheckbox(775, 590, 64, 64, TextGet("NotificationsChatJoinOwner"), Player.NotificationSettings.ChatJoin.Owner);
-	DrawCheckbox(1075, 590, 64, 64, TextGet("NotificationsChatJoinLovers"), Player.NotificationSettings.ChatJoin.Lovers);
-	DrawCheckbox(1375, 590, 64, 64, TextGet("NotificationsChatJoinFriendlist"), Player.NotificationSettings.ChatJoin.Friendlist);
-
+	if (Player.NotificationSettings.ChatJoin.Enabled) {
+		DrawCheckbox(775, 590, 64, 64, TextGet("NotificationsChatJoinOwner"), Player.NotificationSettings.ChatJoin.Owner);
+		DrawCheckbox(1075, 590, 64, 64, TextGet("NotificationsChatJoinLovers"), Player.NotificationSettings.ChatJoin.Lovers);
+		DrawCheckbox(1375, 590, 64, 64, TextGet("NotificationsChatJoinFriendlist"), Player.NotificationSettings.ChatJoin.Friendlist);
+	} else {
+		DrawCheckboxDisabled(775, 590, 64, 64, TextGet("NotificationsChatJoinOwner"));
+		DrawCheckboxDisabled(1075, 590, 64, 64, TextGet("NotificationsChatJoinLovers"));
+		DrawCheckboxDisabled(1375, 590, 64, 64, TextGet("NotificationsChatJoinFriendlist"));
+	}
 	MainCanvas.textAlign = "center";
 
 	// Reset button
@@ -1744,7 +1749,7 @@ function PreferenceSubscreenNotificationsClick() {
 	const settings = Player.NotificationSettings;
 	if (MouseIn(500, 270, 64, 64)) settings.Beeps = !settings.Beeps;
 	if (MouseIn(500, 350, 64, 64)) settings.Chat = !settings.Chat;
-	if (MouseIn(600, 430, 64, 64)) settings.ChatActions = !settings.ChatActions;
+	if (MouseIn(600, 430, 64, 64)) settings.ChatActions = !settings.ChatActions && settings.Chat;
 	if (MouseIn(500, 510, 64, 64)) {
 		settings.ChatJoin.Enabled = !settings.ChatJoin.Enabled;
 		if (!settings.ChatJoin.Enabled) {
@@ -1760,3 +1765,4 @@ function PreferenceSubscreenNotificationsClick() {
 	// Reset button
 	if (MouseIn(500, 800, 380, 64)) NotificationsResetAll();
 }
+

--- a/BondageClub/Screens/Character/Preference/Preference.js
+++ b/BondageClub/Screens/Character/Preference/Preference.js
@@ -1735,5 +1735,5 @@ function PreferenceSubscreenNotificationsClick() {
 	if (MouseIn(600, 430, 64, 64)) Player.NotificationSettings.ChatActions = !Player.NotificationSettings.ChatActions;
 
 	// Reset button
-	if (MouseIn(500, 800, 380, 64)) CommonNotificationResetAll();
+	if (MouseIn(500, 800, 380, 64)) NotificationsResetAll();
 }

--- a/BondageClub/Screens/Character/Preference/Preference.js
+++ b/BondageClub/Screens/Character/Preference/Preference.js
@@ -369,7 +369,12 @@ function PreferenceInitPlayer() {
 	if (typeof C.NotificationSettings.Beeps !== "boolean") C.NotificationSettings.Beeps = true;
 	if (typeof C.NotificationSettings.Chat !== "boolean") C.NotificationSettings.Chat = true;
 	if (typeof C.NotificationSettings.ChatActions !== "boolean") C.NotificationSettings.ChatActions = false;
-
+	if (C.NotificationSettings.ChatJoin == undefined) C.NotificationSettings.ChatJoin = {};
+	if (typeof C.NotificationSettings.ChatJoin.Enabled !== "boolean") C.NotificationSettings.ChatJoin.Enabled = false;
+	if (typeof C.NotificationSettings.ChatJoin.Owner !== "boolean") C.NotificationSettings.ChatJoin.Owner = false;
+	if (typeof C.NotificationSettings.ChatJoin.Lovers !== "boolean") C.NotificationSettings.ChatJoin.Lovers = false;
+	if (typeof C.NotificationSettings.ChatJoin.Friendlist !== "boolean") C.NotificationSettings.ChatJoin.Friendlist = false;
+	
 	// Forces some preferences depending on difficulty
 
 	// Difficulty: non-Roleplay settings
@@ -1714,6 +1719,12 @@ function PreferenceSubscreenNotificationsRun() {
 	DrawCheckbox(500, 270, 64, 64, TextGet("NotificationsBeeps"), Player.NotificationSettings.Beeps);
 	DrawCheckbox(500, 350, 64, 64, TextGet("NotificationsChat"), Player.NotificationSettings.Chat);
 	DrawCheckbox(600, 430, 64, 64, TextGet("NotificationsChatActions"), Player.NotificationSettings.ChatActions);
+	DrawCheckbox(500, 510, 64, 64, TextGet("NotificationsChatJoin"), Player.NotificationSettings.ChatJoin.Enabled);
+	DrawText("Only:", 600, 622, "Black", "Gray");
+	DrawCheckbox(775, 590, 64, 64, TextGet("NotificationsChatJoinOwner"), Player.NotificationSettings.ChatJoin.Owner);
+	DrawCheckbox(1075, 590, 64, 64, TextGet("NotificationsChatJoinLovers"), Player.NotificationSettings.ChatJoin.Lovers);
+	DrawCheckbox(1375, 590, 64, 64, TextGet("NotificationsChatJoinFriendlist"), Player.NotificationSettings.ChatJoin.Friendlist);
+
 	MainCanvas.textAlign = "center";
 
 	// Reset button
@@ -1733,7 +1744,19 @@ function PreferenceSubscreenNotificationsClick() {
 	if (MouseIn(500, 270, 64, 64)) Player.NotificationSettings.Beeps = !Player.NotificationSettings.Beeps;
 	if (MouseIn(500, 350, 64, 64)) Player.NotificationSettings.Chat = !Player.NotificationSettings.Chat;
 	if (MouseIn(600, 430, 64, 64)) Player.NotificationSettings.ChatActions = !Player.NotificationSettings.ChatActions;
-
+	if (MouseIn(500, 510, 64, 64)) {
+		let settings = Player.NotificationSettings.ChatJoin;
+		settings.Enabled = !settings.Enabled;
+		if (!settings.Enabled) {
+			settings.Owner = false;
+			settings.Lovers = false;
+			settings.Friendlist = false;
+		}
+	}
+	if (MouseIn(775, 590, 64, 64) && Player.NotificationSettings.ChatJoin.Enabled) Player.NotificationSettings.ChatJoin.Owner = !Player.NotificationSettings.ChatJoin.Owner;
+	if (MouseIn(1075, 590, 64, 64) && Player.NotificationSettings.ChatJoin.Enabled) Player.NotificationSettings.ChatJoin.Lovers = !Player.NotificationSettings.ChatJoin.Lovers;
+	if (MouseIn(1375, 590, 64, 64) && Player.NotificationSettings.ChatJoin.Enabled) Player.NotificationSettings.ChatJoin.Friendlist = !Player.NotificationSettings.ChatJoin.Friendlist;
+	
 	// Reset button
 	if (MouseIn(500, 800, 380, 64)) NotificationsResetAll();
 }

--- a/BondageClub/Screens/Character/Preference/Preference.js
+++ b/BondageClub/Screens/Character/Preference/Preference.js
@@ -1741,21 +1741,21 @@ function PreferenceSubscreenNotificationsClick() {
 	if (MouseIn(1815, 75, 90, 90)) PreferenceSubscreen = "";
 
 	// Checkboxes
-	if (MouseIn(500, 270, 64, 64)) Player.NotificationSettings.Beeps = !Player.NotificationSettings.Beeps;
-	if (MouseIn(500, 350, 64, 64)) Player.NotificationSettings.Chat = !Player.NotificationSettings.Chat;
-	if (MouseIn(600, 430, 64, 64)) Player.NotificationSettings.ChatActions = !Player.NotificationSettings.ChatActions;
+	const settings = Player.NotificationSettings;
+	if (MouseIn(500, 270, 64, 64)) settings.Beeps = !settings.Beeps;
+	if (MouseIn(500, 350, 64, 64)) settings.Chat = !settings.Chat;
+	if (MouseIn(600, 430, 64, 64)) settings.ChatActions = !settings.ChatActions;
 	if (MouseIn(500, 510, 64, 64)) {
-		let settings = Player.NotificationSettings.ChatJoin;
-		settings.Enabled = !settings.Enabled;
-		if (!settings.Enabled) {
-			settings.Owner = false;
-			settings.Lovers = false;
-			settings.Friendlist = false;
+		settings.ChatJoin.Enabled = !settings.ChatJoin.Enabled;
+		if (!settings.ChatJoin.Enabled) {
+			settings.ChatJoin.Owner = false;
+			settings.ChatJoin.Lovers = false;
+			settings.ChatJoin.Friendlist = false;
 		}
 	}
-	if (MouseIn(775, 590, 64, 64) && Player.NotificationSettings.ChatJoin.Enabled) Player.NotificationSettings.ChatJoin.Owner = !Player.NotificationSettings.ChatJoin.Owner;
-	if (MouseIn(1075, 590, 64, 64) && Player.NotificationSettings.ChatJoin.Enabled) Player.NotificationSettings.ChatJoin.Lovers = !Player.NotificationSettings.ChatJoin.Lovers;
-	if (MouseIn(1375, 590, 64, 64) && Player.NotificationSettings.ChatJoin.Enabled) Player.NotificationSettings.ChatJoin.Friendlist = !Player.NotificationSettings.ChatJoin.Friendlist;
+	if (MouseIn(775, 590, 64, 64) && settings.ChatJoin.Enabled) settings.ChatJoin.Owner = !settings.ChatJoin.Owner;
+	if (MouseIn(1075, 590, 64, 64) && settings.ChatJoin.Enabled) settings.ChatJoin.Lovers = !settings.ChatJoin.Lovers;
+	if (MouseIn(1375, 590, 64, 64) && settings.ChatJoin.Enabled) settings.ChatJoin.Friendlist = !settings.ChatJoin.Friendlist;
 	
 	// Reset button
 	if (MouseIn(500, 800, 380, 64)) NotificationsResetAll();

--- a/BondageClub/Screens/Character/Preference/Preference.js
+++ b/BondageClub/Screens/Character/Preference/Preference.js
@@ -366,6 +366,7 @@ function PreferenceInitPlayer() {
 
 	// Notification settings
 	if (!C.NotificationSettings) C.NotificationSettings = {};
+	if (typeof C.NotificationSettings.Audio !== "boolean") C.NotificationSettings.Audio = false;
 	if (typeof C.NotificationSettings.Beeps !== "boolean") C.NotificationSettings.Beeps = true;
 	if (typeof C.NotificationSettings.Chat !== "boolean") C.NotificationSettings.Chat = true;
 	if (typeof C.NotificationSettings.ChatActions !== "boolean") C.NotificationSettings.ChatActions = false;
@@ -903,6 +904,7 @@ function PreferenceSubscreenAudioRun() {
 	DrawCheckbox(500, 272, 64, 64, TextGet("AudioPlayBeeps"), Player.AudioSettings.PlayBeeps);
 	DrawCheckbox(500, 352, 64, 64, TextGet("AudioPlayItem"), Player.AudioSettings.PlayItem);
 	DrawCheckbox(500, 432, 64, 64, TextGet("AudioPlayItemPlayerOnly"), Player.AudioSettings.PlayItemPlayerOnly);
+	DrawCheckbox(500, 512, 64, 64, TextGet("NotificationsAudio"), Player.NotificationSettings.Audio);
 	MainCanvas.textAlign = "center";
 	DrawBackNextButton(500, 193, 250, 64, Player.AudioSettings.Volume * 100 + "%", "White", "",
 		() => PreferenceSettingsVolumeList[(PreferenceSettingsVolumeIndex + PreferenceSettingsVolumeList.length - 1) % PreferenceSettingsVolumeList.length] * 100 + "%",
@@ -1229,6 +1231,7 @@ function PreferenceSubscreenAudioClick() {
 		if ((MouseY >= 272) && (MouseY < 336)) Player.AudioSettings.PlayBeeps = !Player.AudioSettings.PlayBeeps;
 		if ((MouseY >= 352) && (MouseY < 416)) Player.AudioSettings.PlayItem = !Player.AudioSettings.PlayItem;
 		if ((MouseY >= 432) && (MouseY < 496)) Player.AudioSettings.PlayItemPlayerOnly = !Player.AudioSettings.PlayItemPlayerOnly;
+		if ((MouseY >= 512) && (MouseY < 576)) Player.NotificationSettings.Audio = !Player.NotificationSettings.Audio;
 	}
 
 }
@@ -1711,24 +1714,25 @@ function PreferenceSubscreenNotificationsRun() {
 	// Left-aligned text controls
 	MainCanvas.textAlign = "left";
 	DrawText(TextGet("NotificationsPreferences"), 500, 125, "Black", "Gray");
-	DrawText(TextGet("NotificationsChatRooms"), 500, 225, "Black", "Gray");
-	DrawCheckbox(500, 270, 64, 64, TextGet("NotificationsBeeps"), Player.NotificationSettings.Beeps);
-	DrawCheckbox(500, 350, 64, 64, TextGet("NotificationsChat"), Player.NotificationSettings.Chat);
+	DrawCheckbox(500, 190, 64, 64, TextGet("NotificationsAudio"), Player.NotificationSettings.Audio);
+	DrawText(TextGet("NotificationsChatRooms"), 500, 305, "Black", "Gray");
+	DrawCheckbox(500, 350, 64, 64, TextGet("NotificationsBeeps"), Player.NotificationSettings.Beeps);
+	DrawCheckbox(500, 430, 64, 64, TextGet("NotificationsChat"), Player.NotificationSettings.Chat);
 	if (Player.NotificationSettings.Chat) {
-		DrawCheckbox(600, 430, 64, 64, TextGet("NotificationsChatActions"), Player.NotificationSettings.ChatActions);
+		DrawCheckbox(600, 510, 64, 64, TextGet("NotificationsChatActions"), Player.NotificationSettings.ChatActions);
 	} else {
-		DrawCheckboxDisabled(600, 430, 64, 64, TextGet("NotificationsChatActions"));
+		DrawCheckboxDisabled(600, 510, 64, 64, TextGet("NotificationsChatActions"));
 	}
-	DrawCheckbox(500, 510, 64, 64, TextGet("NotificationsChatJoin"), Player.NotificationSettings.ChatJoin.Enabled);
-	DrawText("Only:", 600, 622, "Black", "Gray");
+	DrawCheckbox(500, 590, 64, 64, TextGet("NotificationsChatJoin"), Player.NotificationSettings.ChatJoin.Enabled);
+	DrawText("Only:", 600, 702, "Black", "Gray");
 	if (Player.NotificationSettings.ChatJoin.Enabled) {
-		DrawCheckbox(775, 590, 64, 64, TextGet("NotificationsChatJoinOwner"), Player.NotificationSettings.ChatJoin.Owner);
-		DrawCheckbox(1075, 590, 64, 64, TextGet("NotificationsChatJoinLovers"), Player.NotificationSettings.ChatJoin.Lovers);
-		DrawCheckbox(1375, 590, 64, 64, TextGet("NotificationsChatJoinFriendlist"), Player.NotificationSettings.ChatJoin.Friendlist);
+		DrawCheckbox(775, 670, 64, 64, TextGet("NotificationsChatJoinOwner"), Player.NotificationSettings.ChatJoin.Owner);
+		DrawCheckbox(1075, 670, 64, 64, TextGet("NotificationsChatJoinLovers"), Player.NotificationSettings.ChatJoin.Lovers);
+		DrawCheckbox(1375, 670, 64, 64, TextGet("NotificationsChatJoinFriendlist"), Player.NotificationSettings.ChatJoin.Friendlist);
 	} else {
-		DrawCheckboxDisabled(775, 590, 64, 64, TextGet("NotificationsChatJoinOwner"));
-		DrawCheckboxDisabled(1075, 590, 64, 64, TextGet("NotificationsChatJoinLovers"));
-		DrawCheckboxDisabled(1375, 590, 64, 64, TextGet("NotificationsChatJoinFriendlist"));
+		DrawCheckboxDisabled(775, 670, 64, 64, TextGet("NotificationsChatJoinOwner"));
+		DrawCheckboxDisabled(1075, 670, 64, 64, TextGet("NotificationsChatJoinLovers"));
+		DrawCheckboxDisabled(1375, 670, 64, 64, TextGet("NotificationsChatJoinFriendlist"));
 	}
 	MainCanvas.textAlign = "center";
 
@@ -1747,10 +1751,11 @@ function PreferenceSubscreenNotificationsClick() {
 
 	// Checkboxes
 	const settings = Player.NotificationSettings;
-	if (MouseIn(500, 270, 64, 64)) settings.Beeps = !settings.Beeps;
-	if (MouseIn(500, 350, 64, 64)) settings.Chat = !settings.Chat;
-	if (MouseIn(600, 430, 64, 64)) settings.ChatActions = !settings.ChatActions && settings.Chat;
-	if (MouseIn(500, 510, 64, 64)) {
+	if (MouseIn(500, 190, 64, 64)) settings.Audio = !settings.Audio;
+	if (MouseIn(500, 350, 64, 64)) settings.Beeps = !settings.Beeps;
+	if (MouseIn(500, 430, 64, 64)) settings.Chat = !settings.Chat;
+	if (MouseIn(600, 510, 64, 64)) settings.ChatActions = !settings.ChatActions && settings.Chat;
+	if (MouseIn(500, 590, 64, 64)) {
 		settings.ChatJoin.Enabled = !settings.ChatJoin.Enabled;
 		if (!settings.ChatJoin.Enabled) {
 			settings.ChatJoin.Owner = false;
@@ -1758,11 +1763,10 @@ function PreferenceSubscreenNotificationsClick() {
 			settings.ChatJoin.Friendlist = false;
 		}
 	}
-	if (MouseIn(775, 590, 64, 64) && settings.ChatJoin.Enabled) settings.ChatJoin.Owner = !settings.ChatJoin.Owner;
-	if (MouseIn(1075, 590, 64, 64) && settings.ChatJoin.Enabled) settings.ChatJoin.Lovers = !settings.ChatJoin.Lovers;
-	if (MouseIn(1375, 590, 64, 64) && settings.ChatJoin.Enabled) settings.ChatJoin.Friendlist = !settings.ChatJoin.Friendlist;
+	if (MouseIn(775, 670, 64, 64) && settings.ChatJoin.Enabled) settings.ChatJoin.Owner = !settings.ChatJoin.Owner;
+	if (MouseIn(1075, 670, 64, 64) && settings.ChatJoin.Enabled) settings.ChatJoin.Lovers = !settings.ChatJoin.Lovers;
+	if (MouseIn(1375, 670, 64, 64) && settings.ChatJoin.Enabled) settings.ChatJoin.Friendlist = !settings.ChatJoin.Friendlist;
 	
 	// Reset button
 	if (MouseIn(500, 800, 380, 64)) NotificationsResetAll();
 }
-

--- a/BondageClub/Screens/Character/Preference/Text_Preference.csv
+++ b/BondageClub/Screens/Character/Preference/Text_Preference.csv
@@ -264,3 +264,7 @@ NotificationsBeeps,Missed beeps
 NotificationsChat,Unread messages in chat rooms
 NotificationsChatActions,Include item and arousal activity messages
 NotificationsReset,Reset Notifications
+NotificationsChatJoin,Players entering chat rooms while away
+NotificationsChatJoinOwner,Owner
+NotificationsChatJoinLovers,Lovers
+NotificationsChatJoinFriendlist,Friends

--- a/BondageClub/Screens/Character/Preference/Text_Preference.csv
+++ b/BondageClub/Screens/Character/Preference/Text_Preference.csv
@@ -259,6 +259,7 @@ PressDownOnDpad,Press Down on Dpad
 PressLeftOnDpad,Press Left on Dpad
 PressRightOnDpad,Press Right on Dpad
 DeadZone,Dead Zone
+NotificationsAudio,Audio alert for notifications
 NotificationsChatRooms,Raise notifications for:
 NotificationsBeeps,Missed beeps
 NotificationsChat,Unread messages in chat rooms

--- a/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
+++ b/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
@@ -1529,7 +1529,7 @@ function ChatRoomMessage(data) {
 					if (!Player.AudioSettings.PlayItemPlayerOnly || IsPlayerInvolved)
 						AudioPlayContent(data);
 
-					if (data.Type == "Action" && IsPlayerInvolved && Player.NotificationSettings.ChatActions) NotificationsChatRoomIncrement();
+					if (data.Type == "Action" && IsPlayerInvolved && SenderCharacter.MemberNumber !== Player.MemberNumber && Player.NotificationSettings.ChatActions) NotificationsChatRoomIncrement();
 				}
 			}
 
@@ -1572,7 +1572,8 @@ function ChatRoomMessage(data) {
 				else if (data.Type == "Action") msg = "(" + msg + ")";
 				else if (data.Type == "ServerMessage") msg = "<b>" + msg + "</b>";
 
-				if (Player.NotificationSettings.Chat && (data.Type == "Chat" || data.Type == "Whisper" || data.Type == "Emote")) NotificationsChatRoomIncrement();
+				if (Player.NotificationSettings.Chat && SenderCharacter.MemberNumber !== Player.MemberNumber
+					&& (data.Type == "Chat" || data.Type == "Whisper" || data.Type == "Emote")) NotificationsChatRoomIncrement();
 			}
 
 			// Outputs the sexual activities text and runs the activity if the player is targeted
@@ -1608,7 +1609,7 @@ function ChatRoomMessage(data) {
 				// Exits before outputting the text if the player doesn't want to see the sexual activity messages
 				if ((Player.ChatSettings != null) && (Player.ChatSettings.ShowActivities != null) && !Player.ChatSettings.ShowActivities) return;
 
-				if (TargetMemberNumber == Player.MemberNumber && Player.NotificationSettings.ChatActions) NotificationsChatRoomIncrement();
+				if (TargetMemberNumber === Player.MemberNumber && SenderCharacter.MemberNumber !== Player.MemberNumber && Player.NotificationSettings.ChatActions) NotificationsChatRoomIncrement();
 			}
 
 			// Adds the message and scrolls down unless the user has scrolled up

--- a/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
+++ b/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
@@ -2501,37 +2501,6 @@ function ChatRoomSetLoadRules(C, Rule) {
 }
 
 /**
- * Increase the number of unread messages in the notifications
- * @returns {void} - Nothing
- */
-function ChatRoomNotification() {
-	if (!ChatRoomNewMessageVisible()) {
-		ChatRoomUnreadMessages = true;
-		CommonNotificationIncrement("Chat");
-	}
-}
-
-/**
- * Remove the notifications if there are new messages that have been seen
- * @returns {void} - Nothing
- */
-function ChatRoomNotificationCheck() {
-	if (ChatRoomUnreadMessages && ChatRoomNewMessageVisible()) {
-		ChatRoomUnreadMessages = false;
-		CommonNotificationReset("Chat");
-	}
-}
-
-/**
- * Returns whether the most recent chat message is on screen
- * @returns {boolean} - TRUE if the screen has focus and the chat log is scrolled to the bottom
- */
-function ChatRoomNewMessageVisible() {
-	if (!document.hasFocus()) return false;
-	else return ElementIsScrolledToEnd("TextAreaChatLog");
-}
-
-/**
  * Take a screenshot of all characters in the chatroom
  * @returns {void} - Nothing
  */

--- a/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
+++ b/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
@@ -955,8 +955,8 @@ function ChatRoomRun() {
 	// Runs any needed online game script
 	OnlineGameRun();
 
-	// Clear any new message notification once they are seen
-	NotificationsChatRoomCheck();
+	// Clear any notifications if needed
+	NotificationsChatRoomReset();
 }
 
 /**
@@ -1672,9 +1672,11 @@ function ChatRoomSync(data) {
 				return;
 			}
 			else if (ChatRoomCharacter.length == data.Character.length - 1) {
-				ChatRoomCharacter.push(CharacterLoadOnline(data.Character[data.Character.length - 1], data.SourceMemberNumber));
+				let C = CharacterLoadOnline(data.Character[data.Character.length - 1], data.SourceMemberNumber);
+				ChatRoomCharacter.push(C);
 				ChatRoomData = data;
-				
+				NotificationsChatRoomJoin(C);
+
 				if (ChatRoomLeashList.indexOf(data.SourceMemberNumber) >= 0) {
 					// Ping to make sure they are still leashed
 					ServerSend("ChatRoomChat", { Content: "PingHoldLeash", Type: "Hidden", Target: data.SourceMemberNumber });

--- a/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
+++ b/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
@@ -956,7 +956,7 @@ function ChatRoomRun() {
 	OnlineGameRun();
 
 	// Clear any new message notification once they are seen
-	ChatRoomNotificationCheck();
+	NotificationsChatRoomCheck();
 }
 
 /**
@@ -1529,7 +1529,7 @@ function ChatRoomMessage(data) {
 					if (!Player.AudioSettings.PlayItemPlayerOnly || IsPlayerInvolved)
 						AudioPlayContent(data);
 
-					if (data.Type == "Action" && IsPlayerInvolved && Player.NotificationSettings.ChatActions) ChatRoomNotification();
+					if (data.Type == "Action" && IsPlayerInvolved && Player.NotificationSettings.ChatActions) NotificationsChatRoomIncrement();
 				}
 			}
 
@@ -1572,7 +1572,7 @@ function ChatRoomMessage(data) {
 				else if (data.Type == "Action") msg = "(" + msg + ")";
 				else if (data.Type == "ServerMessage") msg = "<b>" + msg + "</b>";
 
-				if (Player.NotificationSettings.Chat && (data.Type == "Chat" || data.Type == "Whisper" || data.Type == "Emote")) ChatRoomNotification();
+				if (Player.NotificationSettings.Chat && (data.Type == "Chat" || data.Type == "Whisper" || data.Type == "Emote")) NotificationsChatRoomIncrement();
 			}
 
 			// Outputs the sexual activities text and runs the activity if the player is targeted
@@ -1608,7 +1608,7 @@ function ChatRoomMessage(data) {
 				// Exits before outputting the text if the player doesn't want to see the sexual activity messages
 				if ((Player.ChatSettings != null) && (Player.ChatSettings.ShowActivities != null) && !Player.ChatSettings.ShowActivities) return;
 
-				if (TargetMemberNumber == Player.MemberNumber && Player.NotificationSettings.ChatActions) ChatRoomNotification();
+				if (TargetMemberNumber == Player.MemberNumber && Player.NotificationSettings.ChatActions) NotificationsChatRoomIncrement();
 			}
 
 			// Adds the message and scrolls down unless the user has scrolled up

--- a/BondageClub/Screens/Online/ChatSearch/ChatSearch.js
+++ b/BondageClub/Screens/Online/ChatSearch/ChatSearch.js
@@ -31,7 +31,7 @@ function ChatSearchLoad() {
 	ElementCreateInput("InputSearch", "text", "", "20");
 	ChatSearchQuery();
 	ChatSearchMessage = "";
-	CommonNotificationReset("Chat");
+	NotificationsReset("Chat");
 }
 
 /**

--- a/BondageClub/Scripts/Common.js
+++ b/BondageClub/Scripts/Common.js
@@ -9,7 +9,7 @@ var CurrentOnlinePlayers = 0;
 var CommonIsMobile = false;
 var CommonCSVCache = {};
 var CutsceneStage = 0;
-var Notifications = {};
+
 var CommonPhotoMode = false;
 
 /**
@@ -555,47 +555,13 @@ const CommonGetFontName = CommonMemoize(() => {
 });
 
 /**
- * Increase the reported number of a notifications by one and updates the header
- * @param {string} Type - The type of notification
- * @returns {void}
- */
-function CommonNotificationIncrement(Type) {
-	Notifications[Type] = (Notifications[Type] || 0) + 1;
-	CommonNotificationUpdate();
-}
-
-/**
- * Sets the number of notifications for a type back to zero and updates the header
- * @param {any} Type - The type of notification
- * @returns {void}
- */
-function CommonNotificationReset(Type) {
-	if (Notifications[Type] != null && Notifications[Type] != 0) {
-		Notifications[Type] = 0;
-		CommonNotificationUpdate();
-	}
-}
-
-/**
- * Sets the number of notifications to zero
- * @returns {void}
- */
-function CommonNotificationResetAll() {
-	Notifications = {};
-	CommonNotificationUpdate();
-}
-
-/**
- * Sets or clears notifications in the tab header
+ * Take a screenshot of specified area in "photo mode" and open the image in a new tab
+ * @param {number} Left - Position of the area to capture from the left of the canvas
+ * @param {number} Top - Position of the area to capture from the top of the canvas
+ * @param {number} Width - Width of the area to capture
+ * @param {number} Height - Height of the area to capture
  * @returns {void} - Nothing
  */
-function CommonNotificationUpdate() {
-	let total = 0;
-	for (let key in Notifications) total += Notifications[key];
-	let prefix = total == 0 ? "" : "(" + total.toString() + ") ";
-	document.title = prefix + "Bondage Club";
-}
-
 function CommonTakePhoto(Left, Top, Width, Height) {
 	CommonPhotoMode = true;
 

--- a/BondageClub/Scripts/Drawing.js
+++ b/BondageClub/Scripts/Drawing.js
@@ -880,6 +880,21 @@ function DrawCheckboxColor(Left, Top, Width, Height, Text, IsChecked, Color) {
 }
 
 /**
+ * Draw a grey-filled rectangle to represent a disabled checkbox
+ * @param {number} Left - Position of the component from the left of the canvas
+ * @param {number} Top - Position of the component from the top of the canvas
+ * @param {number} Width - Width of the component
+ * @param {number} Height - Height of the component
+ * @param {string} Text - The text to follow the checkbox
+ * @returns {void} - Nothing
+ */
+function DrawCheckboxDisabled(Left, Top, Width, Height, Text) {
+	DrawRect(Left, Top, Width, Height, "#ebebe4");
+	DrawEmptyRect(Left, Top, Width, Height, "Black", 2);
+	DrawText(Text, Left + 100, Top + 33, "Black", "Gray");
+}
+
+/**
  * Draw a back & next button component
  * @param {number} Left - Position of the component from the left of the canvas
  * @param {number} Top - Position of the component from the top of the canvas

--- a/BondageClub/Scripts/Notifications.js
+++ b/BondageClub/Scripts/Notifications.js
@@ -1,0 +1,75 @@
+﻿"use strict";
+var Notifications = {};
+
+/**
+ * Increase the reported number of a notifications by one and updates the header
+ * @param {string} Type - The type of notification
+ * @returns {void}
+ */
+function CommonNotificationIncrement(Type) {
+	Notifications[Type] = (Notifications[Type] || 0) + 1;
+	CommonNotificationUpdate();
+}
+
+/**
+ * Sets the number of notifications for a type back to zero and updates the header
+ * @param {any} Type - The type of notification
+ * @returns {void}
+ */
+function CommonNotificationReset(Type) {
+	if (Notifications[Type] != null && Notifications[Type] != 0) {
+		Notifications[Type] = 0;
+		CommonNotificationUpdate();
+	}
+}
+
+/**
+ * Sets the number of notifications to zero
+ * @returns {void}
+ */
+function CommonNotificationResetAll() {
+	Notifications = {};
+	CommonNotificationUpdate();
+}
+
+/**
+ * Sets or clears notifications in the tab header
+ * @returns {void} - Nothing
+ */
+function CommonNotificationUpdate() {
+	let total = 0;
+	for (let key in Notifications) total += Notifications[key];
+	let prefix = total == 0 ? "" : "(" + total.toString() + ") ";
+	document.title = prefix + "Bondage Club";
+}
+
+/**
+ * Increase the number of unread messages in the notifications
+ * @returns {void} - Nothing
+ */
+function ChatRoomNotification() {
+	if (!ChatRoomNewMessageVisible()) {
+		ChatRoomUnreadMessages = true;
+		CommonNotificationIncrement("Chat");
+	}
+}
+
+/**
+ * Remove the notifications if there are new messages that have been seen
+ * @returns {void} - Nothing
+ */
+function ChatRoomNotificationCheck() {
+	if (ChatRoomUnreadMessages && ChatRoomNewMessageVisible()) {
+		ChatRoomUnreadMessages = false;
+		CommonNotificationReset("Chat");
+	}
+}
+
+/**
+ * Returns whether the most recent chat message is on screen
+ * @returns {boolean} - TRUE if the screen has focus and the chat log is scrolled to the bottom
+ */
+function ChatRoomNewMessageVisible() {
+	if (!document.hasFocus()) return false;
+	else return ElementIsScrolledToEnd("TextAreaChatLog");
+}

--- a/BondageClub/Scripts/Notifications.js
+++ b/BondageClub/Scripts/Notifications.js
@@ -1,5 +1,6 @@
 ﻿"use strict";
 var Notifications = {};
+var NotificationsAudio = new Audio("Audio/BeepAlarm.mp3");
 
 /**
  * Increase the reported number of a notifications by one and updates the header
@@ -7,7 +8,14 @@ var Notifications = {};
  * @returns {void}
  */
 function NotificationsIncrement(Type) {
+	// Increase the number for the type by 1
 	Notifications[Type] = (Notifications[Type] || 0) + 1;
+	// Play a beep for the first notification for a type
+	if (Notifications[Type] === 1 && Player.NotificationSettings.Audio && Type !== "Beep") {
+		NotificationsAudio.volume = Player.AudioSettings.Volume;
+		NotificationsAudio.play();
+	}
+	// Update the title
 	NotificationsUpdate();
 }
 

--- a/BondageClub/Scripts/Notifications.js
+++ b/BondageClub/Scripts/Notifications.js
@@ -39,7 +39,7 @@ function NotificationsResetAll() {
 function NotificationsUpdate() {
 	let total = 0;
 	for (let key in Notifications) total += Notifications[key];
-	let prefix = total == 0 ? "" : "(" + total.toString() + ") ";
+	const prefix = total == 0 ? "" : "(" + total.toString() + ") ";
 	document.title = prefix + "Bondage Club";
 }
 
@@ -58,10 +58,16 @@ function NotificationsChatRoomIncrement() {
  * Remove the notifications if there are new messages that have been seen
  * @returns {void} - Nothing
  */
-function NotificationsChatRoomCheck() {
+function NotificationsChatRoomReset() {
+	// If there were new messages that are now read
 	if (ChatRoomUnreadMessages && NotificationsChatRoomNewMessageVisible()) {
 		ChatRoomUnreadMessages = false;
 		NotificationsReset("Chat");
+	}
+
+	// If someone joined the room earlier
+	if (Notifications["ChatJoin"] > 0) {
+		NotificationsReset("ChatJoin");
 	}
 }
 
@@ -72,4 +78,25 @@ function NotificationsChatRoomCheck() {
 function NotificationsChatRoomNewMessageVisible() {
 	if (!document.hasFocus()) return false;
 	else return ElementIsScrolledToEnd("TextAreaChatLog");
+}
+
+/**
+ * Raise a notification when particular people enter the room the player is in
+ * @param {Character} C - The player that joined the room
+ * @returns {void} - Nothing
+ */
+function NotificationsChatRoomJoin(C) {
+	if (!document.hasFocus()) {
+		const settings = Player.NotificationSettings.ChatJoin;
+		if (settings.Enabled) {
+			let notify = false;
+
+			if (!settings.Owner && !settings.Lovers && !settings.FriendList) notify = true;
+			else if (settings.Owner && C.IsOwner()) notify = true;
+			else if (settings.Lovers && C.IsLoverOfPlayer()) notify = true;
+			else if (settings.FriendList && Player.FriendList.contains(C.MemberNumber)) notify = true;
+
+			if (notify) NotificationsIncrement("ChatJoin");
+		}
+	}
 }

--- a/BondageClub/Scripts/Notifications.js
+++ b/BondageClub/Scripts/Notifications.js
@@ -66,9 +66,7 @@ function NotificationsChatRoomReset() {
 	}
 
 	// If someone joined the room earlier
-	if (Notifications["ChatJoin"] > 0) {
-		NotificationsReset("ChatJoin");
-	}
+	NotificationsReset("ChatJoin");
 }
 
 /**

--- a/BondageClub/Scripts/Notifications.js
+++ b/BondageClub/Scripts/Notifications.js
@@ -6,9 +6,9 @@ var Notifications = {};
  * @param {string} Type - The type of notification
  * @returns {void}
  */
-function CommonNotificationIncrement(Type) {
+function NotificationsIncrement(Type) {
 	Notifications[Type] = (Notifications[Type] || 0) + 1;
-	CommonNotificationUpdate();
+	NotificationsUpdate();
 }
 
 /**
@@ -16,10 +16,10 @@ function CommonNotificationIncrement(Type) {
  * @param {any} Type - The type of notification
  * @returns {void}
  */
-function CommonNotificationReset(Type) {
+function NotificationsReset(Type) {
 	if (Notifications[Type] != null && Notifications[Type] != 0) {
 		Notifications[Type] = 0;
-		CommonNotificationUpdate();
+		NotificationsUpdate();
 	}
 }
 
@@ -27,16 +27,16 @@ function CommonNotificationReset(Type) {
  * Sets the number of notifications to zero
  * @returns {void}
  */
-function CommonNotificationResetAll() {
+function NotificationsResetAll() {
 	Notifications = {};
-	CommonNotificationUpdate();
+	NotificationsUpdate();
 }
 
 /**
  * Sets or clears notifications in the tab header
  * @returns {void} - Nothing
  */
-function CommonNotificationUpdate() {
+function NotificationsUpdate() {
 	let total = 0;
 	for (let key in Notifications) total += Notifications[key];
 	let prefix = total == 0 ? "" : "(" + total.toString() + ") ";
@@ -47,10 +47,10 @@ function CommonNotificationUpdate() {
  * Increase the number of unread messages in the notifications
  * @returns {void} - Nothing
  */
-function ChatRoomNotification() {
-	if (!ChatRoomNewMessageVisible()) {
+function NotificationsChatRoomIncrement() {
+	if (!NotificationsChatRoomNewMessageVisible()) {
 		ChatRoomUnreadMessages = true;
-		CommonNotificationIncrement("Chat");
+		NotificationsIncrement("Chat");
 	}
 }
 
@@ -58,10 +58,10 @@ function ChatRoomNotification() {
  * Remove the notifications if there are new messages that have been seen
  * @returns {void} - Nothing
  */
-function ChatRoomNotificationCheck() {
-	if (ChatRoomUnreadMessages && ChatRoomNewMessageVisible()) {
+function NotificationsChatRoomCheck() {
+	if (ChatRoomUnreadMessages && NotificationsChatRoomNewMessageVisible()) {
 		ChatRoomUnreadMessages = false;
-		CommonNotificationReset("Chat");
+		NotificationsReset("Chat");
 	}
 }
 
@@ -69,7 +69,7 @@ function ChatRoomNotificationCheck() {
  * Returns whether the most recent chat message is on screen
  * @returns {boolean} - TRUE if the screen has focus and the chat log is scrolled to the bottom
  */
-function ChatRoomNewMessageVisible() {
+function NotificationsChatRoomNewMessageVisible() {
 	if (!document.hasFocus()) return false;
 	else return ElementIsScrolledToEnd("TextAreaChatLog");
 }

--- a/BondageClub/Scripts/Server.js
+++ b/BondageClub/Scripts/Server.js
@@ -713,7 +713,7 @@ function ServerAccountBeep(data) {
 				ServerBeep.Message = ServerBeep.Message + " " + DialogFindPlayer("InRoom") + " \"" + ServerBeep.ChatRoomName + "\" " + (data.ChatRoomSpace === "Asylum" ? DialogFindPlayer("InAsylum") : '');
 			FriendListBeepLog.push({ MemberNumber: data.MemberNumber, MemberName: data.MemberName, ChatRoomName: data.ChatRoomName, ChatRoomSpace: data.ChatRoomSpace, Sent: false, Time: new Date() });
 			if (CurrentScreen == "FriendList") ServerSend("AccountQuery", { Query: "OnlineFriends" });
-			if (Player.NotificationSettings.Beeps && !document.hasFocus()) CommonNotificationIncrement("Beep");
+			if (Player.NotificationSettings.Beeps && !document.hasFocus()) NotificationsIncrement("Beep");
 		} else if (data.BeepType == "Leash" && ChatRoomLeashPlayer == data.MemberNumber && data.ChatRoomName) {
 			if (Player.OnlineSharedSettings && Player.OnlineSharedSettings.AllowPlayerLeashing != false && ( CurrentScreen != "ChatRoom" || !ChatRoomData || (CurrentScreen == "ChatRoom" && ChatRoomData.Name != data.ChatRoomName))) {
 				if (ChatRoomCanBeLeashedBy(data.MemberNumber, Player)) {
@@ -740,7 +740,7 @@ function ServerAccountBeep(data) {
 function ServerDrawBeep() {
 	if ((ServerBeep.Timer != null) && (ServerBeep.Timer > CurrentTime)) {
 		DrawButton((CurrentScreen == "ChatRoom") ? 0 : 500, 0, 1000, 50, ServerBeep.Message, "Pink", "");
-		if (document.hasFocus()) CommonNotificationReset("Beep");
+		if (document.hasFocus()) NotificationsReset("Beep");
 	}
 }
 

--- a/BondageClub/index.html
+++ b/BondageClub/index.html
@@ -52,6 +52,7 @@
 <script src="Scripts/VibratorMode.js"></script>
 <script src="Scripts/socket.io/socket.io.js"></script>
 <script src="Scripts/DynamicDraw.js"></script>
+<script src="Scripts/Notifications.js"></script>
 <script src="Assets/Female3DCG/Female3DCG.js"></script>
 <script src="Screens/Character/Login/Login.js"></script>
 <script src="Screens/Character/Appearance/Appearance.js"></script>


### PR DESCRIPTION
Changes:
- A new option has been added to raise a notification when someone enters the chat room while the player is not focused on the window, which can be restricted to owners and/or lovers and/or friends only.
- An option to trigger the 'beep' sound on receiving a notification has been added. This setting is available in the Audio preferences screen as well. The sound will only occur for the first instance of a notification type. For example one chat message and one player entrance will prompt two beeps, whereas two chat messages will only prompt a beep on the first message. This won't occur for Beep notifications since player beeps already have a dedicated sound setting.
- The notifications code has been moved into its own file instead of cluttering up Common.
- The code to create a grey box to simulate a disabled checkbox has been generalised into DrawCheckboxDisabled for re-use.
- Minor fixes and improvements to notifications in general.