### PR TITLE
ChatRoomSync-Split: Replacement functions only

### DIFF
--- a/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
+++ b/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
@@ -1902,6 +1902,68 @@ function ChatRoomMessage(data) {
 }
 
 /**
+ * Adds a character into the chat room.
+ * @param {object} newCharacter - The new character to be added to the chat room.
+ * @param {object} newRawCharacter - The raw character data of the new character as it was received from the server.
+ * @returns {void} - Nothing
+ */
+function ChatRoomAddCharacterToChatRoom(newCharacter, newRawCharacter)
+{
+	if(newCharacter == null) { return; }
+	if(newRawCharacter == null) { return; }
+ 
+	// Update the chat room characters
+	let characterIndex = ChatRoomCharacter.findIndex(x => x.MemberNumber == newCharacter.MemberNumber)
+	if(characterIndex >= 0) // If we found an existing entry...
+	{
+		// Update it
+		ChatRoomCharacter[characterIndex] = newCharacter
+	}
+	else // If we didn't update existing data...
+	{
+		// Push a new entry
+		ChatRoomCharacter.push(newCharacter)
+	}
+	 
+	// Update chat room data backup
+	characterIndex = ChatRoomData.Character.findIndex(x => x.MemberNumber == newRawCharacter.MemberNumber)
+	if(characterIndex >= 0) // If we found an existing entry...
+	{
+		// Update it
+		ChatRoomData.Character[characterIndex] = newRawCharacter
+	}
+	else // If we didn't update existing data...
+	{
+		// Push a new entry
+		ChatRoomData.Character.push(newRawCharacter)
+	}
+ 
+}
+
+/**
+ * Handles the reception of the complete room data from the server.
+ * @param {object} data - Room object containing the updated chatroom data.
+ * @returns {boolean} - Returns true if the passed properties are valid and false if they're invalid.
+ */
+function ChatRoomValidateProperties(chatRoomProperties)
+{
+	let isValid = true
+
+	isValid &= chatRoomProperties != null && typeof chatRoomProperties === "object"
+	isValid &= chatRoomProperties.Name != null && typeof chatRoomProperties.Name === "string"
+	isValid &= chatRoomProperties.Description != null && typeof chatRoomProperties.Description === "string"
+	isValid &= Array.isArray(chatRoomProperties.Admin)
+	isValid &= Array.isArray(chatRoomProperties.Ban)
+	isValid &= chatRoomProperties.Background != null && typeof chatRoomProperties.Background === "string"
+	isValid &= chatRoomProperties.Limit != null && typeof chatRoomProperties.Limit === "number"
+	isValid &= chatRoomProperties.Locked != null && typeof chatRoomProperties.Locked === "boolean"
+	isValid &= chatRoomProperties.Private != null && typeof chatRoomProperties.Private === "boolean"
+	isValid &= Array.isArray(chatRoomProperties.BlockCategory)
+
+	return isValid;
+}
+
+/**
  * Handles the reception of the new room data from the server.
  * @param {object} data - Room object containing the updated chatroom data.
  * @returns {void} - Nothing.
@@ -1969,6 +2031,236 @@ function ChatRoomSync(data) {
 		// The allowed menu actions may have changed
 		ChatRoomMenuBuild();
 	}
+}
+
+
+/**
+ * Handles the reception of the character data of a single player from the server.
+ * @param {object} data - object containing the character's data.
+ * @returns {void} - Nothing.
+ */
+function ChatRoomSyncCharacter(data) {
+	if (data == null || (typeof data !== "object")) {
+		return;
+	}
+
+	const newCharacter = CharacterLoadOnline(data.Character, data.SourceMemberNumber)
+	ChatRoomAddCharacterToChatRoom(newCharacter, data.Character)
+		
+}
+
+/**
+ * Handles the reception of the character data of a newly joined player from the server.
+ * @param {object} data - object containing the joined character's data.
+ * @returns {void} - Nothing.
+ */
+function ChatRoomSyncMemberJoin(data) {
+	if (data == null || (typeof data !== "object")) {
+		return;
+	}
+
+	//Load the character to the chat room
+	const newCharacter = CharacterLoadOnline(data.Character, data.SourceMemberNumber)
+	ChatRoomAddCharacterToChatRoom(newCharacter, data.Character)
+	
+	// After Join Actions
+	if (ChatRoomNotificationRaiseChatJoin(newCharacter)) {
+		NotificationRaise(NotificationEventType.CHATJOIN, { characterName: newCharacter.Name });
+	}
+	if (ChatRoomLeashList.includes(newCharacter.MemberNumber)) {
+		// Ping to make sure they are still leashed
+		ServerSend("ChatRoomChat", { Content: "PingHoldLeash", Type: "Hidden", Target: newCharacter.MemberNumber });
+	}
+	// Check whether the player's last chatroom data needs updating
+	ChatRoomCheckForLastChatRoomUpdates();
+	// The allowed menu actions may have changed
+	ChatRoomMenuBuild();
+	
+}
+
+/**
+ * Handles the reception of the leave notification of a player from the server.
+ * @param {object} data - Room object containing the leaving character's member number.
+ * @returns {void} - Nothing.
+ */
+function ChatRoomSyncMemberLeave(data) {
+	if (data == null || (typeof data !== "object")) {
+		return;
+	}
+
+	// Remove the character
+	ChatRoomCharacter = ChatRoomCharacter.filter(x => x.MemberNumber != data.SourceMemberNumber)
+	ChatRoomData.Character = ChatRoomData.Character.filter(x => x.MemberNumber != data.SourceMemberNumber)
+
+	// Check whether the player's last chatroom data needs updating
+	ChatRoomCheckForLastChatRoomUpdates();
+
+	// The allowed menu actions may have changed
+	ChatRoomMenuBuild();
+
+}
+
+/**
+ * Handles the reception of the room properties from the server.
+ * @param {object} data - Room object containing the updated chatroom properties.
+ * @returns {void} - Nothing.
+ */
+function ChatRoomSyncRoomProperties(data) {
+	if (data == null || (typeof data !== "object")) {
+		return;
+	}
+	
+	if(ChatRoomValidateProperties(data) == false) // If the room data we received is invalid...
+	{
+		// Instantly leave the chat room again
+		DialogLentLockpicks = false;
+		ChatRoomClearAllElements();
+		ChatRoomSetLastChatRoom("")
+		ServerSend("ChatRoomLeave", "");
+		ChatSearchMessage = "ErrorInvalidRoomProperties"
+		CommonSetScreen("Online", "ChatSearch");
+		return;
+	}
+
+	// Copy the received properties to chat room data
+	for (let property in data) {
+		if (data.hasOwnProperty(property)) {
+			ChatRoomData[property] = data[property]
+		}
+	}
+
+	if (ChatRoomData.Game != null) ChatRoomGame = ChatRoomData.Game;
+
+	// Check whether the player's last chatroom data needs updating
+	ChatRoomCheckForLastChatRoomUpdates();
+
+	// Reloads the online game statuses if needed
+	OnlineGameLoadStatus();
+
+	// The allowed menu actions may have changed
+	ChatRoomMenuBuild();
+	
+}
+
+/**
+ * Handles the swapping of two players by a room administrator.
+ * @param {object} data - Object containing the member numbers of the swapped characters.
+ * @returns {void} - Nothing.
+ */
+function ChatRoomSyncSwapPlayers(data) {
+	if (data == null || (typeof data !== "object")) {
+		return;
+	}
+
+	// Update the chat room characters
+	let index1 = ChatRoomCharacter.findIndex(x => (x.MemberNumber == data.MemberNumber1))
+	let index2 = ChatRoomCharacter.findIndex(x => (x.MemberNumber == data.MemberNumber2))
+
+	if(index1 >= 0 && index2 >= 0) // If we found both characters to swap...
+	{
+		//Swap them
+		let bufferCharacter = ChatRoomCharacter[index1]
+		ChatRoomCharacter[index1] = ChatRoomCharacter[index2]
+		ChatRoomCharacter[index2] = bufferCharacter
+	}
+
+	// Update the chat room data backup
+	index1 = ChatRoomData.Character.findIndex(x => x.MemberNumber == data.MemberNumber1)
+	index2 = ChatRoomData.Character.findIndex(x => x.MemberNumber == data.MemberNumber2)
+
+	if(index1 >= 0 && index2 >= 0) // If we found both entries to swap...
+	{
+		//Swap them
+		let bufferCharacter = ChatRoomData.Character[index1]
+		ChatRoomData.Character[index1] = ChatRoomData.Character[index2]
+		ChatRoomData.Character[index2] = bufferCharacter
+	}
+	
+}
+
+/**
+ * Handles the moving of a player by a room administrator.
+ * @param {object} data - Object containing the member numbers of the swapped characters.
+ * @returns {void} - Nothing.
+ */
+function ChatRoomSyncMovePlayer(data) {
+	if (data == null || (typeof data !== "object")) {
+		return;
+	}
+
+	let moveOffset = 0
+	switch(data.Direction)
+	{
+		case "Left": moveOffset = -1; break;
+		case "Right": moveOffset = 1; break;
+		default: moveOffset = 0; break;
+	}
+
+	// Update the chat room characters
+	let index = ChatRoomCharacter.findIndex(x => x.MemberNumber == data.TargetMemberNumber)
+	if(index >= 0 && index < ChatRoomCharacter.length &&
+		index+moveOffset >= 0 && index+moveOffset < ChatRoomCharacter.length) // If we found the character to move and the moving is valid...
+	{
+		//Move it
+		let bufferCharacter = ChatRoomCharacter[index]
+		ChatRoomCharacter[index] = ChatRoomCharacter[index+moveOffset]
+		ChatRoomCharacter[index+moveOffset] = bufferCharacter
+	}
+
+	// Update the chat room data backup
+	index = ChatRoomData.Character.findIndex(x => x.MemberNumber == data.TargetMemberNumber)
+	if(index >= 0 && index < ChatRoomCharacter.length &&
+		index+moveOffset >= 0 && index+moveOffset < ChatRoomCharacter.length) // If we found the entry to move and the moving is valid...
+	{
+		//Move it
+		let bufferCharacter = ChatRoomData.Character[index]
+		ChatRoomData.Character[index] = ChatRoomData.Character[index+moveOffset]
+		ChatRoomData.Character[index+moveOffset] = bufferCharacter
+	}
+
+}
+
+/**
+ * Handles the swapping of two players by a room administrator.
+ * @param {object} data - Object containing the member numbers of the swapped characters.
+ * @returns {void} - Nothing.
+ */
+function ChatRoomSyncReorderPlayers(data) {
+	if (data == null || (typeof data !== "object")) {
+		return;
+	}
+
+	let newChatRoomCharacter = []
+	let newChatRoomDataCharacter = []
+	let index = 0
+
+	for(let i=0; i<data.PlayerOrder.length; i++) // For every player to reorder...
+	{
+		//Chat Room Characters
+		index = ChatRoomCharacter.findIndex(x => x.MemberNumber == data.PlayerOrder[i])
+		newChatRoomCharacter.push(ChatRoomCharacter.splice(index, 1)[0])
+
+		//Chat Room Data Backup
+		index = ChatRoomData.Character.findIndex(x => x.MemberNumber == data.PlayerOrder[i])
+		newChatRoomDataCharacter.push(ChatRoomData.Character.splice(index, 1)[0])
+
+	}
+
+	if(ChatRoomCharacter.length > 0) // If we forgot about some characters for some reason...
+	{
+		//Push the missed entries to the end
+		Array.prototype.push.apply(newChatRoomCharacter, ChatRoomCharacter)
+	}
+	if(ChatRoomData.Character.length > 0) // If we forgot about some entries for some reason...
+	{
+		//Push the missed entries to the end
+		Array.prototype.push.apply(newChatRoomDataCharacter, ChatRoomData.Character)
+	}
+
+	//Update the origin arrays
+	ChatRoomCharacter = newChatRoomCharacter
+	ChatRoomData.Character = newChatRoomDataCharacter
+	
 }
 
 /**


### PR DESCRIPTION
Even though this PR includes all the functions introduced in #2253, it does not enable them for usage yet. For this purpose, seperate pull requests will be opened. This is to make testing the individual functions easier as requested by @Ben987.
The same has been done with the related Server PR [#76](https://github.com/Ben987/Bondage-Club-Server/pull/76), which got split as described in [#79](https://github.com/Ben987/Bondage-Club-Server/pull/79).

The usage of each function can be enabled with it's respective Client and Server PR:
- **ChatRoomSyncCharacter** - Client: #2273 Server: [#80](https://github.com/Ben987/Bondage-Club-Server/pull/80)
- **ChatRoomSyncMemberJoin** - Client: #2274 Server: [#81](https://github.com/Ben987/Bondage-Club-Server/pull/81)
- **ChatRoomSyncMemberLeave** - Client: #2275 Server: [#82](https://github.com/Ben987/Bondage-Club-Server/pull/82)
- **ChatRoomSyncRoomProperties** - Client: #2276 Server: [#83](https://github.com/Ben987/Bondage-Club-Server/pull/83)
- **ChatRoomSyncSwapPlayers** - Client: #2277 Server: [#84](https://github.com/Ben987/Bondage-Club-Server/pull/84)
- **ChatRoomSyncMovePlayer** - Client: #2278 Server: [#85](https://github.com/Ben987/Bondage-Club-Server/pull/85)
- **ChatRoomSyncReorderPlayers** - Client: #2279 Server: [#86](https://github.com/Ben987/Bondage-Club-Server/pull/86)


**As this is the major part of the split of #2253 in smaller PRs, i'll duplicate it's description here to make it easier to keep an overview over the total functionality**

> This PR splits ChatRoomSync up into multiple, functions with reduced overhead each. This way, lots of chat room operations will result in much smaller message transfers, reducing the transfer time especially in chat rooms with many players.
> 
> **This PR requires the server PR [ #76](https://github.com/Ben987/Bondage-Club-Server/pull/76) to work.** The server PR also takes care of the compatibility with older clients without this change which would be the case during beta.
> 
> **Edit - Important Note:** Is is possible that during beta the Server performance actually drops a bit. This is because the server's workaround to ensure compatibility with non-beta players is a bit more costy. This effect, however, should reduce as the beta link spreads around as it usually does.
> 
> ### New functions
> **ChatRoomSync:**
> This one still exists and is used to send all chatroom related data to newly entering players. This, however, is it's only usage right now and it only is called for the entering players and noone else. This function now also makes sure the transferred chat room properties are valid.
> 
> **ChatRoomSyncCharacter:**
> This function is used for single character updates. If lovers/owner data is changed, we only need to update one(the newly owned sub) or two(the newly engaged lovers) characters. This could further split up in the future to reduce the payload further but since it's only called on special occations i assumed no high impact on performance and kept it like this to have it more reusable for future changes.
> 
> **ChatRoomSyncMemberJoin:**
> This one basically does the same as _ChatRoomSyncCharacter_. It sends the character data of a newly joined player to everyone already in the room. The decission why i put this into a seperate function is to make new joins distinct from simple updates. The updated data might change in the future. This also helped to remove a hack to detect newly joined players in  _ChatRoomSyncCharacter_ and instead perform the required actions in this function.
> 
> **ChatRoomSyncMemberLeave:**
> When a player leaves a chat room, instead of resending the whole chat room data, only the member number of the leaving player is sent. The clients then remove the related player from their ChatRoomCharacters and ChatRoomData.Characters arrays themselves instead of updating them completely.
> 
> **ChatRoomSyncRoomProperties:**
> This one is used to update the chat room properties after they got changed by a room administrator. Character data is not send along. This function also makes sure the transferred properties are valid.
> 
> **ChatRoomSyncSwapPlayers:**
> This is called when a room administrator swaps two players within a chat room. It just sends the member numbers of both swapped characters and the clients reorder their ChatRoomCharacters and ChatRoomData.Characters arrays themselves.
> The server still also does this swap to ensure the order is the same for newly joined players.
> 
> **ChatRoomSyncMovePlayer:**
> Like _ChatRoomSyncSwapPlayers_. However, instead of sending two member numbers, here the member number of the moved player and the direction as a string is transferred ("Left" or "Right").
> 
> **ChatRoomSyncReorderPlayers:**
> This function is used in LARP battles when the players within a chat room are shuffled at the start of the game. It sends an array with the member numbers of all players in the chat room in the new order. Just like with _ChatRoomSyncSwapPlayers_ and _ChatRoomSyncMovePlayer_, the clients reorder on basis of this array their ChatRoomCharacters and ChatRoomData.Characters arrays themselves
> 
> ### Tests
> Since this PR changes a critical part of the game (that was used for a lot of different features), thorough testing is a necessity. And even though i already tested this a lot, i want to encourage reviewers to try and break this change as much as they can to discover every possible oversight i might have made.
> 
> **Things i already tested:**
> - Beta players joining and leaving rooms with beta and non-beta characters
> - Non-Beta players joining and leaving rooms with beta and non-beta characters
> - Moving and swapping players with both, beta and non-beta players in the room
> - Changing room properties with both, beta and non-beta players in the room
> - Creating new rooms with with beta and non-beta players
> - Starting a larp game with beta and non-beta players to confirm the shuffling still works
> - Offering and accepting a trial period as submissive and confirming all beta and non-beta players in the room get the update
> - Offering and accepting a lovers request and confirming all beta and non-beta players in the room get the update
> - Breaking up with a lover and confirming all beta and non-beta players in a room with the other lover as well as the lover herself gets the update
> 
> **Edit - More Tests:**
> - Kicking beta and non-beat players with other beta and non-beta players in the room
> - Banning present beta and non-beta players in the with other beta and non-beta players in the room
> - Banning not present beta and non-beta players in the with other beta and non-beta players in the room
> - Unbanning beta and non-beta players in the with other beta and non-beta players in the room
> 
> All the tests showed the intended behaviour
