### PR TITLE
Fix for crash if character with invalid effect enters the chat room

### DIFF
--- a/BondageClub/Scripts/Server.js
+++ b/BondageClub/Scripts/Server.js
@@ -281,7 +281,7 @@ function ServerValidateProperties(C, Item, Validation) {
 	}
 
 	// For each effect on the item
-	if ((Item.Property != null) && (Item.Property.Effect != null) && Array.isArray(Item.Property.Effect) == true) {
+	if ((Item.Property != null) && Array.isArray(Item.Property.Effect)) {
 		for (let E = Item.Property.Effect.length - 1; E >= 0; E--) {
 
 			// Make sure the item or its subtype can be locked, remove any lock that's invalid

--- a/BondageClub/Scripts/Server.js
+++ b/BondageClub/Scripts/Server.js
@@ -281,7 +281,7 @@ function ServerValidateProperties(C, Item, Validation) {
 	}
 
 	// For each effect on the item
-	if ((Item.Property != null) && (Item.Property.Effect != null)) {
+	if ((Item.Property != null) && (Item.Property.Effect != null) && Array.isArray(Item.Property.Effect) == true) {
 		for (let E = Item.Property.Effect.length - 1; E >= 0; E--) {
 
 			// Make sure the item or its subtype can be locked, remove any lock that's invalid


### PR DESCRIPTION
This adds an additional check to `ServerValidateProperties` to check if Item.Property.Effect is an array.

This missing check actually was abused by a player to purposefully crash other player's clients.
This very same bug could be abused to enter chat rooms invisible under other circumstances