### PR TITLE
Hands Colour Fix

### DIFF
--- a/BondageClub/Assets/Female3DCG/Female3DCG.js
+++ b/BondageClub/Assets/Female3DCG/Female3DCG.js
@@ -1241,7 +1241,7 @@ var AssetFemale3DCG = [
 		AllowPose: ["TapedHands", "BackBoxTie", "BackCuffs", "BackElbowTouch", "AllFours"],
 		Asset: ["Default"],
 		InheritColor: "BodyUpper",
-		Color: ["Default", "White", "Asian", "Black"],
+		Color: ["Default"],
 	},
 	
 	{

--- a/BondageClub/Scripts/CommonDraw.js
+++ b/BondageClub/Scripts/CommonDraw.js
@@ -193,6 +193,9 @@ function CommonDrawAppearanceBuild(C, {
 			Color = Color[Layer.ColorIndex] || AG.ColorSchema[0];
 		}
 
+		// Fix to legacy appearance data when Hands could be different to BodyUpper
+		if (GroupName === "Hands") Color = "Default";
+
 		// Check if we need to copy the color of another asset
 		let InheritColor = (Color == "Default" ? (Layer.InheritColor || A.InheritColor || AG.InheritColor) : null);
 		let ColorInherited = false;


### PR DESCRIPTION
Hands were removed as a separate appearance option relatively recently and will always take the colour Default which lets them inherit the BodyUpper colour. However saved wardrobe slots from before that time will have Hands saved with a non-Default colour. Trying to change the body colour after loading a slot will leave the hands at the old colour with no way to change them. This forces hand colours to always be Default.