### PR TITLE
Bugfix: Futuristic vibrator crash

### DIFF
--- a/BondageClub/Screens/Inventory/ItemVulva/FuturisticVibrator/FuturisticVibrator.js
+++ b/BondageClub/Screens/Inventory/ItemVulva/FuturisticVibrator/FuturisticVibrator.js
@@ -15,11 +15,10 @@ function InventoryItemVulvaFuturisticVibratorLoad() {
 		ItemVulvaFuturisticVibratorTriggerValues = DialogFocusItem.Property.TriggerValues.split(',')
 
 		// Only create the inputs if the zone isn't blocked
-		if (!InventoryGroupIsBlocked(C, C.FocusGroup.Name)) {
-			for (let I = 0; I < ItemVulvaFuturisticVibratorTriggers.length; I++) {
-				ElementCreateInput("FuturisticVibe" + ItemVulvaFuturisticVibratorTriggers[I], "text", "", "12"); document.getElementById("FuturisticVibe" + ItemVulvaFuturisticVibratorTriggers[I]).placeholder = ItemVulvaFuturisticVibratorTriggerValues[I];
-			}
-		}
+		ItemVulvaFuturisticVibratorTriggers.forEach((trigger, i) => {
+			const input = ElementCreateInput("FuturisticVibe" + trigger, "text", "", "12");
+			if (input) input.placeholder = ItemVulvaFuturisticVibratorTriggerValues[i];
+		});
 	}
 }
 
@@ -32,20 +31,15 @@ function InventoryItemVulvaFuturisticVibratorDraw() {
 		DrawAssetPreview(1387, 50, DialogFocusItem.Asset);
 		const mode = DialogFindPlayer(DialogFocusItem.Property.Mode || "Off");
 		DrawText(DialogFindPlayer("CurrentMode") + mode, 1500, 375, "white", "gray");
-
-		if (InventoryGroupIsBlocked(C, C.FocusGroup.Name)) {
-			// If the group is blocked don't draw the controls
-			DrawText(DialogFindPlayer("ZoneBlocked"), 1500, 500, "white", "gray");
-		} else {
-			// Otherwise draw each of the triggers and position their inputs, then draw the save button
-			ItemVulvaFuturisticVibratorTriggers.forEach((trigger, i) => {
-				MainCanvas.textAlign = "right";
-				DrawText(DialogFindPlayer("FuturisticVibrator" + trigger), 1400, 450 + 60 * i, "white", "gray");
-				MainCanvas.textAlign = "center";
-				ElementPosition("FuturisticVibe" + trigger, 1650, 450 + 60 * i, 400);
-			});
-			DrawButton(1325, 450 + 60 * ItemVulvaFuturisticVibratorTriggers.length, 350, 64, DialogFindPlayer("FuturisticVibratorSaveVoiceCommands"), "White", "");
-		}
+		// Draw each of the triggers and position their inputs
+		ItemVulvaFuturisticVibratorTriggers.forEach((trigger, i) => {
+			MainCanvas.textAlign = "right";
+			DrawText(DialogFindPlayer("FuturisticVibrator" + trigger), 1400, 450 + 60 * i, "white", "gray");
+			MainCanvas.textAlign = "center";
+			ElementPosition("FuturisticVibe" + trigger, 1650, 450 + 60 * i, 400);
+		});
+		// Draw the save button
+		DrawButton(1325, 450 + 60 * ItemVulvaFuturisticVibratorTriggers.length, 350, 64, DialogFindPlayer("FuturisticVibratorSaveVoiceCommands"), "White", "");
 	}
 }
 
@@ -53,9 +47,7 @@ function InventoryItemVulvaFuturisticVibratorClick() {
 	var C = CharacterGetCurrent();
 	if (InventoryItemMouthFuturisticPanelGagValidate(C) !== "") InventoryItemMouthFuturisticPanelGagClickAccessDenied()
 	else if (MouseIn(1885, 25, 90, 90)) InventoryItemVulvaFuturisticVibratorExit();
-	else if (!InventoryGroupIsBlocked(C, C.FocusGroup.Name)) {
-		if (MouseIn(1325, 450 + 60 * ItemVulvaFuturisticVibratorTriggers.length, 350, 64)) InventoryItemVulvaFuturisticVibratorClickSet();
-	}
+	else if (MouseIn(1325, 450 + 60 * ItemVulvaFuturisticVibratorTriggers.length, 350, 64)) InventoryItemVulvaFuturisticVibratorClickSet();
 }
 
 

