### PR TITLE
Bugfix: Prevents the handheld remote from bypassing remote owner rules

### DIFF
--- a/BondageClub/Screens/Room/Shop/Shop.js
+++ b/BondageClub/Screens/Room/Shop/Shop.js
@@ -170,7 +170,7 @@ function ShopClick() {
 				if (InventoryAvailable(Player, ShopCart[A].Name, ShopCart[A].Group.Name)) ShopText = TextGet("AlreadyOwned");
 				else if (ShopCart[A].Value > Player.Money) ShopText = TextGet("NotEnoughMoney");
 				else if (LogQuery("BlockKey", "OwnerRule") && (Player.Ownership != null) && (Player.Ownership.Stage == 1) && ((ShopCart[A].Name == "Lockpicks") || (ShopCart[A].Name == "MetalCuffsKey") || (ShopCart[A].Name == "MetalPadlockKey") || (ShopCart[A].Name == "IntricatePadlockKey") || (ShopCart[A].Name == "HighSecurityPadlockKey"))) ShopText = TextGet("CannotSellKey");
-				else if (LogQuery("BlockRemote", "OwnerRule") && (Player.Ownership != null) && (Player.Ownership.Stage == 1) && (ShopCart[A].Name == "VibratorRemote" || ShopCart[A].Name == "LoversVibratorRemote")) ShopText = TextGet("CannotSellRemote");
+				else if (LogQuery("BlockRemote", "OwnerRule") && (Player.Ownership != null) && (Player.Ownership.Stage == 1) && (ShopCart[A].Name == "VibratorRemote" || ShopCart[A].Name == "LoversVibratorRemote" || ShopCart[A].Name === "SpankingToysVibeRemote")) ShopText = TextGet("CannotSellRemote");
 				else {
 
 					// Add the item and removes the money

--- a/BondageClub/Scripts/Inventory.js
+++ b/BondageClub/Scripts/Inventory.js
@@ -841,6 +841,7 @@ function InventoryConfiscateRemote() {
 	InventoryDelete(Player, "VibratorRemote", "ItemVulva");
 	InventoryDelete(Player, "VibratorRemote", "ItemNipples");
 	InventoryDelete(Player, "LoversVibratorRemote", "ItemVulva");
+	InventoryDelete(Player, "SpankingToysVibeRemote", "ItemHands");
 }
 
 /**


### PR DESCRIPTION
## Summary

Because the new handheld vibrator remote is in the same buy group as the existing vibrator remotes, it can be purchased in the shop to bypass the "cannot buy remotes" owner rule, and is not confiscated at the same time as other remotes, causing them to appear in the player's inventory on their next login. This PR fixes these issues.