### PR TITLE
Sell Items in the Shop

### DIFF
--- a/BondageClub/Screens/Room/Shop/Dialog_NPC_Shop_Vendor.csv
+++ b/BondageClub/Screens/Room/Shop/Dialog_NPC_Shop_Vendor.csv
@@ -25,27 +25,18 @@ ItemPelvisLeatherWhip,,,(You whip her butt as she whimpers.)  Oooww.  Are you a 
 ItemPelvisLeatherCrop,,,(You lash the leather crop pretty hard on her butt.)  Damn it!  I need a better job.,,
 0,,,Greetings Mistress DialogPlayerName.  What are you looking for today?,,"DialogLogQuery(""ClubMistress"", ""Management"")"
 0,,,(She looks at you and giggles.)  Are you looking for some clothes?,,Player.IsNaked()
-0,,,Welcome to the Bondage Club store.  What are you looking for today?,,
-0,100,I'm looking for clothes and accessories.,"Of course, what kind of clothes?",,
-0,110,I'm looking for underwear.,"Absolutely, what kind of underwear?",,
-0,120,I'm looking for exotic accessories.,"Absolutely, what kind of accessories?",,
-0,200,I'm looking for kinky items for the head.,Excellent!  For which body part exactly?,,
-0,210,I'm looking for kinky items for the body or arms.,Excellent!  For which body part exactly?,,
-0,220,I'm looking for kinky items for private parts or legs.,Excellent!  For which body part exactly?,,
-0,10,I'd like to ask you some questions.,Don't be shy.  How can I help you?,,
+0,,,Welcome to the Bondage Club store.  How can I help you today?,,
+0,90,I'd like to buy something.,Of course! What are you looking for?,SetBuyMode(),
+0,90,I want to return something I bought.,"Sure! You can sell back anything for half of the original price. What kind of item is it?",SetSellMode(),
+0,,Can you show me everything that I don't have?,,SelectAssetMissing(),
+0,,What are you selling?,"Look around, there are clothes of all kinds and lots of BDSM gear.",,
+0,,Who owns this store?,It belongs to the Bondage Club.  All profits go back to the organization.,,
+0,20,Can I tie you up?,"I'll make a deal with you.  If you buy everything from the store, I'll let you use the items on me.",CheckBoughtEverything(),!VendorAllowItem
 0,,Can you help me out?,I'm not allowed to release you.  But I can help you to shop and pay.  I will be honest.,,!Player.CanInteract()
 0,30,Do you have work for me?,"Sure, I can give you a salary if you're willing to demonstrate the items we are selling.  Are you ready for that?",,Player.CanInteract()
 0,,I need to run.  (Leave her.),,DialogLeave(),
-10,,,You have some questions for me?,,
-10,,What are you selling?,"Look around, there are clothes of all kinds and lots of BDSM gear.",,
-10,,Who owns this store?,It belongs to the Bondage Club.  All profits go back to the organization.,,
-10,,Can you show me everything that I don't have?,,SelectAssetMissing(),
-10,20,Can I tie you up?,"I'll make a deal with you.  If you buy everything from the store, I'll let you use the items on me.",CheckBoughtEverything(),!VendorAllowItem
-10,,Will you restrain me?,Maybe later after my shift.,,
-10,0,I don't have any more questions.,"Alright, would you like to buy something then?",,
-10,,Let's talk later.  (Leave her.),,DialogLeave(),
-20,10,Check my items.  I've bought everything.,No way!  Well a deal is a deal.  You can strap me up if you want.,VendorBondage(),BoughtEverything
-20,10,I'll remember that deal.,Sure!  Do you have more questions for me?,,
+20,0,Check my items.  I've bought everything.,No way!  Well a deal is a deal.  You can strap me up if you want.,VendorBondage(),BoughtEverything
+20,0,I'll remember that deal.,Sure!  Do you have more questions for me?,,
 30,,What's the job?,Selling gears.  Customers wants to know if the items are secure and good looking.  You could demonstrate for them.,,
 30,,How much does it pay?,"I can give you 10% of the selling price, minimum 5$, for each item you help me to sell.  It's a good commission.",,
 30,31,I'm ready!,"Very well, let me find an item to promote.  (She checks on the shelves for an item to use on you.)",,!Player.IsRestrained()
