### PR TITLE
Bugfix: Prevents expression reset from removing lip color

### DIFF
--- a/BondageClub/Scripts/Dialog.js
+++ b/BondageClub/Scripts/Dialog.js
@@ -2362,7 +2362,7 @@ function DialogClickExpressionMenu() {
 	if (MouseIn(20, 50, 90, 90)) {
 		DialogFacialExpressions.forEach(FE => {
 			let Color = null;
-			if (FE.Appearance.Asset.Group.AllowColorize && FE.Group !== "Eyes") Color = "Default";
+			if (FE.Appearance.Asset.Group.AllowColorize && FE.Group !== "Eyes" && FE.Group !== "Mouth") Color = "Default";
 			CharacterSetFacialExpression(Player, FE.Group, null, null, Color);
 			FE.CurrentExpression = null;
 		});


### PR DESCRIPTION
## Summary

With the introduction of the color picker to the expression menu, and the modification to the reset button, the reset button now removes players' lip color, which was something of an oversight - it seems logical to have the reset button only reset colors on groups that aren't body parts. This PR prevents the button from resetting a player's mouth color.