### PR TITLE
Bugfix: Several lock-related fixes

### DIFF
--- a/BondageClub/Screens/Inventory/ItemMisc/HighSecurityPadlock/HighSecurityPadlock.js
+++ b/BondageClub/Screens/Inventory/ItemMisc/HighSecurityPadlock/HighSecurityPadlock.js
@@ -91,13 +91,14 @@ function InventoryItemMiscHighSecurityPadlockClick() {
 						C.Appearance[A] = DialogFocusSourceItem;
 				}
 				
-				if (HighSecurityPadlockConfigOwner && Player.Owner && list.indexOf(Player.Owner) < 0) {
-					list.push(Player.Owner)
+				if (HighSecurityPadlockConfigOwner && Player.Ownership && Player.Ownership.MemberNumber != null && list.indexOf(Player.Ownership.MemberNumber) < 0) {
+					list.push(Player.Ownership.MemberNumber);
 				}
 				if (HighSecurityPadlockConfigLover && Player.Lovership) {
 					for (let L = 0; L < Player.Lovership.length; L++) {
-						if (list.indexOf(Player.Lovership[L]) < 0)
-							list.push(Player.Lovership[L].MemberNumber)
+						const lover = Player.Lovership[L];
+						if (lover.MemberNumber != null && list.indexOf(lover.MemberNumber) < 0)
+							list.push(Player.Lovership[L].MemberNumber);
 					}
 				}
 				if (HighSecurityPadlockConfigWhitelist && Player.WhiteList) {

--- a/BondageClub/Scripts/Inventory.js
+++ b/BondageClub/Scripts/Inventory.js
@@ -755,10 +755,6 @@ function InventoryLock(C, Item, Lock, MemberNumber) {
 				if (Item.Property == null) Item.Property = {};
 				if (Item.Property.Effect == null) Item.Property.Effect = [];
 				if (Item.Property.Effect.indexOf("Lock") < 0) Item.Property.Effect.push("Lock");
-				if (Item.Property.Effect.indexOf("MemberNumberList") < 0) {
-					if (!Item.Property) Item.Property = {}
-					if (!Item.Property.MemberNumberList) Item.Property.MemberNumberList = "" + MemberNumber
-				}
 				
 				if (!Item.Property.MemberNumberListKeys && Lock.Asset.Name == "HighSecurityPadlock") Item.Property.MemberNumberListKeys = "" + MemberNumber
 				Item.Property.LockedBy = Lock.Asset.Name;

--- a/BondageClub/Scripts/Server.js
+++ b/BondageClub/Scripts/Server.js
@@ -273,7 +273,7 @@ function ServerValidateProperties(C, Item, Validation) {
 
 	// Remove LockMemberNumber if the source is incorrect prior to all checks
 	if ((Item.Property != null) && (C.ID == 0) && (Validation != null) && (Validation.SourceMemberNumber != null)) {
-		var Lock = InventoryGetLock(Item);
+		const Lock = InventoryGetLock(Item);
 		if ((Lock != null) && (Lock.Property != null)) {
 			if (!Validation.FromOwner && Lock.Asset.OwnerOnly) delete Item.Property.LockMemberNumber;
 			else if (!Validation.FromLoversOrOwner && Lock.Asset.LoverOnly) delete Item.Property.LockMemberNumber;
@@ -302,9 +302,9 @@ function ServerValidateProperties(C, Item, Validation) {
 			if ((Effect == "Lock") && (InventoryGetLock(Item) != null)) {
 
 				// Make sure the combination number on the lock is valid, 4 digits only
-				var Lock = InventoryGetLock(Item);
+				const Lock = InventoryGetLock(Item);
 				if ((Item.Property.CombinationNumber != null) && (typeof Item.Property.CombinationNumber == "string")) {
-					var Regex = /^[0-9]+$/;
+					const Regex = /^[0-9]+$/;
 					if (!Item.Property.CombinationNumber.match(Regex) || (Item.Property.CombinationNumber.length != 4)) {
 						Item.Property.CombinationNumber = "0000";
 					}
@@ -312,7 +312,6 @@ function ServerValidateProperties(C, Item, Validation) {
 				
 				
 				// Make sure the seed on the lock is valid
-				var Lock = InventoryGetLock(Item);
 				if ((Item.Property.LockPickSeed != null) && (typeof Item.Property.LockPickSeed == "string")) {
 					var conv = CommonConvertStringToArray(Item.Property.LockPickSeed)
 					for (let PP = 0; PP < conv.length; PP++) {
@@ -324,9 +323,8 @@ function ServerValidateProperties(C, Item, Validation) {
 				} else delete Item.Property.LockPickSeed;
 
 				// Make sure the password on the lock is valid, 6 letters only
-				var Lock = InventoryGetLock(Item);
 				if ((Item.Property.Password != null) && (typeof Item.Property.Password == "string")) {
-					var Regex = /^[A-Z]+$/;
+					const Regex = /^[A-Z]+$/;
 					if (!Item.Property.Password.toUpperCase().match(Regex) || (Item.Property.Password.length > 8)) {
 						Item.Property.Password = "UNLOCK";
 					}
@@ -602,7 +600,7 @@ function ServerItemCopyProperty(C, Item, NewProperty) {
 	if (Item.Property.RemoveItem != null) NewProperty.RemoveItem = Item.Property.RemoveItem; else delete NewProperty.RemoveItem;
 	if (Item.Property.ShowTimer != null) NewProperty.ShowTimer = Item.Property.ShowTimer; else delete NewProperty.ShowTimer;
 	if (Item.Property.EnableRandomInput != null) NewProperty.EnableRandomInput = Item.Property.EnableRandomInput; else delete NewProperty.EnableRandomInput;
-	if (!NewProperty.EnableRandomInput || NewProperty.LockedBy != "LoversTimerPadlock") {
+	if (!NewProperty.EnableRandomInput || !["LoversTimerPadlock", "OwnerTimerPadlock"].includes(NewProperty.LockedBy)) {
 		if (Item.Property.MemberNumberList != null) NewProperty.MemberNumberList = Item.Property.MemberNumberList; else delete NewProperty.MemberNumberList;
 		if (Item.Property.RemoveTimer != null) NewProperty.RemoveTimer = Math.round(Item.Property.RemoveTimer); else delete NewProperty.RemoveTimer;
 	}


### PR DESCRIPTION
## Summary

This makes several small fixes to certain lock functionality. ~~I'd be grateful if @Ada18980 could cast an eye over this to ensure that I've not inadvertently broken anything about lockpicking or the high security padlock (although I've tested it, and it seems to work fine)~~ (Ada has confirmed that this shouldn't cause any issues).

Fixes:
* Fixes an issue where `MemberNumberList` was being incorrectly set to a string in `InventoryLock`, rather than an array, which broke use of `MemberNumberList` in timer padlocks
* Fixes an issue where people were unable to add/remove timer from owner timer padlocks
* Fixes a problem where the "Append owner" feature of the high security padlock was appending the owner's name rather than their member number
* Fixes an issue where the "Append lovers" feature of the high security padlock would crash if the player had an NPC lover (as NPCs have no member number)