### PR TITLE
Rejoin Failed Message

### DIFF
--- a/BondageClub/Screens/Online/ChatSearch/ChatSearch.js
+++ b/BondageClub/Screens/Online/ChatSearch/ChatSearch.js
@@ -430,6 +430,7 @@ function ChatSearchResultResponse(data) {
 					ChatRoomNewRoomToUpdate = NewRoom
 				}
 			} else {
+				ChatSearchMessage = roomIsFull ? "ResponseRoomFull" : "ResponseCannotFindRoom";
 				ChatRoomSetLastChatRoom("")
 			}
 		}
@@ -443,7 +444,7 @@ function ChatSearchResultResponse(data) {
  */
 function ChatSearchQuery() {
 	var Query = ElementValue("InputSearch").toUpperCase().trim();
-	// Prevent spam searching the same thing.
+	
 	if (ChatRoomJoinLeash != null && ChatRoomJoinLeash != "") {
 		Query = ChatRoomJoinLeash.toUpperCase().trim();
 	} else if (Player.ImmersionSettings && Player.LastChatRoom && Player.LastChatRoom != "") {
@@ -454,6 +455,7 @@ function ChatSearchQuery() {
 		}
 	}
 
+	// Prevent spam searching the same thing.
 	if (ChatSearchLastQuerySearch != Query || ChatSearchLastQuerySearchHiddenRooms != ChatSearchIgnoredRooms.length || (ChatSearchLastQuerySearch == Query && ChatSearchLastQuerySearchTime + 2000 < CommonTime())) { 
 		ChatSearchLastQuerySearch = Query;
 		ChatSearchLastQuerySearchTime = CommonTime();
@@ -461,6 +463,8 @@ function ChatSearchQuery() {
 		ChatSearchResult = [];
 		ServerSend("ChatRoomSearch", { Query: Query, Space: ChatRoomSpace, Game: ChatRoomGame, FullRooms: (Player.OnlineSettings && Player.OnlineSettings.SearchShowsFullRooms), Ignore: ChatSearchIgnoredRooms });
 	}
+
+	ChatSearchMessage = "EnterName";
 }
 
 /**


### PR DESCRIPTION
When a player 1) has the rejoin chatroom setting on, 2) does not have the room recreate setting on, and 3) tries to rejoin a room that no longer exists, then they're greeted with an empty search screen and the "No chat room found" message which doesn't really communicate what happened.
Now in such cases the "Room doesn't exist anymore" or "This room is already full" messages will appear in the bottom left as they normally would if the user clicked on a room button. The Search button will now reset the message as well.