### PR TITLE
Collar no longer needed for futuristic items to be locked out

### DIFF
--- a/BondageClub/Screens/Inventory/ItemMouth/FuturisticPanelGag/FuturisticPanelGag.js
+++ b/BondageClub/Screens/Inventory/ItemMouth/FuturisticPanelGag/FuturisticPanelGag.js
@@ -281,7 +281,7 @@ function InventoryItemMouthFuturisticPanelGagValidate(C, Option) {
 
 	if (DialogFocusItem && DialogFocusItem.Property && DialogFocusItem.Property.LockedBy && !DialogCanUnlock(C, DialogFocusItem)) {
 		var collar = InventoryGet(C, "ItemNeck")
-		if (collar && (!collar.Property || collar.Property.OpenPermission != true)) {
+		if (!collar || (!collar.Property || collar.Property.OpenPermission != true)) {
 			Allowed = DialogExtendedMessage = DialogFindPlayer("CantChangeWhileLockedFuturistic");
 		}
 	}


### PR DESCRIPTION
Due to a bug, a collar on the wearer was required for futuristic item settings to be locked out if a player cannot unlock it. Now the player is locked out if they don't have a collar either.