### PR TITLE
Removes the struggle options when not restrained and the item is unlock

### DIFF
--- a/BondageClub/Scripts/Struggle.js
+++ b/BondageClub/Scripts/Struggle.js
@@ -151,7 +151,7 @@ function StruggleProgressStart(C, PrevItem, NextItem) {
 	StruggleProgress = 0;
 	DialogMenuButtonBuild(C);
 		
-	if (C != Player || PrevItem == null || (-StruggleStrengthGetDifficulty(C, PrevItem, NextItem).difficulty < 2 && StruggleStrengthGetDifficulty(C, PrevItem, NextItem).auto > 0)) {
+	if (C != Player || PrevItem == null || (Player.CanInteract() && (PrevItem != null) && (!InventoryItemHasEffect(PrevItem, "Lock", true) || DialogCanUnlock(C, PrevItem)) && !InventoryItemHasEffect(PrevItem, "Mounted", true))) {
 		StruggleProgressCurrentMinigame = "Strength"
 		StruggleStrengthStart(C, StruggleProgressChoosePrevItem, StruggleProgressChooseNextItem);
 	}


### PR DESCRIPTION
This should solve issues of things like handheld toys bringing up the minigame choices.