### PR TITLE
Bugfix: Fix for an infinite loop in the shop job

### DIFF
--- a/BondageClub/Screens/Room/Shop/Dialog_NPC_Shop_Vendor.csv
+++ b/BondageClub/Screens/Room/Shop/Dialog_NPC_Shop_Vendor.csv
@@ -56,11 +56,13 @@ ItemPelvisLeatherCrop,,,(You lash the leather crop pretty hard on her butt.)  Da
 32,33,(Wait for a customer.),,JobStart(),
 33,0,Thanks a lot!,My pleasure.  Is there anything else you need?,,
 33,0,(Nod happily.),My pleasure.  Is there anything else you need?,,
-33,31,Can I do it again?,Sure!  Let me find an item to promote.  (She checks on the shelves for an item to use on you.),,Player.CanInteract()
+33,,Can I do it again?,(She giggles.)  You'll need to get out of those restraints before you can try again!,,!JobCanGoAgain()
+33,31,Can I do it again?,Sure!  Let me find an item to promote.  (She checks on the shelves for an item to use on you.),,JobCanGoAgain()
 33,,Can you help me out?,"I don't have time, there's too many customers.  Go find a maid if you can't struggle out.",DialogRemove(),!Player.CanInteract()
 34,0,I'm not a great saleswoman.,Don't worry about it.  Is there anything else you need?,,
 34,0,(Nod very slowly.),Don't worry about it.  Is there anything else you need?,,
-34,31,Can I try again?,Alright.  Let me find an item to promote.  (She checks on the shelves for an item to use on you.),,Player.CanInteract()
+34,,Can I try again?,  I'm afraid you'll need to get out of those restraints before you can try again,,!JobCanGoAgain()
+34,31,Can I try again?,Alright.  Let me find an item to promote.  (She checks on the shelves for an item to use on you.),,JobCanGoAgain()
 34,,Can you help me out?,"I don't have time, there's too many customers.  Go find a maid if you can't struggle out.",DialogRemove(),!Player.CanInteract()
 100,,Regular clothes or outfits.,,"Start(""Cloth"")",
 100,,Accesories to go with clothes.,,"Start(""ClothAccessory"")",

--- a/BondageClub/Screens/Room/Shop/Shop.js
+++ b/BondageClub/Screens/Room/Shop/Shop.js
@@ -298,9 +298,12 @@ function ShopJobRestrain() {
 
 	// First, we find a body part where we can use the item
 	DialogChangeReputation("Dominant", -1);
-	while (true) {
-		ShopDemoItemGroup = CommonRandomItemFromList("", ShopDemoItemGroupList);
-		if ((InventoryGet(Player, ShopDemoItemGroup) == null) && !InventoryGroupIsBlocked(Player, ShopDemoItemGroup)) break;
+	const availableGroups = ShopJobFilterAvailableGroups();
+	if (availableGroups.length > 0) {
+		ShopDemoItemGroup = CommonRandomItemFromList("", availableGroups);
+	} else {
+		ShopVendor.Stage = 30;
+		return;
 	}
 
 	// Add a random item on that body part and creates a customer
@@ -327,4 +330,23 @@ function ShopJobStart() {
 	EmptyCharacter.push(Player);
 	EmptyCharacter.push(ShopCustomer);
 	CommonSetScreen("Room", "Empty");
+}
+
+/**
+ * Filters the list of shop demo items down to the groups that are currently available on the player
+ * @returns {string[]} - The filtered list demo item groups that are both empty and unblocked
+ */
+function ShopJobFilterAvailableGroups() {
+	return ShopDemoItemGroupList.filter((group) => {
+		return !InventoryGet(Player, group) && !InventoryGroupIsBlocked(Player, group);
+	});
+}
+
+/**
+ * Checks whether or not the player is able to retry the shop job after completing one
+ * @returns {boolean} - Returns true if the player is able to continue running shop jobs (are able to interact, not all
+ * demo item groups are occupied/blocked)
+ */
+function ShopJobCanGoAgain() {
+	return Player.CanInteract() && ShopJobFilterAvailableGroups().length > 0;
 }


### PR DESCRIPTION
## Summary

This fixes an infinite loop in the shop job that can occurs if the player is wearing a gag that doesn't muffle their speech (e.g. the futuristic gags in padded mode). I've removed the `while (true)` altogether and replaced it with a safer alternative, and added dialogue lines to the shopkeeper to handle this case

## Steps to reproduce

1. Equip arm, ankle and leg cuffs, but don't connect them
2. Equip a futuristic gag and set it to padded mode
3. Start the shop job. The shopkeeper should give you a blindfold (the issue only occurs if the blindfold doesn't also gag the player)
4. After completing the job (either successfully or unsuccessfully), ask to try again
5. The game will freeze in an infinite loop, as all demo groups are occupied, so the `while` loop in `ShopJobRestrain` will never terminate