### PR TITLE
Bugfix: Ensures Futuristic Vibrator works with the default triggers on first equip

### DIFF
--- a/BondageClub/Screens/Inventory/ItemVulva/FuturisticVibrator/FuturisticVibrator.js
+++ b/BondageClub/Screens/Inventory/ItemVulva/FuturisticVibrator/FuturisticVibrator.js
@@ -138,8 +138,10 @@ function InventoryItemVulvaFuturisticVibratorSetMode(C, Item, Option) {
 }
 
 function InventoryItemVulvaFuturisticVibratorHandleChat(C, Item, LastTime) {
-	if (!Item || !Item.Property || !Item.Property.TriggerValues) return;
-	var TriggerValues = Item.Property.TriggerValues.split(',')
+	if (!Item) return;
+	if (!Item.Property) VibratorModeSetProperty(Item, VibratorModeOptions[VibratorModeSet.STANDARD][0].Property);
+	var TriggerValues = Item.Property.TriggerValues && Item.Property.TriggerValues.split(',');
+	if (!TriggerValues) TriggerValues = ItemVulvaFuturisticVibratorTriggers;
 	for (let CH = 0; CH < ChatRoomChatLog.length; CH++) {
 		if (ChatRoomChatLog[CH].Time > LastTime) {
 			var msg = InventoryItemVulvaFuturisticVibratorDetectMsg(ChatRoomChatLog[CH].Chat.toUpperCase(), TriggerValues)


### PR DESCRIPTION
This causes the futuristic vibrator to use the default triggers when it is first equipped, without the need for someone to visit its extended item menu first. If no triggers have been set, the vibrator will respond to the default triggers in `ItemVulvaFuturisticVibratorTriggers`.