### PR TITLE
Fix having struggle options for things like the bed

### DIFF
--- a/BondageClub/Scripts/Struggle.js
+++ b/BondageClub/Scripts/Struggle.js
@@ -151,7 +151,8 @@ function StruggleProgressStart(C, PrevItem, NextItem) {
 	StruggleProgress = 0;
 	DialogMenuButtonBuild(C);
 		
-	if (C != Player || PrevItem == null || (Player.CanInteract() && (PrevItem != null) && (!InventoryItemHasEffect(PrevItem, "Lock", true) || DialogCanUnlock(C, PrevItem)) && !InventoryItemHasEffect(PrevItem, "Mounted", true))) {
+	if (C != Player || PrevItem == null ||
+		((PrevItem != null) && (!InventoryItemHasEffect(PrevItem, "Lock", true) || DialogCanUnlock(C, PrevItem)) && ((Player.CanInteract() && !InventoryItemHasEffect(PrevItem, "Mounted", true)) || StruggleStrengthGetDifficulty(C, PrevItem, NextItem).auto >= 0))) {
 		StruggleProgressCurrentMinigame = "Strength"
 		StruggleStrengthStart(C, StruggleProgressChoosePrevItem, StruggleProgressChooseNextItem);
 	}


### PR DESCRIPTION
Anytime when DialogProgressAuto >= 0, it will use the strength minigame to save time from picking a struggle option.