### PR TITLE
Bugfix: Removes duplicated DefaultColor property

### DIFF
--- a/BondageClub/Assets/Female3DCG/Female3DCG.js
+++ b/BondageClub/Assets/Female3DCG/Female3DCG.js
@@ -2037,7 +2037,7 @@ var AssetFemale3DCG = [
 					{ Name: "Rings" },
 				]
 			},
-			{ Name: "LeatherCuffs", Fetish: ["Leather"], Priority: 29, Value: 100, Left: 0, Top: 0, Difficulty: 3, Time: 20, Random: false, AllowLock: true, DefaultColor: "#404040", AllowPose: ["BackBoxTie", "BackElbowTouch", "OverTheHead", "BackCuffs", "Yoked"], Effect: ["CuffedArms"], AllowEffect: ["Block", "Prone", "NotSelfPickable"], AllowType: ["Wrist", "Elbow", "Both"], Extended: true, HasType: false, RemoveItemOnRemove: [{ Name: "X-Cross", Group: "ItemDevices" }],
+			{ Name: "LeatherCuffs", Fetish: ["Leather"], Priority: 29, Value: 100, Left: 0, Top: 0, Difficulty: 3, Time: 20, Random: false, AllowLock: true, AllowPose: ["BackBoxTie", "BackElbowTouch", "OverTheHead", "BackCuffs", "Yoked"], Effect: ["CuffedArms"], AllowEffect: ["Block", "Prone", "NotSelfPickable"], AllowType: ["Wrist", "Elbow", "Both"], Extended: true, HasType: false, RemoveItemOnRemove: [{ Name: "X-Cross", Group: "ItemDevices" }],
 			  DefaultColor: ["#2E2E2E", "Default"],
 		      Layer: [
 				  { Name: "Cuffs" },

--- a/BondageClub/Tools/Node/AssetCheck_Types.js
+++ b/BondageClub/Tools/Node/AssetCheck_Types.js
@@ -48,7 +48,7 @@ const AssetType = {
 	BuyGroup: "String",
 	PrerequisiteBuyGroups: "[String]",
 	Effect: "[String]",
-	Bonus: "Maybe String",
+	Bonus: "String",
 	Block: "[String]",
 	Expose: "[String]",
 	Hide: "[String]",

--- a/BondageClub/Tools/Node/AssetCheck_Types.js
+++ b/BondageClub/Tools/Node/AssetCheck_Types.js
@@ -48,7 +48,7 @@ const AssetType = {
 	BuyGroup: "String",
 	PrerequisiteBuyGroups: "[String]",
 	Effect: "[String]",
-	Bonus: "[{ Factor: Number, Type: String }]",
+	Bonus: "Maybe String",
 	Block: "[String]",
 	Expose: "[String]",
 	Hide: "[String]",


### PR DESCRIPTION
Removes a duplicated `DefaultColor` property from `Female3DCG.js` that was probably missed when #2258 went in. Also adjusts the type of the `Bonus` property in the asset check script so that the script no longer fails, as noted by @jomshir98.