### PR TITLE
Add High Security Lock to Strong Locks

### DIFF
--- a/BondageClub/Screens/Room/MainHall/MainHall.js
+++ b/BondageClub/Screens/Room/MainHall/MainHall.js
@@ -14,7 +14,11 @@ var MainHallMaidWasCalledManually = false;
 
 var MainHallBeingPunished = false;
 var MainHallFirstFrame = false;
-var MainHallStrongLocks = [{ Name: "CombinationPadlock", Group: "ItemMisc", Type: null }, { Name: "PasswordPadlock", Group: "ItemMisc", Type: null }, { Name: "TimerPasswordPadlock", Group: "ItemMisc", Type: null }];
+var MainHallStrongLocks = [{ Name: "CombinationPadlock", Group: "ItemMisc", Type: null },
+	{ Name: "PasswordPadlock", Group: "ItemMisc", Type: null },
+	{ Name: "TimerPasswordPadlock", Group: "ItemMisc", Type: null },
+	{ Name: "HighSecurityPadlock", Group: "ItemMisc", Type: null },
+];
 
 var MainHallPunishmentList = [
 	{ItemMouth:"BallGag", ItemHead: "LeatherBlindfold", ItemHands: "DuctTape"},


### PR DESCRIPTION
Since the High-Security lock can only be unlocked by owners/lovers and the equipper (plus anyone the equipper delegates) but can be applied by anyone, someone without an owner/lover could be permanently locked into a corset or other non-restraint item by a stranger.
Adding the lock to the 'strong lock' list alongside others like the password locks to prevent this.