### PR TITLE
Virtual reality fix with light sensory deprivation

### DIFF
--- a/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
+++ b/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
@@ -547,7 +547,7 @@ function ChatRoomDrawCharacter(DoClick) {
 	// The number of characters to show in the room
 	const RenderSingle = Player.GameplaySettings.SensDepChatLog == "SensDepExtreme" && Player.GameplaySettings.BlindDisableExamine && Player.GetBlindLevel() >= 3 && !Player.Effect.includes("VRAvatars");
 	var ChatRoomCharacterTemp = ChatRoomCharacter
-	if (Player.Effect.includes("VRAvatars")) {
+	if (Player.Effect.includes("VRAvatars") && Player.GameplaySettings.SensDepChatLog != "SensDepLight") {
 		ChatRoomCharacterTemp = []
 		for (let CC = 0; CC < ChatRoomCharacter.length; CC++) {
 			if (ChatRoomCharacter[CC].Effect.includes("VRAvatars")) {


### PR DESCRIPTION
Current behavior: Being on Light sensory deprivation settings causes you to be able to see the whole chat room. There is a bug where you can't see anyone but those wearing VR headsets even if you are on Light, which goes against the purpose of Light mode.

Fix: Make it so that all players get drawn regardless of VR status when player is in Light sensory deprivation mode