### PR TITLE
Asset description line break fix

### DIFF
--- a/BondageClub/Scripts/Asset.js
+++ b/BondageClub/Scripts/Asset.js
@@ -330,7 +330,7 @@ function AssetBuildDescription(Family, CSV) {
 			if (map.has(`${line[0]}:${line[1]}`)) {
 				console.warn("Duplicate Asset Description: ", line);
 			}
-			map.set(`${line[0]}:${line[1]}`, line[2]);
+			map.set(`${line[0]}:${line[1]}`, line[2].trim());
 		} else {
 			console.warn("Bad Asset Description line: ", line);
 		}


### PR DESCRIPTION
Correcting the buiding of the asset description list, since it included line breaks resulting in chat messages like this:
> (Player uses a ball gag
 on her mouth
.)