### PR TITLE
Refactor: Removes handling of the unused Restrain property

### DIFF
--- a/BondageClub/Screens/Inventory/ItemHands/PaddedMittens/PaddedMittens.js
+++ b/BondageClub/Screens/Inventory/ItemHands/PaddedMittens/PaddedMittens.js
@@ -3,7 +3,7 @@ var InventoryItemHandsPaddedMittensMsg = null;
 
 // Loads the item extension properties
 function InventoryItemHandsPaddedMittensLoad() {
-	if (DialogFocusItem.Property == null) DialogFocusItem.Property = { Restrain: null };
+	if (DialogFocusItem.Property == null) DialogFocusItem.Property = {};
 	InventoryItemHandsPaddedMittensMsg = null;
 }
 

--- a/BondageClub/Screens/Inventory/ItemHands/PawMittens/PawMittens.js
+++ b/BondageClub/Screens/Inventory/ItemHands/PawMittens/PawMittens.js
@@ -3,7 +3,7 @@ var InventoryItemHandsPawMittensMsg = null;
 
 // Loads the item extension properties
 function InventoryItemHandsPawMittensLoad() {
-	if (DialogFocusItem.Property == null) DialogFocusItem.Property = { Restrain: null };
+	if (DialogFocusItem.Property == null) DialogFocusItem.Property = {};
 	InventoryItemHandsPawMittensMsg = null;
 }
 

--- a/BondageClub/Scripts/Validation.js
+++ b/BondageClub/Scripts/Validation.js
@@ -475,10 +475,11 @@ function ValidationSanitizeProperties(C, item) {
 		}
 	}
 
-	// Remove impossible combinations
-	if (property.Type == null && property.Restrain == null) {
+	// Remove invalid properties from non-typed items
+	if (property.Type == null) {
 		["SetPose", "Difficulty", "SelfUnlock", "Hide"].forEach(P => {
 			if (property[P] != null) {
+				console.warn("Removing invalid property:", P);
 				delete property[P];
 				changed = true;
 			}


### PR DESCRIPTION
## Summary

All items that were actually using the `Restrain` property have now been moved to use the extended item script. I've therefore removed handling of `Restrain` from the validation code, and have removed the property from the padded mittens and paw mittens, where it was not being used.