### PR TITLE
Bugfix: Incorrect variable reference in collar auto shock unit

### DIFF
--- a/BondageClub/Screens/Inventory/ItemNeckAccessories/CollarAutoShockUnit/CollarAutoShockUnit.js
+++ b/BondageClub/Screens/Inventory/ItemNeckAccessories/CollarAutoShockUnit/CollarAutoShockUnit.js
@@ -126,7 +126,7 @@ function InventoryItemNeckAccessoriesCollarAutoShockUnitUpdate(data) {
 			&& !ChatRoomLastMessage[ChatRoomLastMessage.length-1].startsWith("(") && !ChatRoomLastMessage[ChatRoomLastMessage.length-1].startsWith("*") && ChatRoomLastMessage[ChatRoomLastMessage.length-1].replace(/[A-Za-z]+/g, '') != ChatRoomLastMessage[ChatRoomLastMessage.length-1]
 			 && (!ChatRoomLastMessage[ChatRoomLastMessage.length-1].startsWith("/")
 			|| (keywords && (ChatRoomLastMessage[ChatRoomLastMessage.length-1].startsWith("/me") || ChatRoomLastMessage[ChatRoomLastMessage.length-1].startsWith("*")))))))
-			GagTriggerPunish = true
+			ShockTriggerPunish = true;
 		if (Item.Property.Sensitivity == 2 && ChatRoomLastMessage && ChatRoomLastMessage.length != LastMessages
 			&& !ChatRoomLastMessage[ChatRoomLastMessage.length-1].startsWith("(") && !ChatRoomLastMessage[ChatRoomLastMessage.length-1].startsWith("*") && !ChatRoomLastMessage[ChatRoomLastMessage.length-1].startsWith("/")
 			&& (ChatRoomLastMessage[ChatRoomLastMessage.length-1].length > 25


### PR DESCRIPTION
## Summary

This fixes an incorrect reference in the collar auto shock unit where it was referencing `GagTriggerPunish` rather than `ShockTriggerPunish`, causing errors as below:

![image](https://user-images.githubusercontent.com/62729616/110834035-f8732b00-8294-11eb-840f-0bca516bc598.png)