@@ -64,59 +55,75 @@ ItemPelvisLeatherCrop,,,(You lash the leather crop pretty hard on her butt.)  Da
 34,,Can I try again?,  I'm afraid you'll need to get out of those restraints before you can try again,,!JobCanGoAgain()
 34,31,Can I try again?,Alright.  Let me find an item to promote.  (She checks on the shelves for an item to use on you.),,JobCanGoAgain()
 34,,Can you help me out?,"I don't have time, there's too many customers.  Go find a maid if you can't struggle out.",DialogRemove(),!Player.CanInteract()
-100,,Regular clothes or outfits.,,"Start(""Cloth"")",
-100,,Accesories to go with clothes.,,"Start(""ClothAccessory"")",
-100,,Show me your suits.,,"Start(""Suit"")",
-100,,Show me your pants or skirts.,,"Start(""ClothLower"")",
-100,,Hats or head accessories.,,"Start(""Hat"")",
-100,,Do you have glasses?,,"Start(""Glasses"")",
-100,,Do you have masks?,,"Start(""Mask"")",
-100,101,What other types of clothes do you have?,We have all kinds of clothes,,
-100,0,I've changed my mind.,Can I help you with something else?,,
-101,,Do you have any necklaces?,,"Start(""Necklace"")",
-101,,Show me your gloves.,,"Start(""Gloves"")",
-101,,Maybe some shoes.,,"Start(""Shoes"")",
-101,,Do you have any Corsets?,,"Start(""Corset"")",
-101,100,What other types of clothes do you have?,We have all kinds of clothes,,
-101,0,I've changed my mind.,Can I help you with something else?,,
-110,,Can I see your bras?,,"Start(""Bra"")",
-110,,Maybe some panties.,,"Start(""Panties"")",
-110,,Do you sell socks?,,"Start(""Socks"")",
-110,0,I've changed my mind.,Can I help you with something else?,,
-120,,Do you sell outfits or accessories for body?,,"Start(""Wings"")",
-120,,Do you by chance have any tail straps?,,"Start(""TailStraps"")",
-120,,Do you have any hair accessories?,,"Start(""HairAccessory1"")",
-120,,Do you have some special bondage Devices?,,"Start(""ItemDevices"")",
-120,,Do you have addons for special bondage Devices?,,"Start(""ItemAddon"")",
-120,0,I've changed my mind.,Can I help you with something else?,,
-200,,Can I see your blindfolds?,,"Start(""ItemHead"")",
-200,,Do you sell anything to keep the noise down?,,"Start(""ItemEars"")",
-200,,I'm looking for gags.,,"Start(""ItemMouth"")",
-200,,What about collars?,,"Start(""ItemNeck"")",
-200,,Do you have any accessories for collars?,,"Start(""ItemNeckAccessories"")",
-200,,Do you sell any restraints to go on collars?,,"Start(""ItemNeckRestraints"")",
-200,201,What other types of head items do you have?,We have all sorts of items.,,
-201,,Do you have hoods?,,"Start(""ItemHood"")",
-201,,Do you have items for the nose?,,"Start(""ItemNose"")",
-201,,Do you have locks and keys?,,"Start(""ItemMisc"")",
-201,200,What other types of head items do you have?,We have all sorts of items.,,
-200,0,I've changed my mind.,Can I help you with something else?,,
-210,,Show me your arm restraints.,,"Start(""ItemArms"")",
-210,,Show me your hand restraints.,,"Start(""ItemHands"")",
-210,,Something for the breast.,,"Start(""ItemBreast"")",
-210,,Some toys for the nipples.,,"Start(""ItemNipples"")",
-210,,Something to decorate the nipples.,,"Start(""ItemNipplesPiercings"")",
-210,,Any harnesses for the torso?,,"Start(""ItemTorso"")",
-210,,Do you sell chastity belts?,,"Start(""ItemPelvis"")",
-210,0,I've changed my mind.,Can I help you with something else?,,
-220,,Do you sell chastity belts?,,"Start(""ItemPelvis"")",
-220,,Kinky items for the kinky region.,,"Start(""ItemVulva"")",
-220,,I'd like some piercings for down below.,,"Start(""ItemVulvaPiercings"")",
-220,,What can be used on the butt?,,"Start(""ItemButt"")",
-220,,Something to restrain the legs.,,"Start(""ItemLegs"")",
-220,,What do you have for feet?,,"Start(""ItemFeet"")",
-220,,You got any boots?,,"Start(""ItemBoots"")",
-220,0,I've changed my mind.,Can I help you with something else?,,
+90,100,Clothes and accessories.,"What kind of clothes?",,CanShow(Cloth|ClothAccessory|Suit|ClothLower|Hat|Glasses|Mask|Necklace|Gloves|Shoes|Corset)
+90,110,Underwear.,"What kind of underwear?",,CanShow(Bra|Panties|Socks)
+90,120,Exotic accessories.,"What kind of accessories?",,CanShow(Wings|TailStraps|HairAccessory1|ItemDevices|ItemAddon)
+90,200,Something for the head.,For which body part exactly?,,CanShow(ItemHead|ItemEars|ItemMouth|ItemNeck|ItemNeckAccessories|ItemNeckRestraints|ItemHood|ItemNose|ItemMisc)
+90,210,Something for the body or arms.,For which body part exactly?,,CanShow(ItemArms|ItemHands|ItemBreast|ItemNipples|ItemNipplesPiercings|ItemTorso|ItemPelvis)
+90,220,Something for private parts or legs.,For which body part exactly?,,CanShow(ItemPelvis|ItemVulva|ItemVulvaPiercings|ItemButt|ItemLegs|ItemFeet|ItemBoots)
+90,0,I've changed my mind.,Can I help you with anything else?,,
+100,,Regular clothes or outfits.,,Start(Cloth),CanShow(Cloth)
+100,,Accesories to go with clothes.,,Start(ClothAccessory),CanShow(ClothAccessory)
+100,,Suits.,,Start(Suit),CanShow(Suit)
+100,,Pants or skirts.,,Start(ClothLower),CanShow(ClothLower)
+100,,Hats or head accessories.,,Start(Hat),CanShow(Hat)
+100,,Glasses.,,Start(Glasses),CanShow(Glasses)
+100,101,It's another type of clothes.,What kind is it?,,CanShow(Mask|Necklace|Gloves|Shoes|Corset)
+100,90,What else do you have?,We have many items available.,,BuyMode
+100,90,Actually it's something else.,What kind of item is it?,,!BuyMode
+101,,Masks.,,Start(Mask),CanShow(Mask)
+101,,Necklaces.,,Start(Necklace),CanShow(Necklace)
+101,,Gloves.,,Start(Gloves),CanShow(Gloves)
+101,,Shoes.,,Start(Shoes),CanShow(Shoes)
+101,,Corsets.,,Start(Corset),CanShow(Corset)
+101,100,It's another type of clothes.,What kind is it?,,
+101,90,What else do you have?,We have many items available.,,BuyMode
+101,90,Actually it's something else.,What kind of item is it?,,!BuyMode
+110,,Bras.,,Start(Bra),CanShow(Bra)
+110,,Panties.,,Start(Panties),CanShow(Panties)
+110,,Socks.,,Start(Socks),CanShow(Socks)
+110,90,What else do you have?,We have many items available.,,BuyMode
+110,90,Actually it's something else.,What kind of item is it?,,!BuyMode
+120,,Outfits or accessories for the body.,,Start(Wings),CanShow(Wings)
+120,,Tail straps.,,Start(TailStraps),CanShow(TailStraps)
+120,,Hair accessories.,,Start(HairAccessory1),CanShow(HairAccessory1)
+120,,Special bondage devices.,,Start(ItemDevices),CanShow(ItemDevices)
+120,,Addons for special bondage devices.,,Start(ItemAddon),CanShow(ItemAddon)
+120,90,What else do you have?,We have many items available.,,BuyMode
+120,90,Actually it's something else.,What kind of item is it?,,!BuyMode
+200,,Blindfolds.,,Start(ItemHead),CanShow(ItemHead)
+200,,Earplugs.,,Start(ItemEars),CanShow(ItemEars)
+200,,Gags.,,Start(ItemMouth),CanShow(ItemMouth)
+200,,Collars.,,Start(ItemNeck),CanShow(ItemNeck)
+200,,Accessories for collars.,,Start(ItemNeckAccessories),CanShow(ItemNeckAccessories)
+200,,Restraints to go on collars.,,Start(ItemNeckRestraints),CanShow(ItemNeckRestraints)
+200,201,It's another type of head item.,What sort is it?,,CanShow(ItemHood|ItemNose|ItemMisc)
+200,90,What else do you have?,We have many items available.,,BuyMode
+200,90,Actually it's something else.,What kind of item is it?,,!BuyMode
+201,,Hoods.,,Start(ItemHood),CanShow(ItemHood)
+201,,Items for the nose.,,Start(ItemNose),CanShow(ItemNose)
+201,,Locks and keys.,,Start(ItemMisc),CanShow(ItemMisc)
+201,200,It's another type of head item.,What sort is it?,,
+201,90,What else do you have?,We have many items available.,,BuyMode
+201,90,Actually it's something else.,What kind of item is it?,,!BuyMode
+210,,Arm restraints.,,Start(ItemArms),CanShow(ItemArms)
+210,,Hand restraints.,,Start(ItemHands),CanShow(ItemHands)
+210,,Items for breasts.,,Start(ItemBreast),CanShow(ItemBreast)
+210,,Toys for the nipples.,,Start(ItemNipples),CanShow(ItemNipples)
+210,,Items to decorate the nipples.,,Start(ItemNipplesPiercings),CanShow(ItemNipplesPiercings)
+210,,Harnesses for the torso.,,Start(ItemTorso),CanShow(ItemTorso)
+210,,Chastity belts.,,Start(ItemPelvis),CanShow(ItemPelvis)
+210,90,What else do you have?,We have many items available.,,BuyMode
+210,90,Actually it's something else.,What kind of item is it?,,!BuyMode
+220,,Chastity belts.,,Start(ItemPelvis),CanShow(ItemPelvis)
+220,,Kinky items for the kinky region.,,Start(ItemVulva),CanShow(ItemVulva)
+220,,Piercings for down below.,,Start(ItemVulvaPiercings),CanShow(ItemVulvaPiercings)
+220,,Something to be used on the butt.,,Start(ItemButt),CanShow(ItemButt)
+220,,Something to restrain the legs.,,Start(ItemLegs),CanShow(ItemLegs)
+220,,Something for the feet.,,Start(ItemFeet),CanShow(ItemFeet)
+220,,Boots.,,Start(ItemBoots),CanShow(ItemBoots)
+220,90,What else do you have?,We have many items available.,,BuyMode
+220,90,Actually it's something else.,What kind of item is it?,,!BuyMode
 MaidRescue,,,(She struggles in her restraints.)  Help!,,IsVendorRestrained()
 MaidRescue,,,"(She gives you a thumbs up.)  Everything is back to normal, thanks to you and the sorority.",,!IsVendorRestrained()
 MaidRescue,,Do you need help?,"(She nods quickly.)  Yes, yes, yes!  Please help.",,IsVendorRestrained()

