### PR TITLE
Appearance Esc Fix

### DIFF
--- a/BondageClub/Screens/Character/Appearance/Appearance.js
+++ b/BondageClub/Screens/Character/Appearance/Appearance.js
@@ -1141,7 +1141,6 @@ function AppearanceMenuClick(C) {
 							CharacterRefresh(C, false);
 						}
 						if (C.FocusGroup.PreviewZone) AppearancePreviewCleanup();
-						C.FocusGroup = null;
 						AppearanceExit();
 					}
 
@@ -1154,7 +1153,6 @@ function AppearanceMenuClick(C) {
 						}
 						else {
 							if (C.FocusGroup.PreviewZone) AppearancePreviewCleanup();
-							C.FocusGroup = null;
 							AppearanceExit();
 						}
 					}
@@ -1188,6 +1186,8 @@ function AppearanceExit() {
 		CharacterAppearanceHeaderText = "";
 		ElementRemove("InputWardrobeName");
 	} else CharacterAppearanceExit(CharacterAppearanceSelection);
+
+	CharacterAppearanceSelection.FocusGroup = null;
 }
 
 /**


### PR DESCRIPTION
Opening an appearance category in the appearance menu then exiting using the Escape key instead of the Accept/Cancel buttons was not setting the character's FocusGroup to null. This meant that when clicking on the character later, it immediately opened the inventory screen showing clothes options in a 3x4 grid instead of starting the expected dialog.