### PR TITLE
Character in Previews - Performance Improvement

### DIFF
--- a/BondageClub/Screens/Character/Appearance/Appearance.js
+++ b/BondageClub/Screens/Character/Appearance/Appearance.js
@@ -733,17 +733,20 @@ function AppearanceMenuDraw() {
 /**
  * Create a list of characters with different items from the group applied, to use as the preview images
  * @param {Character} C - The character that the dialog inventory has been loaded for
+ * @param {boolean} buildCanvases - Determines whether the preview canvases need to be (re)built, e.g. for the initial load or due to an appearance change
  * @returns {void} - Nothing
  */
-function AppearancePreviewBuild(C) {
+function AppearancePreviewBuild(C, buildCanvases) {
+	AppearancePreviews = [];
 	if (C.FocusGroup && C.FocusGroup.PreviewZone && DialogInventory) {
-		AppearancePreviews = [];
-		const baseAppearance = C.Appearance.filter(A => A.Asset.Group.Category === "Appearance");
+		const baseAppearance = buildCanvases ? C.Appearance.filter(A => A.Asset.Group.Category === "Appearance") : null;
 		DialogInventory.forEach(item => {
 			let PreviewChar = CharacterLoadSimple("AppearancePreview-" + item.Asset.Name);
-			PreviewChar.Appearance = Array.from(baseAppearance);
-			CharacterAppearanceSetItem(PreviewChar, item.Asset.Group.Name, item.Asset, null, null, null, false);
-			CharacterLoadCanvas(PreviewChar);
+			if (buildCanvases) {
+				PreviewChar.Appearance = Array.from(baseAppearance);
+				CharacterAppearanceSetItem(PreviewChar, item.Asset.Group.Name, item.Asset, null, null, null, false);
+				CharacterLoadCanvas(PreviewChar);
+			}
 			AppearancePreviews.push(PreviewChar);
 		});
 	}
@@ -960,7 +963,7 @@ function AppearanceClick() {
 							else {
 								// Open the clothing group screen
 								C.FocusGroup = AssetGroup[A];
-								DialogInventoryBuild(C);
+								DialogInventoryBuild(C, null, true);
 								CharacterAppearanceCloth = InventoryGet(C, C.FocusGroup.Name);
 								CharacterAppearanceMode = "Cloth";
 								return;
@@ -1201,6 +1204,7 @@ function CharacterAppearanceExit(C) {
 	CharacterAppearanceReturnRoom = "MainHall";
 	CharacterAppearanceReturnModule = "Room";
 	CharacterAppearanceHeaderText = "";
+	AppearancePreviewCleanup();
 }
 
 /**
@@ -1340,7 +1344,7 @@ function AppearanceItemColor(C, Item, AssetGroup, CurrentMode) {
 		if (C.FocusGroup && C.FocusGroup.PreviewZone) {
 			const item = InventoryGet(C, C.FocusGroup.Name);
 			if (CharacterAppearanceColorPickerBackup !== item.Color) {
-				AppearancePreviewBuild(C);
+				AppearancePreviewBuild(C, true);
 			}
 		}
 	});

--- a/BondageClub/Scripts/Dialog.js
+++ b/BondageClub/Scripts/Dialog.js
@@ -711,13 +711,16 @@ function DialogInventorySort() {
  * the player's inventory and the character's inventory for that group
  * @param {Character} C - The character whose inventory must be built
  * @param {number} [Offset] - The offset to be at, if specified.
+ * @param {boolean} [redrawPreviews=false] - If TRUE and if building a list of preview character images, redraw the canvases
  * @returns {void} - Nothing
  */
-function DialogInventoryBuild(C, Offset) {
+function DialogInventoryBuild(C, Offset, redrawPreviews = false) {
 
 	// Make sure there's a focused group
 	DialogInventoryOffset = Offset;
 	if (DialogInventoryOffset == null) DialogInventoryOffset = 0;
+
+	const DialogInventoryBefore = DialogInventoryStringified(C);
 	DialogInventory = [];
 	if (C.FocusGroup != null) {
 
@@ -774,11 +777,24 @@ function DialogInventoryBuild(C, Offset) {
 			}
 		}
 
-		// Rebuilds the dialog menu, its buttons and the preview icons if required
+		// Rebuilds the dialog menu and its buttons
 		DialogInventorySort();
 		DialogMenuButtonBuild(C);
-		AppearancePreviewBuild(C);
+
+		// Build the list of preview images
+		const DialogInventoryAfter = DialogInventoryStringified(C);
+		const redraw = redrawPreviews || (DialogInventoryBefore !== DialogInventoryAfter);
+		AppearancePreviewBuild(C, redraw);
 	}
+}
+
+/**
+ * Create a stringified list of the group and the assets currently in the dialog inventory
+ * @param {Character} C - The character the dialog inventory has been built for
+ * @returns {string} - The list of assets as a string
+ */
+function DialogInventoryStringified(C) {
+	return (C.FocusGroup ? C.FocusGroup.Name : "") + (DialogInventory ? JSON.stringify(DialogInventory.map(I => I.Asset.Name).sort()) : "");
 }
 
 /**


### PR DESCRIPTION
A followup change for #2185: the preview character canvases will only be rebuilt when necessary. For example they won't be when selecting one of the items, since that just shuffles the inventory order.