### PR TITLE
larp typo fix

### DIFF
--- a/BondageClub/Screens/Online/Game/OnlineGameDictionary.csv
+++ b/BondageClub/Screens/Online/Game/OnlineGameDictionary.csv
@@ -41,7 +41,7 @@ LARPOptionChargeSuccess,"SourceName (SourceNumber) charges with her team, giving
 LARPOptionControl,Control (OptionOdds %)
 LARPOptionControlSuccess,"SourceName (SourceNumber) controls the room, preventing everyone from using special abilities for a full cycle."
 LARPOptionDetain,Detain (OptionOdds %)
-LARPOptionDetainSuccess,SourceName (SourceNumber) detrains TargetName (TargetNumber) and restrains her arms using: ItemDesc.
+LARPOptionDetainSuccess,SourceName (SourceNumber) detains TargetName (TargetNumber) and restrains her arms using: ItemDesc.
 LARPOptionExpose,Expose (OptionOdds %)
 LARPOptionExposeSuccess,SourceName (SourceNumber) exposes TargetName (TargetNumber) and removes her clothes.
 LARPOptionInspire,Inspire (OptionOdds %)


### PR DESCRIPTION
Matron will no longer detrain her target. She will detain her instead as she should.