### PR TITLE
Bugfix: Fixes issues with new validation script when run on private room NPCs

### DIFF
--- a/BondageClub/Assets/Female3DCG/Female3DCG.js
+++ b/BondageClub/Assets/Female3DCG/Female3DCG.js
@@ -1222,7 +1222,6 @@ var AssetFemale3DCG = [
 		Group: "Nipples",
 		ParentGroup: "BodyUpper",
 		Priority: 11,
-		Default: false,
 		Left: 175,
 		Top: 285,
 		AllowNone: false,

--- a/BondageClub/Screens/Character/Appearance/Appearance.js
+++ b/BondageClub/Screens/Character/Appearance/Appearance.js
@@ -175,7 +175,7 @@ function CharacterAppearanceFullRandom(C, ClothOnly) {
 
 	// For each item group (non default items only show at a 20% rate, if it can occasionally happen)
 	for (let A = 0; A < AssetGroup.length; A++)
-		if ((AssetGroup[A].Category == "Appearance") && (AssetGroup[A].IsDefault || (AssetGroup[A].Random && Math.random() < 0.2) || CharacterAppearanceRequired(C, AssetGroup[A].Name)) && (!CharacterAppearanceMustHide(C, AssetGroup[A].Name) || !AssetGroup[A].AllowNone) && (CharacterAppearanceGetCurrentValue(C, AssetGroup[A].Name, "Name") == "None")) {
+		if ((AssetGroup[A].Category == "Appearance") && (AssetGroup[A].IsDefault || !AssetGroup[A].AllowNone || (AssetGroup[A].Random && Math.random() < 0.2) || CharacterAppearanceRequired(C, AssetGroup[A].Name)) && (!CharacterAppearanceMustHide(C, AssetGroup[A].Name)) && (CharacterAppearanceGetCurrentValue(C, AssetGroup[A].Name, "Name") == "None")) {
 			
 			// Get the parent size
 			var ParentSize = "";

--- a/BondageClub/Screens/Character/Appearance/Appearance.js
+++ b/BondageClub/Screens/Character/Appearance/Appearance.js
@@ -175,7 +175,7 @@ function CharacterAppearanceFullRandom(C, ClothOnly) {
 
 	// For each item group (non default items only show at a 20% rate, if it can occasionally happen)
 	for (let A = 0; A < AssetGroup.length; A++)
-		if ((AssetGroup[A].Category == "Appearance") && (AssetGroup[A].IsDefault || !AssetGroup[A].AllowNone || (AssetGroup[A].Random && Math.random() < 0.2) || CharacterAppearanceRequired(C, AssetGroup[A].Name)) && (!CharacterAppearanceMustHide(C, AssetGroup[A].Name)) && (CharacterAppearanceGetCurrentValue(C, AssetGroup[A].Name, "Name") == "None")) {
+		if ((AssetGroup[A].Category == "Appearance") && (AssetGroup[A].IsDefault || (AssetGroup[A].Random && Math.random() < 0.2) || CharacterAppearanceRequired(C, AssetGroup[A].Name)) && (!CharacterAppearanceMustHide(C, AssetGroup[A].Name) || !AssetGroup[A].AllowNone) && (CharacterAppearanceGetCurrentValue(C, AssetGroup[A].Name, "Name") == "None")) {
 			
 			// Get the parent size
 			var ParentSize = "";

--- a/BondageClub/Screens/Character/Login/Login.js
+++ b/BondageClub/Screens/Character/Login/Login.js
@@ -466,7 +466,7 @@ function LoginResponse(C) {
 			LoginDifficulty();
 
 			// Loads the player character model and data
-			Player.Appearance = ServerAppearanceLoadFromBundle(Player, C.AssetFamily, C.Appearance, C.MemberNumber);
+			Player.Appearance = ServerAppearanceLoadFromBundle(Player, C.AssetFamily, C.Appearance, C.MemberNumber).appearance;
 			InventoryLoad(Player, C.Inventory);
 			LogLoad(C.Log);
 			ReputationLoad(C.Reputation);

--- a/BondageClub/Scripts/Character.js
+++ b/BondageClub/Scripts/Character.js
@@ -368,7 +368,7 @@ function CharacterOnlineRefresh(Char, data, SourceMemberNumber) {
 	Char.BlockItems = Array.isArray(data.BlockItems) ? data.BlockItems : [];
 	Char.LimitedItems = Array.isArray(data.LimitedItems) ? data.LimitedItems : [];
 	if (Char.ID != 0) Char.WhiteList = data.WhiteList;
-	Char.Appearance = ServerAppearanceLoadFromBundle(Char, "Female3DCG", data.Appearance, SourceMemberNumber);
+	Char.Appearance = ServerAppearanceLoadFromBundle(Char, "Female3DCG", data.Appearance, SourceMemberNumber).appearance;
 	if (Char.ID == 0) LoginValidCollar();
 	if ((Char.ID != 0) && ((Char.MemberNumber == SourceMemberNumber) || (Char.Inventory == null) || (Char.Inventory.length == 0))) InventoryLoad(Char, data.Inventory);
 	CharacterLoadEffect(Char);

--- a/BondageClub/Scripts/Server.js
+++ b/BondageClub/Scripts/Server.js
@@ -15,6 +15,13 @@
  *     object | undefined}>} AppearanceBundle
  */
 
+/**
+ * A map containing appearance item diffs, keyed according to the item group. Used to compare and validate before/after
+ * for appearance items.
+ * @typedef AppearanceDiffMap
+ * @type {object.<string, Item[]>}
+ */
+
 "use strict";
 /** @type {import("socket.io-client").Socket} */
 var ServerSocket = null;
@@ -317,6 +324,14 @@ function ServerAppearanceLoadFromBundle(C, AssetFamily, Bundle, SourceMemberNumb
 	return { appearance, updateValid };
 }
 
+/**
+ * Builds a diff map for comparing changes to a character's appearance, keyed by asset group name
+ * @param {string} assetFamily - The asset family of the appearance
+ * @param {AppearanceItem[]} appearance - The current appearance to compare against
+ * @param {AppearanceBundle} bundle - The new appearance bundle
+ * @returns {AppearanceDiffMap} - An appearance diff map representing the changes that have been made to the character's
+ * appearance
+ */
 function ServerBuildAppearanceDiff(assetFamily, appearance, bundle) {
 	const diffMap = {};
 	appearance.forEach((item) => {
@@ -332,6 +347,13 @@ function ServerBuildAppearanceDiff(assetFamily, appearance, bundle) {
 	return diffMap;
 }
 
+/**
+ * Maps a bundled appearance item, as stored on the server and used for appearance update messages, into a full
+ * appearance item, as used by the game client
+ * @param {string} assetFamily - The asset family of the appearance item
+ * @param {AppearanceBundleItem} item - The bundled appearance item
+ * @returns {AppearanceItem} - A full appearance item representation of the provided bundled appearance item
+ */
 function ServerBundledItemToAppearanceItem(assetFamily, item) {
 	if (!item || typeof item !== "object" || typeof item.Name !== "string" || typeof item.Group !==
 	    "string") return null;
@@ -347,6 +369,13 @@ function ServerBundledItemToAppearanceItem(assetFamily, item) {
 	};
 }
 
+/**
+ * Parses an item color, based on the allowed colorable layers on an asset, and the asset's color schema
+ * @param {Asset} asset - The asset on which the color is set
+ * @param {string|string[]} color - The color value to parse
+ * @param {string[]} schema - The color schema to validate against
+ * @returns {string|string[]} - A parsed valid item color
+ */
 function ServerParseColor(asset, color, schema) {
 	if (Array.isArray(color)) {
 		if (color.length > asset.ColorableLayerCount) color = color.slice(0, asset.ColorableLayerCount);
@@ -356,6 +385,13 @@ function ServerParseColor(asset, color, schema) {
 	}
 }
 
+/**
+ * Populates an appearance diff map with any required items, to ensure that all asset groups are present that need to
+ * be.
+ * @param {string} assetFamily - The asset family for the appearance
+ * @param {AppearanceDiffMap} diffMap - The appearance diff map to populate
+ * @returns {void} - Nothing
+ */
 function ServerAddRequiredAppearance(assetFamily, diffMap) {
 	AssetGroup.forEach(group => {
 		// If it's not in the appearance category or is allowed to empty, return

--- a/BondageClub/Scripts/Server.js
+++ b/BondageClub/Scripts/Server.js
@@ -314,10 +314,9 @@ function ServerAppearanceLoadFromBundle(C, AssetFamily, Bundle, SourceMemberNumb
 		console.warn("Invalid appearance update bundle received. Updating with sanitized appearance.");
 		ChatRoomCharacterUpdate(C);
 	}
-	return appearance;
+	return { appearance, updateValid };
 }
 
-// TODO: JSDoc for all this stuff
 function ServerBuildAppearanceDiff(assetFamily, appearance, bundle) {
 	const diffMap = {};
 	appearance.forEach((item) => {

--- a/BondageClub/Scripts/Validation.js
+++ b/BondageClub/Scripts/Validation.js
@@ -248,7 +248,7 @@ function ValidationResolveModifyDiff(previousItem, newItem, params) {
  * @returns {string} - The warning message
  */
 function ValidationItemWarningMessage(item, { C, sourceMemberNumber }) {
-	return `${item.Asset.Name} on member number ${C.MemberNumber} by member number ${sourceMemberNumber} blocked`;
+	return `${item.Asset.Name} on member number ${C.IsNpc() ? C.Name : C.MemberNumber} by member number ${sourceMemberNumber || Player.MemberNumber} blocked`;
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR fixes errors that occur in the new appearance validation script with private room NPCs. Once I'd fixed the issue, it turned out that there was a minor issue with the definition for the `Nipples` asset group which means that NPCs are actually never populated with nipple assets, due to the group having `Default: false` set. I've accordingly fixed that issue, and added some additional logic into `PrivateLoadCharacter` to update the appearance of any existing private room NPCs whose appearance is invalid. I also added some JSDoc to `Server.js` that I intended to add in the original PR, but forgot about.