### PR TITLE
Bugfix: Fixes the click handler for the clit & dildo vibrator belt

### DIFF
--- a/BondageClub/Screens/Inventory/ItemVulva/ClitAndDildoVibratorbelt/ClitAndDildoVibratorbelt.js
+++ b/BondageClub/Screens/Inventory/ItemVulva/ClitAndDildoVibratorbelt/ClitAndDildoVibratorbelt.js
@@ -28,7 +28,7 @@ function InventoryItemVulvaClitAndDildoVibratorbeltDraw() {
 
 // Catches the item extension clicks
 function InventoryItemVulvaClitAndDildoVibratorbeltClick() {
-	if (MouseIn(1885, 225, 90, 90)) DialogFocusItem = null;
+	if (MouseIn(1885, 25, 90, 90)) DialogFocusItem = null;
 	else if (MouseIn(1200, 775, 200, 55) && (DialogFocusItem.Property.Intensity !== -1)) InventoryItemVulvaClitAndDildoVibratorbeltIntensity(-1 - DialogFocusItem.Property.Intensity);
 	else if (MouseIn(1550, 775, 200, 55) && (DialogFocusItem.Property.Intensity !== 0)) InventoryItemVulvaClitAndDildoVibratorbeltIntensity(0 - DialogFocusItem.Property.Intensity);
 	else if (MouseIn(1200, 835, 200, 55) && (DialogFocusItem.Property.Intensity !== 1)) InventoryItemVulvaClitAndDildoVibratorbeltIntensity(1 - DialogFocusItem.Property.Intensity);


### PR DESCRIPTION
Back in #2004, I removed some duplicated click handler logic for some vibrator items which had invisible exit "buttons" independent of their actual exit buttons. In the case of the Clit & Dildo Vibrator Belt, I accidentally deleted the wrong click handler, so you can only exit the extended item screen by clicking 200px lower than the actual button. This fixes that.