### PR TITLE
Pole Message Fix

### DIFF
--- a/BondageClub/Screens/Character/Player/Dialog_Player.csv
+++ b/BondageClub/Screens/Character/Player/Dialog_Player.csv
@@ -1888,8 +1888,8 @@ ItemArmsTransportJacketSetShortsShortsAndStraps,,,SourceCharacter reinforces Des
 SelectPoleType,,,Select Pole state,,
 PoleTypeUntied,,,Untie from pole,,
 PoleTypeTied,,,Tie to pole,,
-DevicesPoleSetUntied,,,SourceCharacter ties TargetCharacter to the pole.,,
-DevicesPoleSetTied,,,SourceCharacter unties TargetCharacter from the pole.,,
+DevicesPoleSetUntied,,,SourceCharacter unties TargetCharacter from the pole.,,
+DevicesPoleSetTied,,,SourceCharacter ties TargetCharacter to the pole.,,
 SelectEyePatchType,,,Select an eyepatch style.
 EyePatchTypeLeft,,,Left,,
 EyePatchTypeRight,,,Right,,


### PR DESCRIPTION
The text of the two action chat messages for selecting a pole option were set the wrong way around.