### PR TITLE
Bugfix: Re-enables removal of assets with the AllowRemoveExclusive property

### DIFF
--- a/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
+++ b/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
@@ -1906,15 +1906,12 @@ function ChatRoomSyncItem(data) {
 
 			// From another user, we prevent changing the item if the current item is locked by owner/lover locks
 			if (!FromOwner) {
-				var Item = InventoryGet(ChatRoomCharacter[C], data.Item.Group);
+				const Item = InventoryGet(ChatRoomCharacter[C], data.Item.Group);
 				if ((Item != null) && (InventoryOwnerOnlyItem(Item) || (!FromLoversOrOwner && InventoryLoverOnlyItem(Item)))) {
-					if (data.Item.Property == null) return;
-					if (Item.Asset.OwnerOnly) return;
-					if (Item.Asset.LoverOnly) return;
-					if (Item.Asset.Name === data.Item.Name) {
-						ServerItemCopyProperty(ChatRoomCharacter[C], Item, data.Item.Property)
+					if (!ChatRoomAllowChangeLockedItem(data, Item)) return;
+					else if (Item.Asset.Name === data.Item.Name && data.Item.Property != null) {
+						ServerItemCopyProperty(ChatRoomCharacter[C], Item, data.Item.Property);
 					}
-					return;
 				}
 			}
 


### PR DESCRIPTION
## Summary

This has actually been broken since #1387 got merged. In that change, `ChatRoomSyncItem` stopped using the `ChatRoomAllowChangeLockedItem` check, which meant that items with the `AllowRemoveExclusive` property (i.e. the Lovers Vibrator) could no longer be properly removed by people that weren't lovers/owners. This reworks the `ChatRoomSyncItem` function slightly to use `ChatRoomAllowChangeLockedItem` again, which should re-enable the `AllowRemoveExclusive` property, whilst also blocking other changes from non-lovers/owners. As this is (kind of) another lock validation change, I've checked:
* Non-lovers/owners are unable to add/remove lover/owner only items unless they have the `AllowRemoveExclusive` property, even through the console
* Non-lovers/owners can't remove lover/owner-locked items, even through the console
* Non-lovers/owners can't add lover/owner locks to an item, even through the console
* Non-lovers/owners can still add/remove time from lover/owner timer padlocks, where the padlock allows it