### PR TITLE
Item Permissions Colour fix

### DIFF
--- a/BondageClub/Screens/Character/Appearance/Appearance.js
+++ b/BondageClub/Screens/Character/Appearance/Appearance.js
@@ -699,7 +699,7 @@ function AppearanceRun() {
 function AppearanceGetPreviewImageColor(C, item, hover) {
 	if (DialogItemPermissionMode && C.ID === 0) {
 		let permission = "green";
-		if (InventoryIsPermissionBlocked(C, item.Asset.DynamicName(Player), item.Asset.DynamicGroupName)) permission = "red";
+		if (InventoryIsPermissionBlocked(C, item.Asset.Name, item.Asset.Group.Name)) permission = "red";
 		else if (InventoryIsPermissionLimited(C, item.Asset.Name, item.Asset.Group.Name)) permission = "amber";
 		return item.Worn ? "gray" : AppearancePermissionColors[permission][hover ? 1 : 0];
 	} else {


### PR DESCRIPTION
For assets that had both Item and Clothes versions, the button background was not properly set to red in permissions-mode when the item is blocked.