### PR TITLE
ChatRoomSync Split

### DIFF
--- a/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
+++ b/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
@@ -1902,73 +1902,457 @@ function ChatRoomMessage(data) {
 }
 
 /**
- * Handles the reception of the new room data from the server.
+ * Adds a character into the chat room.
+ * @param {object} newCharacter - The new character to be added to the chat room.
+ * @param {object} newRawCharacter - The raw character data of the new character as it was received from the server.
+ * @returns {void} - Nothing
+ */
+ function ChatRoomAddCharacterToChatRoom(newCharacter, newRawCharacter)
+ {
+	 if(newCharacter == null) { return; }
+	 if(newRawCharacter == null) { return; }
+ 
+	 // Update the character
+	 let updated = false
+	 for (let i = 0; i < ChatRoomCharacter.length; i++) //For each character in the room...
+	 {
+		 if(ChatRoomCharacter[i].MemberNumber == newCharacter.MemberNumber) // If the joined player already is in the chat room...
+		 {
+			 // Update the character instead
+			 ChatRoomCharacter[i] = newCharacter
+			 updated = true
+			 break;
+		 }
+	 }
+	 if(updated == false) // If we didn't update existing data...
+	 {
+		 // Push a new entry
+		 ChatRoomCharacter.push(newCharacter)
+	 }
+	 
+	 // Update the chat room data backup
+	 updated = false
+	 for (let i = 0; i < ChatRoomData.Character.length; i++) //For each character in the room...
+	 {
+		 if(ChatRoomData.Character[i].MemberNumber == newRawCharacter.MemberNumber) // If the joined player already is in the chat room...
+		 {
+			 // Update the chat room data instead
+			 ChatRoomData.Character[i] = newRawCharacter
+			 updated = true
+			 break;
+		 }
+	 }
+	 if(updated == false) // If we didn't update existing data...
+	 {
+		 // Push a new entry
+		 ChatRoomData.Character.push(newRawCharacter)
+	 }
+ 
+ }
+
+/**
+ * Handles the reception of the complete room data from the server.
+ * @param {object} data - Room object containing the updated chatroom data.
+ * @returns {bool} - Returns true if the passed properties are valid and false if they're invalid.
+ */
+function ChatRoomValidateProperties(chatRoomProperties)
+{
+	let isValid = true
+
+	isValid &= chatRoomProperties != null && typeof chatRoomProperties === "object"
+	isValid &= chatRoomProperties.Name != null && typeof chatRoomProperties.Name === "string"
+	isValid &= chatRoomProperties.Description != null && typeof chatRoomProperties.Description === "string"
+	isValid &= Array.isArray(chatRoomProperties.Admin)
+	isValid &= Array.isArray(chatRoomProperties.Ban)
+	isValid &= chatRoomProperties.Background != null && typeof chatRoomProperties.Background === "string"
+	isValid &= chatRoomProperties.Limit != null && typeof chatRoomProperties.Limit === "number"
+	isValid &= chatRoomProperties.Locked != null && typeof chatRoomProperties.Locked === "boolean"
+	isValid &= chatRoomProperties.Private != null && typeof chatRoomProperties.Private === "boolean"
+	isValid &= Array.isArray(chatRoomProperties.BlockCategory)
+
+	return isValid;
+}
+
+/**
+ * Handles the reception of the complete room data from the server.
  * @param {object} data - Room object containing the updated chatroom data.
  * @returns {void} - Nothing.
  */
 function ChatRoomSync(data) {
-	if ((data != null) && (typeof data === "object") && (data.Name != null)) {
+	if (data == null || (typeof data !== "object")) {
+		return;
+	}
 
-		// Loads the room
-		var Joining = false;
-		if ((CurrentScreen != "ChatRoom") && (CurrentScreen != "ChatAdmin") && (CurrentScreen != "Appearance") && (CurrentModule != "Character")) {
-			if (ChatRoomPlayerCanJoin) {
-				Joining = true;
-				ChatRoomPlayerCanJoin = false;
-				CommonSetScreen("Online", "ChatRoom");
-				if (ChatRoomPlayerJoiningAsAdmin) {
-					ChatRoomPlayerJoiningAsAdmin = false;
-					// Check if we should push banned members
-					if (Player.OnlineSettings && data.Character.length == 1) {
-						var BanList = ChatRoomConcatenateBanList(Player.OnlineSettings.AutoBanBlackList, Player.OnlineSettings.AutoBanGhostList);
-						if (BanList.length > 0) {
-							data.Ban = BanList;
-							data.Limit = data.Limit.toString();
-							ServerSend("ChatRoomAdmin", { MemberNumber: Player.ID, Room: data, Action: "Update" });
-						}
+	if(ChatRoomValidateProperties(data) == false) // If the room data we received is invalid...
+	{
+		// Instantly leave the chat room again
+		DialogLentLockpicks = false;
+		ChatRoomClearAllElements();
+		ChatRoomSetLastChatRoom("")
+		ServerSend("ChatRoomLeave", "");
+		ChatSearchMessage = "ErrorInvalidRoomProperties"
+		CommonSetScreen("Online", "ChatSearch");
+		return;
+	}
+
+	// Loads the room
+	if ((CurrentScreen != "ChatRoom") && (CurrentScreen != "ChatAdmin") && (CurrentScreen != "Appearance") && (CurrentModule != "Character")) {
+		if (ChatRoomPlayerCanJoin) {
+			ChatRoomPlayerCanJoin = false;
+			CommonSetScreen("Online", "ChatRoom");
+			if (ChatRoomPlayerJoiningAsAdmin) {
+				ChatRoomPlayerJoiningAsAdmin = false;
+				// Check if we should push banned members
+				if (Player.OnlineSettings && data.Character.length == 1) {
+					const BanList = ChatRoomConcatenateBanList(Player.OnlineSettings.AutoBanBlackList, Player.OnlineSettings.AutoBanGhostList);
+					if (BanList.length > 0) {
+						data.Ban = BanList;
+						data.Limit = data.Limit.toString();
+						ServerSend("ChatRoomAdmin", { MemberNumber: Player.ID, Room: data, Action: "Update" });
 					}
 				}
-			} else return;
+			}
+		} else return;
+	}
+
+	// Treat chatroom updates from ourselves as if the updated characters had sent them
+	const trustedUpdate = data.SourceMemberNumber === Player.MemberNumber;
+
+	// Load the characters
+	ChatRoomCharacter = [];
+	for (let C = 0; C < data.Character.length; C++) {
+		const sourceMemberNumber = trustedUpdate ? data.Character[C].MemberNumber : data.SourceMemberNumber;
+		const Char = CharacterLoadOnline(data.Character[C], sourceMemberNumber);
+		ChatRoomCharacter.push(Char);
+	}
+
+	// Keeps a copy of the previous version
+	ChatRoomData = data;
+	if (ChatRoomData.Game != null) {
+		ChatRoomGame = ChatRoomData.Game;
+	}
+
+	// Recreates the chatroom with the stored chatroom data if necessary
+	ChatRoomRecreate();
+
+	// Check whether the player's last chatroom data needs updating
+	ChatRoomCheckForLastChatRoomUpdates();
+
+	// Reloads the online game statuses if needed
+	OnlineGameLoadStatus();
+
+	// The allowed menu actions may have changed
+	ChatRoomMenuBuild();
+	
+}
+
+/**
+ * Handles the reception of the character data of a single player from the server.
+ * @param {object} data - object containing the character's data.
+ * @returns {void} - Nothing.
+ */
+ function ChatRoomSyncCharacter(data) {
+	if (data == null || (typeof data !== "object")) {
+		return;
+	}
+
+	const newCharacter = CharacterLoadOnline(data.Character, data.SourceMemberNumber)
+	ChatRoomAddCharacterToChatRoom(newCharacter, data.Character)
+		
+}
+
+/**
+ * Handles the reception of the character data of a newly joined player from the server.
+ * @param {object} data - object containing the joined character's data.
+ * @returns {void} - Nothing.
+ */
+ function ChatRoomSyncMemberJoin(data) {
+	if (data == null || (typeof data !== "object")) {
+		return;
+	}
+
+	//Load the character to the chat room
+	const newCharacter = CharacterLoadOnline(data.Character, data.SourceMemberNumber)
+	ChatRoomAddCharacterToChatRoom(newCharacter, data.Character)
+	
+	// After Join Actions
+	if (ChatRoomNotificationRaiseChatJoin(newCharacter)) {
+		NotificationRaise(NotificationEventType.CHATJOIN, { characterName: newCharacter.Name });
+	}
+	if (ChatRoomLeashList.includes(newCharacter.MemberNumber)) {
+		// Ping to make sure they are still leashed
+		ServerSend("ChatRoomChat", { Content: "PingHoldLeash", Type: "Hidden", Target: newCharacter.MemberNumber });
+	}
+	// Check whether the player's last chatroom data needs updating
+	ChatRoomCheckForLastChatRoomUpdates();
+	// The allowed menu actions may have changed
+	ChatRoomMenuBuild();
+	
+}
+
+/**
+ * Handles the reception of the leave notification of a player from the server.
+ * @param {object} data - Room object containing the leaving character's member number.
+ * @returns {void} - Nothing.
+ */
+ function ChatRoomSyncMemberLeave(data) {
+	if (data == null || (typeof data !== "object")) {
+		return;
+	}
+
+	// Remove the character
+	for (let i = 0; i < ChatRoomCharacter.length; i++) //For each character in the room...
+	{
+		if(ChatRoomCharacter[i].MemberNumber == data.SourceMemberNumber) // If this player is the one who just left...
+		{
+			// Remove the character
+			ChatRoomCharacter.splice(i, 1)
+			break;
 		}
+	}
 
-		// Treat chatroom updates from ourselves as if the updated characters had sent them
-		const trustedUpdate = data.SourceMemberNumber === Player.MemberNumber;
+	// Update the chat room data backup
+	for (let i = 0; i < ChatRoomData.Character.length; i++) //For each character in the room...
+	{
+		if(ChatRoomData.Character[i].MemberNumber == data.SourceMemberNumber) // If the joined player already is in the chat room...
+		{
+			// Remove the entry
+			ChatRoomData.Character.splice(i, 1)
+			break;
+		}
+	}
 
-		// Load the characters
-		const OldChatRoomCharacter = ChatRoomCharacter || [];
-		ChatRoomCharacter = [];
-		for (let C = 0; C < data.Character.length; C++) {
-			const sourceMemberNumber = trustedUpdate ? data.Character[C].MemberNumber : data.SourceMemberNumber;
-			const Char = CharacterLoadOnline(data.Character[C], sourceMemberNumber);
-			ChatRoomCharacter.push(Char);
-			// Special cases when someone joins the room
-			if (!Joining && !OldChatRoomCharacter.includes(Char)) {
-				if (ChatRoomNotificationRaiseChatJoin(Char)) {
-					NotificationRaise(NotificationEventType.CHATJOIN, { characterName: Char.Name });
-				}
-				if (ChatRoomLeashList.includes(Char.MemberNumber)) {
-					// Ping to make sure they are still leashed
-					ServerSend("ChatRoomChat", { Content: "PingHoldLeash", Type: "Hidden", Target: Char.MemberNumber });
-				}
+	// Check whether the player's last chatroom data needs updating
+	ChatRoomCheckForLastChatRoomUpdates();
+
+	// The allowed menu actions may have changed
+	ChatRoomMenuBuild();
+
+}
+
+/**
+ * Handles the reception of the room properties from the server.
+ * @param {object} data - Room object containing the updated chatroom properties.
+ * @returns {void} - Nothing.
+ */
+ function ChatRoomSyncRoomProperties(data) {
+	if (data == null || (typeof data !== "object")) {
+		return;
+	}
+	
+	if(ChatRoomValidateProperties(data) == false) // If the room data we received is invalid...
+	{
+		// Instantly leave the chat room again
+		DialogLentLockpicks = false;
+		ChatRoomClearAllElements();
+		ChatRoomSetLastChatRoom("")
+		ServerSend("ChatRoomLeave", "");
+		ChatSearchMessage = "ErrorInvalidRoomProperties"
+		CommonSetScreen("Online", "ChatSearch");
+		return;
+	}
+
+	// Copy the received properties to chat room data
+	for (let property in data) {
+		if (data.hasOwnProperty(property)) {
+			ChatRoomData[property] = data[property]
+		}
+	}
+
+	if (ChatRoomData.Game != null) ChatRoomGame = ChatRoomData.Game;
+
+	// Recreates the chatroom with the stored chatroom data if necessary
+	ChatRoomRecreate();
+
+	// Check whether the player's last chatroom data needs updating
+	ChatRoomCheckForLastChatRoomUpdates();
+
+	// Reloads the online game statuses if needed
+	OnlineGameLoadStatus();
+
+	// The allowed menu actions may have changed
+	ChatRoomMenuBuild();
+	
+}
+
+/**
+ * Handles the swapping of two players by a room administrator.
+ * @param {object} data - Object containing the member numbers of the swapped characters.
+ * @returns {void} - Nothing.
+ */
+ function ChatRoomSyncSwapPlayers(data) {
+	if (data == null || (typeof data !== "object")) {
+		return;
+	}
+
+	let index1 = -1
+	let index2 = -1
+
+	for (let i = 0; i < ChatRoomCharacter.length; i++) //For each character in the room...
+	{
+		if(ChatRoomCharacter[i].MemberNumber == data.MemberNumber1) // If this player is the first swapped...
+		{
+			// Remember it
+			index1 = i
+		}
+		if(ChatRoomCharacter[i].MemberNumber == data.MemberNumber2) // If this player is the second swapped...
+		{
+			// Remember it
+			index2 = i
+		}
+	}
+
+	if(index1 >= 0 && index2 >= 0) // If we found both characters to swap...
+	{
+		//Swap them
+		let bufferCharacter = ChatRoomCharacter[index1]
+		ChatRoomCharacter[index1] = ChatRoomCharacter[index2]
+		ChatRoomCharacter[index2] = bufferCharacter
+	}
+
+	// Update the chat room data backup
+	index1 = -1
+	index2 = -1
+	for (let i = 0; i < ChatRoomData.Character.length; i++) //For each character in the room...
+	{
+		if(ChatRoomData.Character[i].MemberNumber == data.MemberNumber1) // If this player is the first swapped...
+		{
+			// Remember it
+			index1 = i
+		}
+		if(ChatRoomData.Character[i].MemberNumber == data.MemberNumber2) // If this player is the second swapped...
+		{
+			// Remember it
+			index2 = i
+		}
+	}
+
+	if(index1 >= 0 && index2 >= 0) // If we found both entries to swap...
+	{
+		//Swap them
+		let bufferCharacter = ChatRoomData.Character[index1]
+		ChatRoomData.Character[index1] = ChatRoomData.Character[index2]
+		ChatRoomData.Character[index2] = bufferCharacter
+	}
+	
+}
+
+/**
+ * Handles the moving of a player by a room administrator.
+ * @param {object} data - Object containing the member numbers of the swapped characters.
+ * @returns {void} - Nothing.
+ */
+ function ChatRoomSyncMovePlayer(data) {
+	if (data == null || (typeof data !== "object")) {
+		return;
+	}
+
+	let index = -1
+
+	for (let i = 0; i < ChatRoomCharacter.length; i++) //For each character in the room...
+	{
+		if(ChatRoomCharacter[i].MemberNumber == data.TargetMemberNumber) // If this player is the moved...
+		{
+			// Remember it
+			index = i
+		}
+	}
+
+	let moveOffset = 0
+	switch(data.Direction)
+	{
+		case "Left": moveOffset = -1; break;
+		case "Right": moveOffset = 1; break;
+		default: moveOffset = 0; break;
+	}
+
+	if(index >= 0 && index < ChatRoomCharacter.length &&
+		index+moveOffset >= 0 && index+moveOffset < ChatRoomCharacter.length) // If we found the character to move and the moving is valid...
+	{
+		//Move it
+		let bufferCharacter = ChatRoomCharacter[index]
+		ChatRoomCharacter[index] = ChatRoomCharacter[index+moveOffset]
+		ChatRoomCharacter[index+moveOffset] = bufferCharacter
+	}
+
+	// Update the chat room data backup
+	index = -1
+	for (let i = 0; i < ChatRoomData.Character.length; i++) //For each character in the room...
+	{
+		if(ChatRoomData.Character[i].MemberNumber == data.TargetMemberNumber) // If this player is the moved...
+		{
+			// Remember it
+			index = i
+		}
+	}
+
+	if(index >= 0 && index < ChatRoomCharacter.length &&
+		index+moveOffset >= 0 && index+moveOffset < ChatRoomCharacter.length) // If we found the entry to move and the moving is valid...
+	{
+		//Move it
+		let bufferCharacter = ChatRoomData.Character[index]
+		ChatRoomData.Character[index] = ChatRoomData.Character[index+moveOffset]
+		ChatRoomData.Character[index+moveOffset] = bufferCharacter
+	}
+
+}
+
+/**
+ * Handles the swapping of two players by a room administrator.
+ * @param {object} data - Object containing the member numbers of the swapped characters.
+ * @returns {void} - Nothing.
+ */
+ function ChatRoomSyncReorderPlayers(data) {
+	if (data == null || (typeof data !== "object")) {
+		return;
+	}
+
+	let newChatRoomCharacter = []
+	let newChatRoomDataCharacter = []
+
+	for(let i=0; i<data.PlayerOrder.length; i++) // For every player to reorder...
+	{
+		for(let j=0; j<ChatRoomCharacter.length; j++) // For every chat room character...
+		{
+			if(ChatRoomCharacter[j].MemberNumber == data.PlayerOrder[i]) // If this player is the first swapped...
+			{
+				// Move to reordered array
+				newChatRoomCharacter.push(ChatRoomCharacter.splice(j,1)[0])
+				break;
+			}
+		}
+		for(let j=0; j<ChatRoomData.Character.length; j++) // For every chat room character...
+		{
+			if(ChatRoomData.Character[j].MemberNumber == data.PlayerOrder[i]) // If this player is the first swapped...
+			{
+				// Move to reordered array
+				newChatRoomDataCharacter.push(ChatRoomData.Character.splice(j,1)[0])
+				break;
 			}
 		}
 
-		// Keeps a copy of the previous version
-		ChatRoomData = data;
-		if (ChatRoomData.Game != null) ChatRoomGame = ChatRoomData.Game;
-
-		// Recreates the chatroom with the stored chatroom data if necessary
-		ChatRoomRecreate();
-
-		// Check whether the player's last chatroom data needs updating
-		ChatRoomCheckForLastChatRoomUpdates();
-
-		// Reloads the online game statuses if needed
-		OnlineGameLoadStatus();
-
-		// The allowed menu actions may have changed
-		ChatRoomMenuBuild();
 	}
+
+	if(ChatRoomCharacter.length > 0) // If we forgot about some characters for some reason...
+	{
+		console.log("Apply1")
+		//Push the missed entries to the end
+		Array.prototype.push.apply(newChatRoomCharacter, ChatRoomCharacter)
+	}
+	if(ChatRoomData.Character.length > 0) // If we forgot about some entries for some reason...
+	{
+		console.log("Apply2")
+		//Push the missed entries to the end
+		Array.prototype.push.apply(newChatRoomDataCharacter, ChatRoomData.Character)
+	}
+
+	//Update the origin arrays
+	ChatRoomCharacter = newChatRoomCharacter
+	ChatRoomData.Character = newChatRoomDataCharacter
+
+	console.log(ChatRoomCharacter)
+	console.log(ChatRoomData.Character)
+	
 }
 
 /**

--- a/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
+++ b/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
@@ -2161,9 +2161,6 @@ function ChatRoomSync(data) {
 
 	if (ChatRoomData.Game != null) ChatRoomGame = ChatRoomData.Game;
 
-	// Recreates the chatroom with the stored chatroom data if necessary
-	ChatRoomRecreate();
-
 	// Check whether the player's last chatroom data needs updating
 	ChatRoomCheckForLastChatRoomUpdates();
 

--- a/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
+++ b/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
@@ -1912,37 +1912,27 @@ function ChatRoomMessage(data) {
 	 if(newCharacter == null) { return; }
 	 if(newRawCharacter == null) { return; }
  
-	 // Update the character
-	 let updated = false
-	 for (let i = 0; i < ChatRoomCharacter.length; i++) //For each character in the room...
+	// Update the chat room characters
+	 let characterIndex = ChatRoomCharacter.findIndex(x => x.MemberNumber == newCharacter.MemberNumber)
+	 if(characterIndex >= 0) // If we found an existing entry...
 	 {
-		 if(ChatRoomCharacter[i].MemberNumber == newCharacter.MemberNumber) // If the joined player already is in the chat room...
-		 {
-			 // Update the character instead
-			 ChatRoomCharacter[i] = newCharacter
-			 updated = true
-			 break;
-		 }
+		// Update it
+		ChatRoomCharacter[characterIndex] = newCharacter
 	 }
-	 if(updated == false) // If we didn't update existing data...
+	 else // If we didn't update existing data...
 	 {
 		 // Push a new entry
 		 ChatRoomCharacter.push(newCharacter)
 	 }
 	 
-	 // Update the chat room data backup
-	 updated = false
-	 for (let i = 0; i < ChatRoomData.Character.length; i++) //For each character in the room...
+	 // Update chat room data backup
+	 characterIndex = ChatRoomData.Character.findIndex(x => x.MemberNumber == newRawCharacter.MemberNumber)
+	 if(characterIndex >= 0) // If we found an existing entry...
 	 {
-		 if(ChatRoomData.Character[i].MemberNumber == newRawCharacter.MemberNumber) // If the joined player already is in the chat room...
-		 {
-			 // Update the chat room data instead
-			 ChatRoomData.Character[i] = newRawCharacter
-			 updated = true
-			 break;
-		 }
+		// Update it
+		ChatRoomData.Character[characterIndex] = newRawCharacter
 	 }
-	 if(updated == false) // If we didn't update existing data...
+	 else // If we didn't update existing data...
 	 {
 		 // Push a new entry
 		 ChatRoomData.Character.push(newRawCharacter)
@@ -1953,7 +1943,7 @@ function ChatRoomMessage(data) {
 /**
  * Handles the reception of the complete room data from the server.
  * @param {object} data - Room object containing the updated chatroom data.
- * @returns {bool} - Returns true if the passed properties are valid and false if they're invalid.
+ * @returns {boolean} - Returns true if the passed properties are valid and false if they're invalid.
  */
 function ChatRoomValidateProperties(chatRoomProperties)
 {
@@ -2101,26 +2091,8 @@ function ChatRoomSync(data) {
 	}
 
 	// Remove the character
-	for (let i = 0; i < ChatRoomCharacter.length; i++) //For each character in the room...
-	{
-		if(ChatRoomCharacter[i].MemberNumber == data.SourceMemberNumber) // If this player is the one who just left...
-		{
-			// Remove the character
-			ChatRoomCharacter.splice(i, 1)
-			break;
-		}
-	}
-
-	// Update the chat room data backup
-	for (let i = 0; i < ChatRoomData.Character.length; i++) //For each character in the room...
-	{
-		if(ChatRoomData.Character[i].MemberNumber == data.SourceMemberNumber) // If the joined player already is in the chat room...
-		{
-			// Remove the entry
-			ChatRoomData.Character.splice(i, 1)
-			break;
-		}
-	}
+	ChatRoomCharacter = ChatRoomCharacter.filter(x => x.MemberNumber != data.SourceMemberNumber)
+	ChatRoomData.Character = ChatRoomData.Character.filter(x => x.MemberNumber != data.SourceMemberNumber)
 
 	// Check whether the player's last chatroom data needs updating
 	ChatRoomCheckForLastChatRoomUpdates();
@@ -2182,22 +2154,9 @@ function ChatRoomSync(data) {
 		return;
 	}
 
-	let index1 = -1
-	let index2 = -1
-
-	for (let i = 0; i < ChatRoomCharacter.length; i++) //For each character in the room...
-	{
-		if(ChatRoomCharacter[i].MemberNumber == data.MemberNumber1) // If this player is the first swapped...
-		{
-			// Remember it
-			index1 = i
-		}
-		if(ChatRoomCharacter[i].MemberNumber == data.MemberNumber2) // If this player is the second swapped...
-		{
-			// Remember it
-			index2 = i
-		}
-	}
+	// Update the chat room characters
+	let index1 = ChatRoomCharacter.findIndex(x => (x.MemberNumber == data.MemberNumber1))
+	let index2 = ChatRoomCharacter.findIndex(x => (x.MemberNumber == data.MemberNumber2))
 
 	if(index1 >= 0 && index2 >= 0) // If we found both characters to swap...
 	{
@@ -2208,21 +2167,8 @@ function ChatRoomSync(data) {
 	}
 
 	// Update the chat room data backup
-	index1 = -1
-	index2 = -1
-	for (let i = 0; i < ChatRoomData.Character.length; i++) //For each character in the room...
-	{
-		if(ChatRoomData.Character[i].MemberNumber == data.MemberNumber1) // If this player is the first swapped...
-		{
-			// Remember it
-			index1 = i
-		}
-		if(ChatRoomData.Character[i].MemberNumber == data.MemberNumber2) // If this player is the second swapped...
-		{
-			// Remember it
-			index2 = i
-		}
-	}
+	index1 = ChatRoomData.Character.findIndex(x => x.MemberNumber == data.MemberNumber1)
+	index2 = ChatRoomData.Character.findIndex(x => x.MemberNumber == data.MemberNumber2)
 
 	if(index1 >= 0 && index2 >= 0) // If we found both entries to swap...
 	{
@@ -2244,17 +2190,6 @@ function ChatRoomSync(data) {
 		return;
 	}
 
-	let index = -1
-
-	for (let i = 0; i < ChatRoomCharacter.length; i++) //For each character in the room...
-	{
-		if(ChatRoomCharacter[i].MemberNumber == data.TargetMemberNumber) // If this player is the moved...
-		{
-			// Remember it
-			index = i
-		}
-	}
-
 	let moveOffset = 0
 	switch(data.Direction)
 	{
@@ -2263,6 +2198,8 @@ function ChatRoomSync(data) {
 		default: moveOffset = 0; break;
 	}
 
+	// Update the chat room characters
+	let index = ChatRoomCharacter.findIndex(x => x.MemberNumber == data.TargetMemberNumber)
 	if(index >= 0 && index < ChatRoomCharacter.length &&
 		index+moveOffset >= 0 && index+moveOffset < ChatRoomCharacter.length) // If we found the character to move and the moving is valid...
 	{
@@ -2273,16 +2210,7 @@ function ChatRoomSync(data) {
 	}
 
 	// Update the chat room data backup
-	index = -1
-	for (let i = 0; i < ChatRoomData.Character.length; i++) //For each character in the room...
-	{
-		if(ChatRoomData.Character[i].MemberNumber == data.TargetMemberNumber) // If this player is the moved...
-		{
-			// Remember it
-			index = i
-		}
-	}
-
+	index = ChatRoomData.Character.findIndex(x => x.MemberNumber == data.TargetMemberNumber)
 	if(index >= 0 && index < ChatRoomCharacter.length &&
 		index+moveOffset >= 0 && index+moveOffset < ChatRoomCharacter.length) // If we found the entry to move and the moving is valid...
 	{
@@ -2306,39 +2234,27 @@ function ChatRoomSync(data) {
 
 	let newChatRoomCharacter = []
 	let newChatRoomDataCharacter = []
+	let index = 0
 
 	for(let i=0; i<data.PlayerOrder.length; i++) // For every player to reorder...
 	{
-		for(let j=0; j<ChatRoomCharacter.length; j++) // For every chat room character...
-		{
-			if(ChatRoomCharacter[j].MemberNumber == data.PlayerOrder[i]) // If this player is the first swapped...
-			{
-				// Move to reordered array
-				newChatRoomCharacter.push(ChatRoomCharacter.splice(j,1)[0])
-				break;
-			}
-		}
-		for(let j=0; j<ChatRoomData.Character.length; j++) // For every chat room character...
-		{
-			if(ChatRoomData.Character[j].MemberNumber == data.PlayerOrder[i]) // If this player is the first swapped...
-			{
-				// Move to reordered array
-				newChatRoomDataCharacter.push(ChatRoomData.Character.splice(j,1)[0])
-				break;
-			}
-		}
+		//Chat Room Characters
+		index = ChatRoomCharacter.findIndex(x => x.MemberNumber == data.PlayerOrder[i])
+		newChatRoomCharacter.push(ChatRoomCharacter.splice(index, 1)[0])
+
+		//Chat Room Data Backup
+		index = ChatRoomData.Character.findIndex(x => x.MemberNumber == data.PlayerOrder[i])
+		newChatRoomDataCharacter.push(ChatRoomData.Character.splice(index, 1)[0])
 
 	}
 
 	if(ChatRoomCharacter.length > 0) // If we forgot about some characters for some reason...
 	{
-		console.log("Apply1")
 		//Push the missed entries to the end
 		Array.prototype.push.apply(newChatRoomCharacter, ChatRoomCharacter)
 	}
 	if(ChatRoomData.Character.length > 0) // If we forgot about some entries for some reason...
 	{
-		console.log("Apply2")
 		//Push the missed entries to the end
 		Array.prototype.push.apply(newChatRoomDataCharacter, ChatRoomData.Character)
 	}
@@ -2346,9 +2262,6 @@ function ChatRoomSync(data) {
 	//Update the origin arrays
 	ChatRoomCharacter = newChatRoomCharacter
 	ChatRoomData.Character = newChatRoomDataCharacter
-
-	console.log(ChatRoomCharacter)
-	console.log(ChatRoomData.Character)
 	
 }
 

--- a/BondageClub/Screens/Online/ChatSearch/Text_ChatSearch.csv
+++ b/BondageClub/Screens/Online/ChatSearch/Text_ChatSearch.csv
@@ -11,6 +11,7 @@ ResponseCannotFindRoom,Room doesn't exist anymore
 ResponseAccountError,Account Error
 ResponseInvalidRoomData,Invalid Room Data
 ResponseJoinedRoom,Entering the room...
+ErrorInvalidRoomProperties,Room has invalid properties.
 FilterMode,Filter Rooms
 NormalMode,Return to room view
 Exit,Leave room search

--- a/BondageClub/Scripts/Server.js
+++ b/BondageClub/Scripts/Server.js
@@ -39,6 +39,13 @@ function ServerInit() {
 	ServerSocket.on("ChatRoomCreateResponse", function (data) { ChatCreateResponse(data); });
 	ServerSocket.on("ChatRoomUpdateResponse", function (data) { ChatAdminResponse(data); });
 	ServerSocket.on("ChatRoomSync", function (data) { ChatRoomSync(data); });
+	ServerSocket.on("ChatRoomSyncCharacter", function (data) { ChatRoomSyncCharacter(data); });
+	ServerSocket.on("ChatRoomSyncMemberJoin", function (data) { ChatRoomSyncMemberJoin(data); });
+	ServerSocket.on("ChatRoomSyncMemberLeave", function (data) { ChatRoomSyncMemberLeave(data); });
+	ServerSocket.on("ChatRoomSyncRoomProperties", function (data) { ChatRoomSyncRoomProperties(data); });
+	ServerSocket.on("ChatRoomSyncSwapPlayers", function (data) { ChatRoomSyncSwapPlayers(data); });
+	ServerSocket.on("ChatRoomSyncMovePlayer", function (data) { ChatRoomSyncMovePlayer(data); });
+	ServerSocket.on("ChatRoomSyncReorderPlayers", function (data) { ChatRoomSyncReorderPlayers(data); });
 	ServerSocket.on("ChatRoomSyncSingle", function (data) { ChatRoomSyncSingle(data); });
 	ServerSocket.on("ChatRoomSyncExpression", function (data) { ChatRoomSyncExpression(data); });
 	ServerSocket.on("ChatRoomSyncPose", function (data) { ChatRoomSyncPose(data); });


### PR DESCRIPTION
This PR splits ChatRoomSync up into multiple, functions with reduced overhead each. This way, lots of chat room operations will result in much smaller message transfers, reducing the transfer time especially in chat rooms with many players.

**This PR requires the server PR [ #76](https://github.com/Ben987/Bondage-Club-Server/pull/76) to work.** The server PR also takes care of the compatibility with older clients without this change which would be the case during beta.

**Edit - Important Note:** Is is possible that during beta the Server performance actually drops a bit. This is because the server's workaround to ensure compatibility with non-beta players is a bit more costy. This effect, however, should reduce as the beta link spreads around as it usually does.

### New functions
**ChatRoomSync:**
This one still exists and is used to send all chatroom related data to newly entering players. This, however, is it's only usage right now and it only is called for the entering players and noone else. This function now also makes sure the transferred chat room properties are valid.

**ChatRoomSyncCharacter:**
This function is used for single character updates. If lovers/owner data is changed, we only need to update one(the newly owned sub) or two(the newly engaged lovers) characters. This could further split up in the future to reduce the payload further but since it's only called on special occations i assumed no high impact on performance and kept it like this to have it more reusable for future changes.

**ChatRoomSyncMemberJoin:**
This one basically does the same as _ChatRoomSyncCharacter_. It sends the character data of a newly joined player to everyone already in the room. The decission why i put this into a seperate function is to make new joins distinct from simple updates. The updated data might change in the future. This also helped to remove a hack to detect newly joined players in  _ChatRoomSyncCharacter_ and instead perform the required actions in this function.

**ChatRoomSyncMemberLeave:**
When a player leaves a chat room, instead of resending the whole chat room data, only the member number of the leaving player is sent. The clients then remove the related player from their ChatRoomCharacters and ChatRoomData.Characters arrays themselves instead of updating them completely.

**ChatRoomSyncRoomProperties:**
This one is used to update the chat room properties after they got changed by a room administrator. Character data is not send along. This function also makes sure the transferred properties are valid.

**ChatRoomSyncSwapPlayers:**
This is called when a room administrator swaps two players within a chat room. It just sends the member numbers of both swapped characters and the clients reorder their ChatRoomCharacters and ChatRoomData.Characters arrays themselves.
The server still also does this swap to ensure the order is the same for newly joined players.

**ChatRoomSyncMovePlayer:**
Like _ChatRoomSyncSwapPlayers_. However, instead of sending two member numbers, here the member number of the moved player and the direction as a string is transferred ("Left" or "Right").

**ChatRoomSyncReorderPlayers:**
This function is used in LARP battles when the players within a chat room are shuffled at the start of the game. It sends an array with the member numbers of all players in the chat room in the new order. Just like with _ChatRoomSyncSwapPlayers_ and _ChatRoomSyncMovePlayer_, the clients reorder on basis of this array their ChatRoomCharacters and ChatRoomData.Characters arrays themselves

### Tests
Since this PR changes a critical part of the game (that was used for a lot of different features), thorough testing is a necessity. And even though i already tested this a lot, i want to encourage reviewers to try and break this change as much as they can to discover every possible oversight i might have made.

**Things i already tested:**
- Beta players joining and leaving rooms with beta and non-beta characters
- Non-Beta players joining and leaving rooms with beta and non-beta characters
- Moving and swapping players with both, beta and non-beta players in the room
- Changing room properties with both, beta and non-beta players in the room
- Creating new rooms with with beta and non-beta players
- Starting a larp game with beta and non-beta players to confirm the shuffling still works
- Offering and accepting a trial period as submissive and confirming all beta and non-beta players in the room get the update
- Offering and accepting a lovers request and confirming all beta and non-beta players in the room get the update
- Breaking up with a lover and confirming all beta and non-beta players in a room with the other lover as well as the lover herself gets the update

**Edit - More Tests:**
- Kicking beta and non-beat players with other beta and non-beta players in the room
- Banning present beta and non-beta players in the with other beta and non-beta players in the room
- Banning not present beta and non-beta players in the with other beta and non-beta players in the room
- Unbanning beta and non-beta players in the with other beta and non-beta players in the room

All the tests showed the intended behaviour
