### PR TITLE
Bugfix: Corrects extended item arguments for the eyepatch

### DIFF
--- a/BondageClub/Screens/Inventory/Glasses/EyePatch1/EyePatch1.js
+++ b/BondageClub/Screens/Inventory/Glasses/EyePatch1/EyePatch1.js
@@ -20,10 +20,10 @@ function InventoryGlassesEyePatch1Load() {
 
 // Draw the item extension screen
 function InventoryGlassesEyePatch1Draw() {
-	ExtendedItemDraw(InventoryGlassesEyePatch1Options, "EyePatchType");
+	ExtendedItemDraw(InventoryGlassesEyePatch1Options, "EyePatchType", null, true, true);
 }
 
 // Catches the item extension clicks
 function InventoryGlassesEyePatch1Click() {
-	ExtendedItemClick(InventoryGlassesEyePatch1Options);
+	ExtendedItemClick(InventoryGlassesEyePatch1Options, true);
 }


### PR DESCRIPTION
## Summary

This is somewhat related to #2241 (and also fixes the same issue for the eyepatch, although it makes sense to include both, as they fix slightly different things) - this adds the `IsCloth` argument to the extended item function calls in the eyepatch's extended item script. This ensures that the options are drawn in the correct place, and prevents the game from sending an appearance update every time the player modifies the eyepatch whilst inside their wardrobe.