### PR TITLE
Feature: Display login queue position

### DIFF
--- a/BondageClub/Screens/Character/Login/Login.js
+++ b/BondageClub/Screens/Character/Login/Login.js
@@ -339,6 +339,15 @@ function LoginExtremeItemSettings() {
 	Player.HiddenItems = [];
 }
 
+/**
+ * Handles server response, when login has been queued
+ * @param {number} Pos The position in queue
+ */
+function LoginQueue(Pos) {
+	if (typeof Pos !== "number") return;
+
+	LoginMessage = TextGet("LoginQueueWait").replace("QUEUE_POS", Pos);
+}
 
 /**
  * Handles player login response data

--- a/BondageClub/Screens/Character/Login/Text_Login.csv
+++ b/BondageClub/Screens/Character/Login/Text_Login.csv
@@ -7,6 +7,7 @@ Language,Language
 CreateNewCharacter,Or create a new character
 NewCharacter,New Character
 ConnectingToServer,Connecting to server...
+LoginQueueWait,Waiting in queue on position: QUEUE_POS
 ErrorLoadingCharacterData,Error loading character data
 ErrorDisconnectedFromServer,Disconnected from server. Retrying...
 ErrorDuplicatedLogin,Disconnected for duplicated login

--- a/BondageClub/Screens/Character/Relog/Text_Relog.csv
+++ b/BondageClub/Screens/Character/Relog/Text_Relog.csv
@@ -5,6 +5,7 @@ Password,Password:
 LogBack,Log back
 GiveUp,Give up
 ValidatingNamePassword,Validating name and password...
+LoginQueueWait,Waiting in queue on position: QUEUE_POS
 InvalidNamePassword,Invalid name or password
 ErrorDisconnectedFromServer,Disconnected from server. Retrying...
 ErrorDuplicatedLogin,Disconnected for duplicated login

--- a/BondageClub/Scripts/Server.js
+++ b/BondageClub/Scripts/Server.js
@@ -33,6 +33,7 @@ function ServerInit() {
 	ServerSocket.on("ServerInfo", function (data) { ServerInfo(data); });
 	ServerSocket.on("CreationResponse", function (data) { CreationResponse(data); });
 	ServerSocket.on("LoginResponse", function (data) { LoginResponse(data); });
+	ServerSocket.on("LoginQueue", function (data) { LoginQueue(data); });
 	ServerSocket.on("ForceDisconnect", function (data) { ServerDisconnect(data, true); });
 	ServerSocket.on("ChatRoomSearchResult", function (data) { ChatSearchResultResponse(data); });
 	ServerSocket.on("ChatRoomSearchResponse", function (data) { ChatSearchResponse(data); });


### PR DESCRIPTION
Improvement for: [Server#78](https://github.com/Ben987/Bondage-Club-Server/pull/78)

Small change to display on which position the player is at the time the login was pressed. The position doesn't update and is meant mainly to notify players, that something is going on while they wait - that they are in queue. 