### PR TITLE
Kneel Button Fix

### DIFF
--- a/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
+++ b/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
@@ -1074,9 +1074,10 @@ function ChatRoomClick() {
 
 	// When the user character kneels
 	if (MouseIn(1254, 0, 120, 62) && Player.CanKneel()) {
-		ServerSend("ChatRoomChat", { Content: (Player.ActivePose == null) ? "KneelDown" : "StandUp", Type: "Action", Dictionary: [{ Tag: "SourceCharacter", Text: Player.Name, MemberNumber: Player.MemberNumber }] });
-		CharacterSetActivePose(Player, (Player.ActivePose == null) ? "Kneel" : null, true);
-		ChatRoomStimulationMessage("Kneel")
+		const PlayerIsKneeling = Player.ActivePose && Player.ActivePose.includes("Kneel");
+		ServerSend("ChatRoomChat", { Content: PlayerIsKneeling ? "StandUp" : "KneelDown", Type: "Action", Dictionary: [{ Tag: "SourceCharacter", Text: Player.Name, MemberNumber: Player.MemberNumber }] });
+		CharacterSetActivePose(Player, PlayerIsKneeling ? "BaseLower" : "Kneel");
+		ChatRoomStimulationMessage("Kneel");
 		ServerSend("ChatRoomCharacterPoseUpdate", { Pose: Player.ActivePose });
 	}
 


### PR DESCRIPTION
The chat room Kneel button would always make the player stand on the first press if they had any pose other than kneeling. Even if that pose was already standing in some form, e.g. legs closed or arms in any pose. 
Now it should always make the player kneel or stand as expected and will no longer remove the arms pose.