### PR TITLE
Fix: Render warning

### DIFF
--- a/BondageClub/Scripts/GLDraw.js
+++ b/BondageClub/Scripts/GLDraw.js
@@ -368,6 +368,7 @@ function GLDrawLoadImage(gl, url) {
         if (Img) {
             GLDrawBingImageToTextureInfo(gl, Img, textureInfo);
         } else {
+            gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 1, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, new Uint8Array([0, 0, 0, 0]));
             Img = new Image();
             GLDrawImageCache.set(url, Img);
 


### PR DESCRIPTION
Fixes following warning in console: `RENDER WARNING: texture bound to texture unit 0 is not renderable.`
The reason for this warning is attempt to render not yet loaded texture.
The fix works by assigning empty, 1px transparent texture, that is replaced when image loads