### PR TITLE
Prevents MiniGameReturnFunction from being called until drawing is done

### DIFF
--- a/BondageClub/Screens/MiniGame/GetUp/GetUp.js
+++ b/BondageClub/Screens/MiniGame/GetUp/GetUp.js
@@ -85,7 +85,6 @@ function GetUpRun() {
 		MiniGameTimer = Math.min(CommonTime() + 750, MiniGameTimer)
 		MiniGameVictory = false
 	}
-	if (Time >= MiniGameTimer + 750) CommonDynamicFunction(MiniGameReturnFunction + "()"); 
 
 
 	DrawProgressBar(500 - GetUpMaxPosition, 500, 2*GetUpMaxPosition, 50, 50*((GetUpPosition + GetUpMaxPosition)/GetUpMaxPosition));
@@ -103,6 +102,9 @@ function GetUpRun() {
 		}
 	}
 	DrawText(GetUpText, 500, 977, "white", "black");
+	
+	
+	if (Time >= MiniGameTimer + 750) CommonDynamicFunction(MiniGameReturnFunction + "()"); 
 	
 }
 


### PR DESCRIPTION
May potentially fix an issue where the minigame return function is called, causing TextGet calls later on to fail.