### PR TITLE
Suspension Kneel Fix

### DIFF
--- a/BondageClub/Screens/Inventory/ItemFeet/Chains/Chains.js
+++ b/BondageClub/Screens/Inventory/ItemFeet/Chains/Chains.js
@@ -18,6 +18,7 @@ var InventoryItemFeetChainsOptions = [
 			Type: "Suspension",
 			Difficulty: 4,
 			SetPose: ["Suspension", "LegsClosed"],
+			AllowActivePose: [],
 		},
 	},
 ];

--- a/BondageClub/Screens/Inventory/ItemFeet/HempRope/HempRope.js
+++ b/BondageClub/Screens/Inventory/ItemFeet/HempRope/HempRope.js
@@ -23,7 +23,7 @@ const HempRopeFeetOptions = [
 	}, {
 		Name: "Suspension",
 		BondageLevel: 6,
-		Property: { Type: "Suspension", SetPose: ["LegsClosed", "Suspension"], Difficulty: 6 },
+		Property: { Type: "Suspension", SetPose: ["LegsClosed", "Suspension"], AllowActivePose: [], Difficulty: 6 },
 		Expression: [{ Group: "Blush", Name: "High", Timer: 30 }],
 		Prerequisite: ["NotKneeling", "NotMounted", "NotChained", "NotHogtied"]
 	}, {


### PR DESCRIPTION
When suspended by the feet, the kneel button is available which can result in kneeling in mid-air.
This adds empty `AllowActivePose` to the options so that they override the assets' `AllowActivePose: ["Kneel"]` and prevents kneeling.