### PR TITLE
Bugfix: Fix for disappearing lover/owner locks on relog

### DIFF
--- a/BondageClub/Screens/Character/Login/Login.js
+++ b/BondageClub/Screens/Character/Login/Login.js
@@ -451,7 +451,7 @@ function LoginResponse(C) {
 			LoginDifficulty();
 
 			// Loads the player character model and data
-			Player.Appearance = ServerAppearanceLoadFromBundle(Player, C.AssetFamily, C.Appearance);
+			Player.Appearance = ServerAppearanceLoadFromBundle(Player, C.AssetFamily, C.Appearance, C.MemberNumber);
 			InventoryLoad(Player, C.Inventory);
 			LogLoad(C.Log);
 			ReputationLoad(C.Reputation);


### PR DESCRIPTION
## Summary

This fixes disappearing owner/lover locks on relog by changing the `LoginResponse` function to report that the appearance bundle originated from the player themselves. I'm not exactly sure why this wasn't already an issue, but this should fix it.