### PR TITLE
Improvement: Item save format

### DIFF
--- a/BondageClub/Screens/Character/Login/Login.js
+++ b/BondageClub/Screens/Character/Login/Login.js
@@ -289,23 +289,26 @@ function LoginValideBuyGroups() {
  * @returns {void} Nothing
  */
 function LoginValidateArrays() {
+	let update = false;
 	var CleanBlockItems = AssetCleanArray(Player.BlockItems);
 	if (CleanBlockItems.length != Player.BlockItems.length) {
 		Player.BlockItems = CleanBlockItems;
-		ServerSend("AccountUpdate", { BlockItems: Player.BlockItems });
+		update = true;
 	}
 
 	var CleanLimitedItems = AssetCleanArray(Player.LimitedItems);
 	if (CleanLimitedItems.length != Player.LimitedItems.length) {
 		Player.LimitedItems = CleanLimitedItems;
-		ServerSend("AccountUpdate", { LimitedItems: Player.LimitedItems });
+		update = true;
 	}
 
 	var CleanHiddenItems = AssetCleanArray(Player.HiddenItems);
 	if (CleanHiddenItems.length != Player.HiddenItems.length) {
 		Player.HiddenItems = CleanHiddenItems;
-		ServerSend("AccountUpdate", { HiddenItems: Player.HiddenItems });
+		update = true;
 	}
+	if (update)
+		ServerPlayerBlockItemsSync();
 }
 
 /**
@@ -317,7 +320,7 @@ function LoginDifficulty() {
 	// If Extreme mode, the player cannot control her blocked items
 	if (Player.GetDifficulty() >= 3) {
 		LoginExtremeItemSettings();
-		ServerSend("AccountUpdate", { BlockItems: Player.BlockItems, LimitedItems: Player.LimitedItems, HiddenItems: Player.HiddenItems });
+		ServerPlayerBlockItemsSync();
 	}
 }
 

--- a/BondageClub/Screens/Character/Login/Login.js
+++ b/BondageClub/Screens/Character/Login/Login.js
@@ -396,6 +396,11 @@ function LoginResponse(C) {
 			Player.LimitedItems = Array.isArray(C.LimitedItems) ? C.LimitedItems :
 				typeof C.LimitedItems === "object" && C.LimitedItems ? CommonUnpackItemArray(C.LimitedItems) : [];
 			Player.HiddenItems = ((C.HiddenItems == null) || !Array.isArray(C.HiddenItems)) ? [] : C.HiddenItems;
+			// TODO: Migration code; remove after few versions (added R66)
+			if (Array.isArray(C.BlockItems) || Array.isArray(C.LimitedItems)) {
+				ServerPlayerBlockItemsSync();
+			}
+
 			Player.Difficulty = C.Difficulty;
 			Player.WardrobeCharacterNames = C.WardrobeCharacterNames;
 			WardrobeCharacter = [];

--- a/BondageClub/Screens/Character/Preference/Preference.js
+++ b/BondageClub/Screens/Character/Preference/Preference.js
@@ -884,7 +884,7 @@ function PreferenceExit() {
 		NotificationSettings: Player.NotificationSettings,
 		ItemPermission: Player.ItemPermission,
 		LabelColor: Player.LabelColor,
-		LimitedItems: Player.LimitedItems,
+		LimitedItems: CommonPackItemArray(Player.LimitedItems),
 	};
 	ServerSend("AccountUpdate", P);
 	PreferenceMessage = "";
@@ -1644,7 +1644,7 @@ function PreferenceVisibilityCheckboxChanged(List, CheckSetting) {
  * @returns {void} - Nothing
  */
 function PreferenceVisibilityExit(SaveChanges) {
-	if (SaveChanges) ServerSend("AccountUpdate", { HiddenItems: Player.HiddenItems, BlockItems: Player.BlockItems });
+	if (SaveChanges) ServerPlayerBlockItemsSync();
 
 	PreferenceVisibilityGroupList = [];
 	PreferenceVisibilityHiddenList = [];

--- a/BondageClub/Scripts/Inventory.js
+++ b/BondageClub/Scripts/Inventory.js
@@ -870,9 +870,9 @@ function InventoryIsWorn(C, AssetName, AssetGroup) {
  * Toggles an item's permission for the player
  * @param {object} Item - Appearance item to toggle
  * @param {object} Type - Type of the item to toggle
- * @returns {void} - Nothing 
+ * @returns {void} - Nothing
  */
-function InventoryTogglePermission(Item, Type) { 
+function InventoryTogglePermission(Item, Type) {
 	if (InventoryIsPermissionBlocked(Player, Item.Asset.Name, Item.Asset.Group.Name, Type)) {
 		Player.BlockItems = Player.BlockItems.filter(B => B.Name != Item.Asset.Name || B.Group != Item.Asset.Group.Name || B.Type != Type);
 		Player.LimitedItems.push({ Name: Item.Asset.Name, Group: Item.Asset.Group.Name, Type: Type });
@@ -881,7 +881,7 @@ function InventoryTogglePermission(Item, Type) {
 		Player.LimitedItems = Player.LimitedItems.filter(B => B.Name != Item.Asset.Name || B.Group != Item.Asset.Group.Name || B.Type != Type);
 	else
 		Player.BlockItems.push({ Name: Item.Asset.Name, Group: Item.Asset.Group.Name, Type: Type });
-	ServerSend("AccountUpdate", { BlockItems: Player.BlockItems, LimitedItems: Player.LimitedItems });
+	ServerPlayerBlockItemsSync();
 }
 
 /**

--- a/BondageClub/Scripts/Server.js
+++ b/BondageClub/Scripts/Server.js
@@ -178,15 +178,33 @@ function ServerPlayerSync() {
 }
 
 /**
- * Syncs the full player inventory to the server. The inventory is a stringified object compressed with LZString
+ * Syncs the full player inventory to the server.
  * @returns {void} - Nothing
  */
 function ServerPlayerInventorySync() {
-	var Inv = [];
-	for (let I = 0; I < Player.Inventory.length; I++)
-		if (Player.Inventory[I].Asset != null)
-			Inv.push([Player.Inventory[I].Asset.Name, Player.Inventory[I].Asset.Group.Name]);
-	ServerSend("AccountUpdate", { Inventory: LZString.compressToUTF16(JSON.stringify(Inv)) });
+	const Inv = {};
+	for (let I = 0; I < Player.Inventory.length; I++) {
+		if (Player.Inventory[I].Asset != null) {
+			let G = Inv[Player.Inventory[I].Asset.Group.Name];
+			if (G === undefined) {
+				G = Inv[Player.Inventory[I].Asset.Group.Name] = [];
+			}
+			G.push(Player.Inventory[I].Asset.Name);
+		}
+	}
+	ServerSend("AccountUpdate", { Inventory: Inv });
+}
+
+/**
+ * Syncs player's blocked, limited and hidden items to the server
+ * @returns {void} - Nothing
+ */
+function ServerPlayerBlockItemsSync() {
+	ServerSend("AccountUpdate", {
+		BlockItems: CommonPackItemArray(Player.BlockItems),
+		LimitedItems: CommonPackItemArray(Player.LimitedItems),
+		HiddenItems: Player.HiddenItems
+	});
 }
 
 /**


### PR DESCRIPTION
**Requires [Bondage-Club-Server#68](https://github.com/Ben987/Bondage-Club-Server/pull/68)**
Otherwise blocked and limited items are not correctly updated in some cases

**Includes #2137**
**Should only be merged the release after #2137 is fully deployed to stable version!**
Otherwise players would loose their inventory and blocked items as well as others would be unable to correctly interpret this player's!

Changes the format in which `Inventory`, `BlockItems` and `LimitedItems` are saved with focus on smallest size transferred over network, expecting per-message-deflate
