### PR TITLE
Bugfix: More disappearing locks

### DIFF
--- a/BondageClub/Scripts/Server.js
+++ b/BondageClub/Scripts/Server.js
@@ -525,7 +525,7 @@ function ServerAppearanceLoadFromBundle(C, AssetFamily, Bundle, SourceMemberNumb
 
 					// If a non-owner/lover has added an owner/lover-only lock, remove it
 					const Lock = InventoryGetLock(NA);
-					if (C.ID === 0 && !FromOwner && Lock && Lock.Asset.OwnerOnly) ServerDeleteLock(NA.Property) && (deleted = true);
+					if (C.ID === 0 && !FromOwner && Lock && Lock.Asset.OwnerOnly) ServerDeleteLock(NA.Property);
 					if (C.ID === 0 && !FromLoversOrOwner && Lock && Lock.Asset.LoverOnly) ServerDeleteLock(NA.Property);
 
 					ServerValidateProperties(C, NA, { SourceMemberNumber: SourceMemberNumber, FromOwner: FromOwner, FromLoversOrOwner: FromLoversOrOwner });


### PR DESCRIPTION
## Summary

This fixes _another_ issue with disappearing owner/lover locks on full appearance updates. This prevents that (and actually makes the `ServerAppearanceLoadFromBundle` function very slightly more efficient). The issue was caused by the `Property` object being assigned to the `NA` object referencing the same object as the original property. The lock then got removed from the `NA` item, but the asset wasn't pushed to the `Appearance` array due to an existing item. I've accordingly moved the `CanPush` logic up to before the asset is recreated, and the code now skips the creation of the `NA` item completely if it's never going to push it to the `Appearance array.

I've tested everything I can think of to make sure owner/lover locks are now behaving as expected:
* Fixes to owner timer locks in #2056 are still working as expected
* Unlocking/removing owner/lover locked items via console is blocked correctly
* _Adding_ owner/lover locks via console is blocked correctly (fix from #1959 still works)
* Beta fix #1901 still applies correctly

Hopefully we now have all of the bases covered for owner/lover locks in appearance updates!

## Steps to reproduce

1. Add an owner-locked item on a Character A
2. Have a player that _is not_ Character A's owner change Character A's clothes
3. Observe that the owner locks have been removed.