### PR TITLE
Revert: "Remove Extra Console Messages"

### DIFF
--- a/BondageClub/Screens/Room/MainHall/MainHall.js
+++ b/BondageClub/Screens/Room/MainHall/MainHall.js
@@ -432,7 +432,6 @@ function MainHallClick() {
  */
 function MainHallOpenChangelog() {
 	window.open("./changelog.html", "_blank");
-	DialogLeave();
 }
 
 /**

--- a/BondageClub/Scripts/GLDraw.js
+++ b/BondageClub/Scripts/GLDraw.js
@@ -42,7 +42,7 @@ function GLDrawLoad() {
         console.log("WebGL: Context restored.");
     }, false);
     
-    //console.log("WebGL Drawing enabled: '" + GLVersion + "'");
+    console.log("WebGL Drawing enabled: '" + GLVersion + "'");
 }
 
 /**

--- a/BondageClub/Scripts/Server.js
+++ b/BondageClub/Scripts/Server.js
@@ -75,7 +75,7 @@ function ServerSetConnected(connected, errorMessage) {
  * Callback when receiving a "connect" event on the socket - this will be called on initial connection and on successful reconnects.
  */
 function ServerConnect() {
-	//console.info("Server connection established");
+	console.info("Server connection established");
 	ServerSetConnected(true);
 }
 

--- a/BondageClub/index.html
+++ b/BondageClub/index.html
@@ -340,6 +340,11 @@ window.onload = function() {
 //	CheatImport();
 	ServerURL = "https://bondage-club-server.herokuapp.com/";
 	GameVersion = "R65";
+	if (!GameVersionFormat.test(GameVersion)) {
+		console.warn("GameVersion is not valid!");
+	} else {
+		console.log(`Loading BondageClub version: ${GameVersion}`);
+	}
 	CommonIsMobile = CommonDetectMobile();
 	TranslationLoad();
 	DrawLoad();


### PR DESCRIPTION
This reverts commit 9f856b9bf5f742a6979cf1efe7dd44c0bd2e92c2.

Reasoning:
First of all the console messages don't have any negative effect at all.
Quite the contrary, they are very helpful whenever someone sends console screenshot:
- The "Loading BondageClub version: ..." message immediately tells us or the player if they are on latest beta/release
- "Server connection established" is helpful to see where connection to server was restored, useful when working around problems connected with connections
- "WebGL Drawing enabled: GLVersion " is REALLY important when working out any drawing problems, because it tells if the browser is using legacy drawing method or which GL version it uses, making it way easier to replicate problems

Also there is a reason opening changelog didn't exit the maid:
In my experience changing screen at the same time new window opens is bad for user, as it can easily make them disoriented, when they don't see the change happen