### PR TITLE
Wardrobe Cancel Button

### DIFF
--- a/BondageClub/Screens/Character/Appearance/Appearance.js
+++ b/BondageClub/Screens/Character/Appearance/Appearance.js
@@ -5,6 +5,7 @@ var CharacterAppearanceNumPerPage = 9;
 var CharacterAppearanceHeaderText = "";
 var CharacterAppearanceHeaderTextTime = 0;
 var CharacterAppearanceBackup = null;
+var CharacterAppearanceInProgressBackup = null;
 var CharacterAppearanceAssets = [];
 var CharacterAppearanceColorPickerGroupName = "";
 var CharacterAppearanceColorPickerBackup = "";
@@ -574,7 +575,7 @@ function AppearanceMenuBuild(C) {
 	
 	// Add the exit buttons
 	if (CharacterAppearanceMode !== "Color") {
-		if (!DialogItemPermissionMode && CharacterAppearanceMode != "Wardrobe") AppearanceMenu.push("Cancel");
+		if (!DialogItemPermissionMode) AppearanceMenu.push("Cancel");
 		AppearanceMenu.push("Accept");
 	}
 }
@@ -1044,7 +1045,16 @@ function AppearanceMenuClick(C) {
 						if (CharacterAppearanceWardrobeOffset >= Player.Wardrobe.length) CharacterAppearanceWardrobeOffset = 0;
 					}
 					if (Button === "Naked") CharacterAppearanceStripLayer(C);
-					if (Button === "Accept") AppearanceExit();
+					if (Button === "Cancel") {
+						CharacterAppearanceRestore(C, CharacterAppearanceInProgressBackup);
+						CharacterRefresh(C, false);
+						CharacterAppearanceInProgressBackup = null;
+						AppearanceExit();
+					}
+					if (Button === "Accept") {
+						CharacterAppearanceInProgressBackup = null;
+						AppearanceExit();
+					}
 					break;
 				case "Cloth":
 					// Extends the current item
@@ -1230,6 +1240,7 @@ function CharacterAppearanceWardrobeLoad(C) {
 	ElementCreateInput("InputWardrobeName", "text", C.Name, "20");
 	CharacterAppearanceMode = "Wardrobe";
 	CharacterAppearanceWardrobeText = TextGet("WardrobeNameInfo");
+	CharacterAppearanceInProgressBackup = CharacterAppearanceStringify(C);
 }
 
 /**


### PR DESCRIPTION
After the menu button refactor, the wardrobe only had an Accept button which jumped back up to the main appearance screen, maintaining the 'Dress manually' behaviour from before. Having to then Cancel from that screen in order to not save the wardrobe change was counterintuitive and was reported as an issue by users.
Now the wardrobe screen has a Cancel button of its own that restores the appearance from before entering the wardrobe, and jumps back up to the main appearance screen to stay consistent with other subscreen accept/cancel button behaviour.