### PR TITLE
Futuristic collar permissions fix

### DIFF
--- a/BondageClub/Screens/Character/Player/Dialog_Player.csv
+++ b/BondageClub/Screens/Character/Player/Dialog_Player.csv
@@ -848,6 +848,7 @@ FuturisticCollarSetOpenPermissionOff,,,DestinationCharacterName bindings now can
 FuturisticCollarBlockRemotes,,,Block remotes on the wearer,,
 FuturisticCollarSetBlockRemotesOn,,,DestinationCharacterName vibrator remotes are now locked.,,
 FuturisticCollarSetBlockRemotesOff,,,DestinationCharacterName vibrator remotes are now unlocked.,,
+FuturisticCollarOptionsLockout,,,Collar settings are locked,,
 FuturisticCollarOptions,,,Current Status:,,
 FuturisticCollarOptionsNoLocks,,,Unlocked,,
 FuturisticCollarOptionsPartialLocks,,,Partially Locked,,

--- a/BondageClub/Screens/Inventory/ItemNeck/FuturisticCollar/FuturisticCollar.js
+++ b/BondageClub/Screens/Inventory/ItemNeck/FuturisticCollar/FuturisticCollar.js
@@ -21,7 +21,11 @@ function InventoryItemNeckFuturisticCollarDraw() {
 	if (InventoryItemMouthFuturisticPanelGagValidate(C) !== "") {
 		InventoryItemMouthFuturisticPanelGagDrawAccessDenied()
 	} else {
-		DrawAssetPreview(1387, 75, DialogFocusItem.Asset);
+		DrawAssetPreview(1387, 65, DialogFocusItem.Asset);
+		
+		if ((DialogFocusItem && DialogFocusItem.Property && DialogFocusItem.Property.LockedBy && !DialogCanUnlock(C, DialogFocusItem))) {
+			DrawText(DialogFindPlayer("FuturisticCollarOptionsLockout"), 1500, 375, "White", "Gray");
+		}
 
 		DrawButton(1125, 395, 64, 64, "", "White", DialogFocusItem.Property.OpenPermission ? "Icons/Checked.png" : "");
 		DrawText(DialogFindPlayer("FuturisticCollarOpenPermission"), 1550, 425, "White", "Gray");
@@ -82,7 +86,7 @@ function InventoryItemNeckFuturisticCollarClick() {
 		
 		if ((MouseX >= 1885) && (MouseX <= 1975) && (MouseY >= 25) && (MouseY <= 110)) InventoryItemNeckFuturisticCollarExit();
 		else if (MouseIn(1125, 395, 64, 64) && !(DialogFocusItem && DialogFocusItem.Property && DialogFocusItem.Property.LockedBy && !DialogCanUnlock(C, DialogFocusItem))) InventoryItemNeckFuturisticCollarTogglePermission(C, DialogFocusItem);
-		else if (MouseIn(1125, 465, 64, 64)) InventoryItemNeckFuturisticCollarToggleRemotes(C, DialogFocusItem);
+		else if (MouseIn(1125, 465, 64, 64) && !(DialogFocusItem && DialogFocusItem.Property && DialogFocusItem.Property.LockedBy && !DialogCanUnlock(C, DialogFocusItem))) InventoryItemNeckFuturisticCollarToggleRemotes(C, DialogFocusItem);
 		else {
 		
 			var FuturisticCollarItems = InventoryItemNeckFuturisticCollarGetItems(C)


### PR DESCRIPTION
Fixes the remote blocking being changeable on the futuristic collar when locked out, even if the open permissions setting is blocked.

Also adds a text message to make it clear to the user that they can't change the setting because the collar is locked.