--- a/BondageClub/Screens/Room/Shop/Text_Shop.csv
+++ b/BondageClub/Screens/Room/Shop/Text_Shop.csv
@@ -1,8 +1,9 @@
 MoreShopping,Can I interest you in anything else?
 SelectItemBuy,Select the item you want to buy.
+SelectItemSell,Select the item to sell it for half price.
 EmptyCategory,There are no items to sell for this category.
 AlreadyOwned,You already own this item.
 NotEnoughMoney,You don't have enough money.
 CannotSellKey,"Sorry, I cannot sell you keys."
 CannotSellRemote,"Sorry, I cannot sell you remotes."
-ThankYou,Thank you!  Something else?
+ThankYou,Thank you!  Anything else?


### PR DESCRIPTION
This allows the player to sell items they own back to the shop for half of the purchase price (rounded up).

When selling, the dialog option for each item category will only appear when the player actually has an item in it to sell. Certain items will not be sellable if they can be obtained in the club for free. E.g. nylon ropes from the introduction room.

The dialog text for the item categories has been simplified so it makes sense for both purchases and sales.
The general page structure of the shopkeeper's dialog has been rearranged a bit for ease of navigation. Before, the first page was a list of the top-level item categories plus the "I'd like to ask you some questions." line linking to a second page with all the other questions/activities. Now the first page will instead cover all the main activities (buy/sell/tie/job etc) with one option to start the buying process and one to start selling.