--- a/BondageClub/Screens/Inventory/ItemVulva/FuturisticVibrator/FuturisticVibrator.js
+++ b/BondageClub/Screens/Inventory/ItemVulva/FuturisticVibrator/FuturisticVibrator.js
@@ -24,38 +24,37 @@ function InventoryItemVulvaFuturisticVibratorLoad() {
 }
 
 function InventoryItemVulvaFuturisticVibratorDraw() {
-	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
+	var C = CharacterGetCurrent();
 	if (InventoryItemMouthFuturisticPanelGagValidate(C) !== "") {
 		InventoryItemMouthFuturisticPanelGagDrawAccessDenied()
 	} else {
+		// Draw the preview & current mode
 		DrawAssetPreview(1387, 50, DialogFocusItem.Asset);
-		for (let I = 0; I <= ItemVulvaFuturisticVibratorTriggers.length; I++) {
-				if (I < ItemVulvaFuturisticVibratorTriggers.length) {
-					MainCanvas.textAlign = "right";
-					DrawText(DialogFindPlayer("FuturisticVibrator" + ItemVulvaFuturisticVibratorTriggers[I]), 1400, 450+60*I, "white", "gray");
-					MainCanvas.textAlign = "center";
-					var mode = DialogFindPlayer("Off" )
-					if (DialogFocusItem.Property && DialogFocusItem.Property.Mode) {
-						mode = DialogFindPlayer(DialogFocusItem.Property.Mode)
-					}
-					DrawText(DialogFindPlayer("CurrentMode" ) + mode, 1500, 375, "white", "gray");
-					ElementPosition("FuturisticVibe" + ItemVulvaFuturisticVibratorTriggers[I], 1650, 450+60*I, 400);
-				} else
-					DrawButton(1325, 450+60*I, 350, 64, DialogFindPlayer("FuturisticVibratorSaveVoiceCommands"), "White", "");
-			}
-			
+		const mode = DialogFindPlayer(DialogFocusItem.Property.Mode || "Off");
+		DrawText(DialogFindPlayer("CurrentMode") + mode, 1500, 375, "white", "gray");
+
+		if (InventoryGroupIsBlocked(C, C.FocusGroup.Name)) {
+			// If the group is blocked don't draw the controls
+			DrawText(DialogFindPlayer("ZoneBlocked"), 1500, 500, "white", "gray");
+		} else {
+			// Otherwise draw each of the triggers and position their inputs, then draw the save button
+			ItemVulvaFuturisticVibratorTriggers.forEach((trigger, i) => {
+				MainCanvas.textAlign = "right";
+				DrawText(DialogFindPlayer("FuturisticVibrator" + trigger), 1400, 450 + 60 * i, "white", "gray");
+				MainCanvas.textAlign = "center";
+				ElementPosition("FuturisticVibe" + trigger, 1650, 450 + 60 * i, 400);
+			});
+			DrawButton(1325, 450 + 60 * ItemVulvaFuturisticVibratorTriggers.length, 350, 64, DialogFindPlayer("FuturisticVibratorSaveVoiceCommands"), "White", "");
+		}
 	}
 }
 
 function InventoryItemVulvaFuturisticVibratorClick() {
-	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
-	if (InventoryItemMouthFuturisticPanelGagValidate(C) !== "") {
-		InventoryItemMouthFuturisticPanelGagClickAccessDenied()
-	} else {
-		
-		if ((MouseX >= 1885) && (MouseX <= 1975) && (MouseY >= 25) && (MouseY <= 110)) InventoryItemVulvaFuturisticVibratorExit();
-		
-		if (MouseIn(1325, 450+60*ItemVulvaFuturisticVibratorTriggers.length, 350, 64)) InventoryItemVulvaFuturisticVibratorClickSet();
+	var C = CharacterGetCurrent();
+	if (InventoryItemMouthFuturisticPanelGagValidate(C) !== "") InventoryItemMouthFuturisticPanelGagClickAccessDenied()
+	else if (MouseIn(1885, 25, 90, 90)) InventoryItemVulvaFuturisticVibratorExit();
+	else if (!InventoryGroupIsBlocked(C, C.FocusGroup.Name)) {
+		if (MouseIn(1325, 450 + 60 * ItemVulvaFuturisticVibratorTriggers.length, 350, 64)) InventoryItemVulvaFuturisticVibratorClickSet();
 	}
 }
 

--- a/BondageClub/Scripts/Element.js
+++ b/BondageClub/Scripts/Element.js
@@ -247,8 +247,12 @@ function ElementRemove(ID) {
  * @returns {void} - Nothing
  */
 function ElementPosition(ElementID, X, Y, W, H) {
-
 	var E = document.getElementById(ElementID);
+
+	if (!E) {
+		console.warn("A call to ElementPosition was made on non-existent element with ID '" + ElementID + "'");
+		return;
+	}
 
 	// For a vertical slider, swap the width and the height (the transformation is handled by CSS)
 	if (E.tagName.toLowerCase() === "input" && E.getAttribute("type") === "range" && E.classList.contains("Vertical")) {
@@ -267,20 +271,16 @@ function ElementPosition(ElementID, X, Y, W, H) {
 	const Left = MainCanvas.canvas.offsetLeft + (X - W / 2) * WRatio;
 
 	// Sets the element style
-	if (E) {
-		Object.assign(E.style, {
-			fontSize: Font + "px",
-			fontFamily: CommonGetFontName(),
-			position: "fixed",
-			left: Left + "px",
-			top: Top + "px",
-			width: Width + "px",
-			height: Height + "px",
-			display: "inline"
-		});
-	} else {
-		console.warn("A call to ElementPosition was made on non-existent element with ID '" + ElementID + "'");
-	}
+	Object.assign(E.style, {
+		fontSize: Font + "px",
+		fontFamily: CommonGetFontName(),
+		position: "fixed",
+		left: Left + "px",
+		top: Top + "px",
+		width: Width + "px",
+		height: Height + "px",
+		display: "inline"
+	});
 }
 
 /**


### PR DESCRIPTION
## Summary

This fixes an issue where the Futuristic Vibrator's extended item menu would crash if the vulva zone was blocked. If the zone was blocked, the inputs were not being added, and subsequently calling `ElementPosition` in the draw function would crash. I've put in a fix to the `ElementPosition` to ensure it logs a warning in such situations, and I've modified the extended item screen for the vibrator the vibrator now functions properly regardless of whether or not the zone is blocked.