### PR TITLE
Exit Club Confirm

### DIFF
--- a/BondageClub/Screens/Room/MainHall/MainHall.js
+++ b/BondageClub/Screens/Room/MainHall/MainHall.js
@@ -341,7 +341,11 @@ function MainHallClick() {
 	if ((MouseX >= 750) && (MouseX < 1250) && (MouseY >= 0) && (MouseY < 1000)) CharacterSetCurrent(Player);
 	if ((MouseX >= 1645) && (MouseX < 1735) && (MouseY >= 25) && (MouseY < 115)) InformationSheetLoadCharacter(Player);
 	if ((MouseX >= 1765) && (MouseX < 1855) && (MouseY >= 25) && (MouseY < 115) && Player.CanChange()) CharacterAppearanceLoadCharacter(Player);
-	if ((MouseX >= 1885) && (MouseX < 1975) && (MouseY >= 25) && (MouseY < 115)) window.location = window.location;
+	if ((MouseX >= 1885) && (MouseX < 1975) && (MouseY >= 25) && (MouseY < 115)) {
+		if (window.confirm(TextGet("ExitConfirm"))) {
+			window.location = window.location;
+		}
+	}
 	if ((MouseX >= 1645) && (MouseX < 1735) && (MouseY >= 145) && (MouseY < 235)) ChatRoomStart("", "", "MainHall", "IntroductionDark", BackgroundsTagList);
 
 	// The options below are only available if the player can move

--- a/BondageClub/Screens/Room/MainHall/Text_MainHall.csv
+++ b/BondageClub/Screens/Room/MainHall/Text_MainHall.csv
@@ -21,6 +21,7 @@ College,Visit the College
 LARPBattle,LARP Battles
 MovieStudio,Movie Studio
 Exit,Leave the Club
+ExitConfirm,Do you want to leave the club?
 SarahBedroom,Sarah's Bedroom
 Gambling,Gambling by git4nick
 Prison,Prison by git4nick


### PR DESCRIPTION
It's been requested a few times to make it harder to hit the Main Hall's exit button and accidentally log out. Now it shows a popup to confirm the exit and give a chance to cancel.