### PR TITLE
Bugfix: Validation typo fixes

### DIFF
--- a/BondageClub/Scripts/Validation.js
+++ b/BondageClub/Scripts/Validation.js
@@ -64,7 +64,7 @@ function ValidationResolveAppearanceDiff(previousItem, newItem, params) {
 	}
 	let { item, valid } = result;
 	// If the diff has resolved to an item, sanitize its properties
-	if (item) valid = valid && !ValidationSanitizeProperties(params.C, result);
+	if (item) valid = valid && !ValidationSanitizeProperties(params.C, item);
 	return { item, valid };
 }
 
@@ -592,7 +592,7 @@ function ValidationSanitizeLock(C, item) {
 
 	// Sanitize lockpicking seed
 	if (typeof property.LockPickSeed === "string") {
-		const seed = CommonConvertStringToArray(Item.Property.LockPickSeed);
+		const seed = CommonConvertStringToArray(property.LockPickSeed);
 		if (!seed.length) {
 			console.warn("Deleting invalid lockpicking seed: ", property.LockPickSeed);
 			delete property.LockPickSeed;


### PR DESCRIPTION
## Summary

I noticed that #2255 introduced an issue with validation where asset validation would not get properly run on appearance updates due to a refactoring error. This also fixes a bug with the validation of lockpick seeds for locks that define the `LockPickSeed` property.