### PR TITLE
Fix lockpicking impossible for locks placed in scripted rooms

### DIFF
--- a/BondageClub/Scripts/Struggle.js
+++ b/BondageClub/Scripts/Struggle.js
@@ -1072,7 +1072,7 @@ function StruggleLockPickProgressStart(C, Item) {
 	var LockPickingImpossible = false
 	if (Item != null && lock) {
 		// Gets the lock rating
-		var BondageLevel = Math.min(10, Item.Difficulty - Item.Asset.Difficulty)
+		var BondageLevel = Item.Difficulty - Item.Asset.Difficulty
 		
 		// Gets the required skill / challenge level based on player/rigger skill and item difficulty (0 by default is easy to pick)
 		var S = 0;
@@ -1206,7 +1206,7 @@ function StruggleLockPickProgressStart(C, Item) {
 				// negative skill of 6 subtracts 12 from all locks
 	
 
-		StruggleLockPickProgressMaxTries = NumTries - NumPins;
+		StruggleLockPickProgressMaxTries = Math.max(1, NumTries - NumPins);
 	}
 }
 

--- a/BondageClub/Scripts/Struggle.js
+++ b/BondageClub/Scripts/Struggle.js
@@ -1072,7 +1072,7 @@ function StruggleLockPickProgressStart(C, Item) {
 	var LockPickingImpossible = false
 	if (Item != null && lock) {
 		// Gets the lock rating
-		var BondageLevel = (Item.Difficulty - Item.Asset.Difficulty)
+		var BondageLevel = Math.min(10, Item.Difficulty - Item.Asset.Difficulty)
 		
 		// Gets the required skill / challenge level based on player/rigger skill and item difficulty (0 by default is easy to pick)
 		var S = 0;


### PR DESCRIPTION
Some people have been making scripted rooms with very high bondage levels on applied stuff. This is making players stuck, so I am adding a cap for the difficulty in lockpicking so it can't be set to something ridiculous like 100.