### PR TITLE
Bugfix: Stops skill modifiers from overlapping skills in the information sheet

### DIFF
--- a/BondageClub/Screens/Character/InformationSheet/InformationSheet.js
+++ b/BondageClub/Screens/Character/InformationSheet/InformationSheet.js
@@ -160,10 +160,10 @@ function InformationSheetSecondScreenRun() {
 		SkillGetLevel(C, "Evasion");
 		if ((C.ID == 0) && (SkillModifier != 0)) {
 			var PlusSign = (SkillModifier > 0) ? "+" : "";
-			DrawText(TextGet("SkillModifier"), 1425, 575, "Black", "Gray");
-			DrawText(TextGet("SkillBondage") + " " + PlusSign + SkillModifier, 1425, 650, "Black", "Gray");
-			DrawText(TextGet("SkillEvasion") + " " + PlusSign + SkillModifier, 1425, 725, "Black", "Gray");
-			DrawText(TextGet("SkillModifierDuration") + " " + (TimermsToTime(LogValue("ModifierDuration", "SkillModifier") - CurrentTime)), 1425, 800, "Black", "Gray");
+			DrawText(TextGet("SkillModifier"), 1425, 650, "Black", "Gray");
+			DrawText(TextGet("SkillBondage") + " " + PlusSign + SkillModifier, 1425, 725, "Black", "Gray");
+			DrawText(TextGet("SkillEvasion") + " " + PlusSign + SkillModifier, 1425, 800, "Black", "Gray");
+			DrawText(TextGet("SkillModifierDuration") + " " + (TimermsToTime(LogValue("ModifierDuration", "SkillModifier") - CurrentTime)), 1425, 875, "Black", "Gray");
 		}
 
 	}


### PR DESCRIPTION
## Summary

With the addition of the lockpicking skill, the skill modifiers in the information sheet can now overlap with the skill list if the player has every skill in the game (see image). Luckily, there's still (just about) space to move the skill modifiers down a line.

![image](https://user-images.githubusercontent.com/62729616/108259086-a557fd80-7158-11eb-81e2-b8b995f8958d.png)
