### PR TITLE
Chess Progress Change

### DIFF
--- a/BondageClub/Screens/MiniGame/Chess/BondageChess.js
+++ b/BondageClub/Screens/MiniGame/Chess/BondageChess.js
@@ -26,9 +26,6 @@ function ChessLoad() {
  */
 function ChessRun() {
 
-	// Applies restraints or strip if there are special rules
-	CollegeChessGameProgress();
-
 	// Draw the characters
 	DrawCharacter(ChessCharacterLeft, 0, 0, 1);
 	DrawCharacter(ChessCharacterRight, 1500, 0, 1);

--- a/BondageClub/Screens/MiniGame/Chess/chess.js
+++ b/BondageClub/Screens/MiniGame/Chess/chess.js
@@ -17,6 +17,7 @@ var MiniGameChessGame = null;
 function MiniGameChessStart(Depth) {
 	const MinMaxDepth = Depth;
 	const PauseDepth = 2;
+	const chessOnMoveEvent = new Event('chessOnMove');
 
 	/**
 	 * Evaluates current chess board relative to player
@@ -134,6 +135,9 @@ function MiniGameChessStart(Depth) {
 		game.move(move);
 		// Update board positions
 		board.position(game.fen());
+
+		// Announce a move was made
+		document.dispatchEvent(chessOnMoveEvent);
 	}
 
 	// Handles what to do after human makes move.
@@ -151,6 +155,9 @@ function MiniGameChessStart(Depth) {
 
 		// Log the move
 		//console.log(move)
+
+		// Announce a move was made
+		document.dispatchEvent(chessOnMoveEvent);
 
 		// make move for black
 		window.setTimeout(function () {

--- a/BondageClub/Screens/Room/CollegeChess/CollegeChess.js
+++ b/BondageClub/Screens/Room/CollegeChess/CollegeChess.js
@@ -59,6 +59,7 @@ function CollegeChessGameStart(Difficulty, Bet) {
 	ChessCharacterLeft = Player;
 	ChessCharacterRight = CollegeChessOpponent;
 	MiniGameStart("Chess", CollegeChessDifficulty, "CollegeChessGameEnd");
+	document.addEventListener("chessOnMove", CollegeChessGameProgress);
 }
 
 /**
@@ -93,7 +94,7 @@ function CollegeChessRestrain(C) {
  */
 function CollegeChessGameProgress() {
 	if ((CollegeChessBet != "Strip") && (CollegeChessBet != "Bondage")) return;
-	if (MiniGameEnded || (MiniGameChessGame.board() == null)) return;
+	if (MiniGameChessGame.board() == null) return;
 	if (MiniGameChessGame.in_checkmate() && (MiniGameChessGame.turn() == "b") && (CollegeChessBet == "Strip")) return CharacterNaked(ChessCharacterRight);
 	if (MiniGameChessGame.in_checkmate() && (MiniGameChessGame.turn() == "w") && (CollegeChessBet == "Strip")) return CharacterNaked(ChessCharacterLeft);
 	if (MiniGameChessGame.in_checkmate() && (MiniGameChessGame.turn() == "b") && (CollegeChessBet == "Bondage")) return InventoryWearRandom(ChessCharacterRight, "ItemArms", 5);
@@ -144,6 +145,7 @@ function CollegeChessGameEnd() {
 	CollegeChessOpponent.Stage = "Result" + ChessEndStatus + CollegeChessBet;
 	CollegeChessOpponent.CurrentDialog = DialogFind(CollegeChessOpponent, "Intro" + ChessEndStatus + CollegeChessBet);
 	CharacterSetCurrent(CollegeChessOpponent);
+	document.removeEventListener("chessOnMove", CollegeChessGameProgress);
 }
 
 /**


### PR DESCRIPTION
The process to calculate the total major and minor values on both sides (`CollegeChessGameProgress`) was running every frame, but it miscalculated and undervalued black's value at some point during their move. This means when their move ended and the value went back up, it thought white lost pieces and punished the player even though no pieces had been taken.
This PR changes this calculation to only occur after a move has completed via an event instead. This avoids unnecessary recalculations and seems to have corrected the miscalculations.