### PR TITLE
Bugfix: Ensures an extended item's exit function is called on extended item type selection

### DIFF
--- a/BondageClub/Scripts/ExtendedItem.js
+++ b/BondageClub/Scripts/ExtendedItem.js
@@ -273,6 +273,7 @@ function ExtendedItemSetType(C, Options, Option, IsCloth) {
 			// If we're in a chatroom, call the item's publish function to publish a message to the chatroom
 			CommonCallFunctionByName(FunctionPrefix + "PublishAction", C, Option, PreviousOption);
 		} else {
+			CommonCallFunctionByName(FunctionPrefix + "Exit");
 			DialogFocusItem = null;
 			if (C.ID === 0) {
 				// Player is using the item on herself


### PR DESCRIPTION
This ensures that any cleanup on items that have extra features (e.g. input boxes) in their extended menus gets executed in single player areas.