### PR TITLE
Online Dialog overflow fix

### DIFF
--- a/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
+++ b/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
@@ -263,12 +263,10 @@ function ChatRoomCanAssistStruggle() { return CurrentCharacter.AllowItem && !Cur
  * Checks if the character options menu is available.
  * @returns {boolean} - Whether or not the player can interact with the target character
  */
-function ChatRoomCanPerformCharacterAction() { return ChatRoomCanAssistStand() || ChatRoomCanAssistKneel() || ChatRoomCanAssistStruggle() || ChatRoomCanHoldLeash() || ChatRoomCanStopHoldLeash()}
-/**
- * Checks if the security options menu is available.
- * @returns {boolean} - Whether or not the player can interact with the target character
- */
-function ChatRoomCanPerformSecurityAction() { return ChatRoomCanGiveLockpicks() || ChatRoomCanGiveHighSecurityKeys() || ChatRoomCanGiveHighSecurityKeysAll()}
+function ChatRoomCanPerformCharacterAction() {
+	return ChatRoomCanAssistStand() || ChatRoomCanAssistKneel() || ChatRoomCanAssistStruggle() || ChatRoomCanHoldLeash() || ChatRoomCanStopHoldLeash()
+		|| ChatRoomCanTakePhotos() || ChatRoomCanGiveLockpicks() || ChatRoomCanGiveHighSecurityKeys() || ChatRoomCanGiveHighSecurityKeysAll();
+}
 /**
  * Checks if the target character can be helped back on her feet. This is different than CurrentCharacter.CanKneel() because it listens for the current active pose and removes certain checks that are not required for someone else to help a person kneel down.
  * @returns {boolean} - Whether or not the target character can stand

--- a/BondageClub/Screens/Online/ChatRoom/Dialog_Online.csv
+++ b/BondageClub/Screens/Online/ChatRoom/Dialog_Online.csv
@@ -8,9 +8,7 @@ PlayerGagged,,,(You don't have access to use or remove items on her.),,!DialogDo
 0,20,(Check her drink tray.),(There's a variety of drinks.  Some are offered by the club and some are more expensive.),,CanTakeDrink()
 0,30,(Room administrator action.),"(As a room administrator, you can take these actions with her.)",,PlayerIsAdmin()
 0,40,(Character actions.),(Possible character actions.),,CanPerformCharacterAction()
-0,41,(Security actions.),(Possible security actions.),,CanPerformSecurityAction()
 0,,(Stop her from leaving.),,StopLeave(),CanStopSlowPlayer()
-0,,(Have a photo taken.),,PhotoCurrentCharacters(),ChatRoomCanTakePhotos()
 0,,(Leave this menu.),,DialogLeave(),
 10,,(Add to item whitelist.),(This member is now on your item permission whitelist.  She will have higher access to restrain or free you.),"ListManage(""Add"", ""WhiteList"")",CanAddWhiteList()
 10,,(Remove from item whitelist.),(This member is no longer on your item permission whitelist.),"ListManage(""Remove"", ""WhiteList"")",CanRemoveWhiteList()
@@ -76,16 +74,16 @@ PlayerGagged,,,(You don't have access to use or remove items on her.),,!DialogDo
 30,0,(Promote her as room administrator.),,"AdminAction(""Promote"")",!CurrentCharacterIsAdmin()
 30,0,(Demote her from room administration.),,"AdminAction(""Demote"")",CurrentCharacterIsAdmin()
 30,0,(Back to main menu.),(Main menu.),,
-41,0,(Lend her some lockpicks.),(You give her some lockpicks to struggle out with until she leaves the room),GiveLockpicks(),CanGiveLockpicks()
-41,0,(Give her a spare key to your locks.),(You give her an extra key to your private padlocks),GiveHighSecurityKeys(),CanGiveHighSecurityKeys()
-41,0,(Hand over the keys to your locks.),(You give her the keys to your private padlocks),GiveHighSecurityKeysAll(),CanGiveHighSecurityKeysAll()
-41,0,(Back to main menu.),(Main menu.),,
 40,,,(Possible character actions.),,
 40,,(Hold on to her leash.),,HoldLeash(),CanHoldLeash()
 40,,(Let go of her leash.),,StopHoldLeash(),CanStopHoldLeash()
 40,0,(Help her stand.),(You help her up on her feet.),KneelStandAssist(),CanAssistStand()
 40,0,(Help her kneel.),(You help her down on her knees.),KneelStandAssist(),CanAssistKneel()
 40,0,(Help her to struggle free.),,StruggleAssist(),CanAssistStruggle()
+40,,(Have a photo taken.),,PhotoCurrentCharacters(),ChatRoomCanTakePhotos()
+40,0,(Lend her some lockpicks.),(You give her some lockpicks to struggle out with until she leaves the room),GiveLockpicks(),CanGiveLockpicks()
+40,0,(Give her a spare key to your locks.),(You give her an extra key to your private padlocks),GiveHighSecurityKeys(),CanGiveHighSecurityKeys()
+40,0,(Hand over the keys to your locks.),(You give her the keys to your private padlocks),GiveHighSecurityKeysAll(),CanGiveHighSecurityKeysAll()
 40,0,(Back to main menu.),(Main menu.),,
 100,110,(Wardrobe access.),(Select her wardrobe access.),,
 100,120,(Whisper rules.),(Select her rules for whispering when you're in the same room.),,


### PR DESCRIPTION
In the last release, the "(Security actions.)" and "(Have a photo taken.)" dialog options for other online players were both added. Both have the potential to push the displayed options over the limit of 8 and make the "(Leave this menu.)" option disappear.
Now both have been moved inside the "(Character actions.)" option's page.