### PR TITLE
Notification Fixes

### DIFF
--- a/BondageClub/Screens/Character/Creation/Creation.js
+++ b/BondageClub/Screens/Character/Creation/Creation.js
@@ -99,9 +99,10 @@ function CreationResponse(data) {
 			Log = [];
 			ImportBondageCollege(Player);
 
-			// Calls the preference init to make sure the preferences are loaded correctly
+			// Load/initialise player settings and global variables
 			PreferenceInitPlayer();
 			ActivitySetArousal(Player, 0);
+			NotificationLoad();
 
 			// Flush the controls and enters the main hall
 			ServerPlayerAppearanceSync();

--- a/BondageClub/Screens/Character/FriendList/FriendList.js
+++ b/BondageClub/Screens/Character/FriendList/FriendList.js
@@ -261,7 +261,7 @@ function FriendListLoadFriendList(data) {
 			}
 			FriendListContent += "</div>";
 		}
-		NotificationReset(NotificationEventType.BEEP);
+		if (document.hasFocus()) NotificationReset(NotificationEventType.BEEP);
 	} else if (mode === "Delete") {
 		// In Delete mode, we show the friend list and allow the user to remove them
 		for (const [k, v] of Array.from(Player.FriendNames).sort((a, b) => a[1].localeCompare(b[1]))) {

--- a/BondageClub/Screens/Character/Relog/Relog.js
+++ b/BondageClub/Screens/Character/Relog/Relog.js
@@ -58,7 +58,7 @@ function RelogRun() {
 	DrawButton(1025, 750, 300, 60, TextGet("GiveUp"), "White", "");
 
 	// Reset any disconnect notifications
-	NotificationReset(NotificationEventType.DISCONNECT);
+	if (document.hasFocus()) NotificationReset(NotificationEventType.DISCONNECT);
 }
 
 /**

--- a/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
+++ b/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
@@ -2843,7 +2843,7 @@ function ChatRoomNotificationReset() {
 	if (CurrentScreen !== "ChatRoom" || ChatRoomNotificationNewMessageVisible()) {
 		NotificationReset(NotificationEventType.CHATMESSAGE);
 	}
-	NotificationReset(NotificationEventType.CHATJOIN);
+	if (document.hasFocus()) NotificationReset(NotificationEventType.CHATJOIN);
 }
 
 /**

--- a/BondageClub/Screens/Online/GameLARP/GameLARP.js
+++ b/BondageClub/Screens/Online/GameLARP/GameLARP.js
@@ -183,7 +183,7 @@ function GameLARPRunProcess() {
 	}
 
 	// Reset any notification that may have been raised
-	NotificationReset(NotificationEventType.LARP);
+	if (document.hasFocus()) NotificationReset(NotificationEventType.LARP);
 }
 
 /**

--- a/BondageClub/Scripts/Notification.js
+++ b/BondageClub/Scripts/Notification.js
@@ -178,7 +178,9 @@ function NotificationLoad() {
  * @returns {void} - Nothing
  */
 function NotificationRaise(eventType, data = {}) {
-	NotificationEvents[eventType].raise(data);
+	if (NotificationEvents) {
+		NotificationEvents[eventType].raise(data);
+	}
 }
 
 /**
@@ -187,7 +189,9 @@ function NotificationRaise(eventType, data = {}) {
  * @returns {void} - Nothing
  */
 function NotificationReset(eventType) {
-	NotificationEvents[eventType].reset(true);
+	if (NotificationEvents) {
+		NotificationEvents[eventType].reset(true);
+	}
 }
 
 /**


### PR DESCRIPTION
Some notifications were resetting and disappearing too quickly, before the user even refocused back on the game. 
This is because I assumed those functions that called the reset step only ran while the screen was active, but this is not true for all browsers.

Notifications broke after creating a new character rather than logging in. They will now be loaded properly. Also added safety checks to the raise/reset.