### PR TITLE
Bugfix: Stops long password lock hints from overflowing

### DIFF
--- a/BondageClub/Screens/Inventory/ItemMisc/PasswordPadlock/PasswordPadlock.js
+++ b/BondageClub/Screens/Inventory/ItemMisc/PasswordPadlock/PasswordPadlock.js
@@ -45,7 +45,7 @@ function InventoryItemMiscPasswordPadlockDraw() {
 		(DialogFocusSourceItem.Property.LockMemberNumber && DialogFocusSourceItem.Property.LockMemberNumber != Player.MemberNumber))) {
 			// Normal lock interface
 			if (DialogFocusSourceItem && DialogFocusSourceItem.Property && DialogFocusSourceItem.Property.Hint)
-				DrawText("\"" + DialogFocusSourceItem.Property.Hint + "\"", 1500, 700, "white", "gray");
+				DrawTextWrap("\"" + DialogFocusSourceItem.Property.Hint + "\"", 1000, 640, 1000, 120, null, null, 2);
 			MainCanvas.textAlign = "right";
 			DrawText(DialogFindPlayer("PasswordPadlockOld"), 1490, 805, "white", "gray");
 			ElementPosition("Password", 1640, 805, 250);


### PR DESCRIPTION
Not exactly a beta fix - this just prevents the hints on password locks from overflowing for particularly long hints by using `DrawTextWrap` instead of `DrawText`.

Before:
![](https://cdn.discordapp.com/attachments/554378725916147722/810083400522137620/pasword_lock_bug.png)

After
![image](https://user-images.githubusercontent.com/62729616/107863232-5c4b3500-6e4a-11eb-8d10-d10be8406583.png)
