### PR TITLE
Change: Allow Asylum chat access without being committed

### DIFF
--- a/BondageClub/Screens/Room/AsylumEntrance/AsylumEntrance.js
+++ b/BondageClub/Screens/Room/AsylumEntrance/AsylumEntrance.js
@@ -12,6 +12,14 @@ var AsylumEntranceEscapedPatientWillJoin = false;
  */
 function AsylumEntranceCanWander() { return (Player.CanWalk() && ((LogValue("Committed", "Asylum") >= CurrentTime) || ((ReputationGet("Asylum") >= 1) && AsylumEntranceIsWearingNurseClothes(Player)))) }
 /**
+ * Checks, if the player is able to enter asylum chatrooms
+ * Requiers player to be either patient or nurse and is wearing clothes (doesn't have to be commited patient)
+ * @returns {boolean} - Returns true, if the player is able to leave, false otherwise
+ */
+function AsylumEntranceCanAccessChatrooms() {
+	return AsylumEntranceCanWander() || Player.CanWalk() && ReputationGet("Asylum") != 0 && (AsylumEntranceIsWearingNurseClothes() || AsylumEntranceIsWearingPatientClothes());
+}
+/**
  * Checks, if the player can bring the nurse to her private room
  * @returns {boolean} - Returns true, if the player can drag the nurse to her private roo, false otherwise
  */
@@ -50,7 +58,7 @@ function AsylumEntranceRun() {
 	DrawCharacter(AsylumEntranceNurse, 1000, 0, 1);
 	if (Player.CanWalk() && (LogValue("Committed", "Asylum") < CurrentTime)) DrawButton(1885, 25, 90, 90, "", "White", "Icons/Exit.png", TextGet("Exit"));
 	DrawButton(1885, 145, 90, 90, "", "White", "Icons/Character.png", TextGet("Profile"));
-	if (AsylumEntranceCanWander()) DrawButton(1885, 265, 90, 90, "", "White", "Icons/Chat.png", TextGet("ChatRoom"));
+	if (AsylumEntranceCanAccessChatrooms()) DrawButton(1885, 265, 90, 90, "", "White", "Icons/Chat.png", TextGet("ChatRoom"));
 	if (AsylumEntranceCanWander()) DrawButton(1885, 385, 90, 90, "", "White", "Icons/Bedroom.png", TextGet("Bedroom"));
 	if (AsylumEntranceCanWander()) DrawButton(1885, 505, 90, 90, "", "White", "Icons/FriendList.png", TextGet("Meeting"));
 	if (AsylumEntranceCanWander()) DrawButton(1885, 625, 90, 90, "", "White", "Icons/Therapy.png", TextGet("Therapy"));
@@ -75,7 +83,7 @@ function AsylumEntranceClick() {
 	}
 	if (MouseIn(1885, 25, 90, 90) && Player.CanWalk() && (LogValue("Committed", "Asylum") < CurrentTime)) CommonSetScreen("Room", "MainHall");
 	if (MouseIn(1885, 145, 90, 90)) InformationSheetLoadCharacter(Player);
-	if (MouseIn(1885, 265, 90, 90) && AsylumEntranceCanWander()) AsylumEntranceStartChat();
+	if (MouseIn(1885, 265, 90, 90) && AsylumEntranceCanAccessChatrooms()) AsylumEntranceStartChat();
 	if (MouseIn(1885, 385, 90, 90) && AsylumEntranceCanWander()) CommonSetScreen("Room", "AsylumBedroom");
 	if (MouseIn(1885, 505, 90, 90) && AsylumEntranceCanWander()) CommonSetScreen("Room", "AsylumMeeting");
 	if (MouseIn(1885, 625, 90, 90) && AsylumEntranceCanWander()) CommonSetScreen("Room", "AsylumTherapy");

--- a/BondageClub/Screens/Room/AsylumEntrance/Dialog_NPC_AsylumEntrance_Nurse.csv
+++ b/BondageClub/Screens/Room/AsylumEntrance/Dialog_NPC_AsylumEntrance_Nurse.csv
@@ -32,6 +32,8 @@ ClubSlave,,(Leave her.),,DialogLeave(),
 20,0,Let me think about it.,Of course.  Do you need anything else?,,
 21,22,I accept to be locked down.,"(She grins.)  Perfect!  First thing first, you need to change and wear patient clothes.",,!Player.IsRestrained()
 21,0,I accept to be locked down.,"(She grins.)  Perfect!  But you need to get out of these restraints first.  Go get a maid to help you, I'm busy.",,Player.IsRestrained()
+21,26,I would just like the clothes.,"(She smiles.)  That's fine too. Would you like me to help you change?",,!Player.IsRestrained()
+21,0,I would just like the clothes.,"(She smiles.)  That's fine too. But you need to get out of these restraints first.  Go get a maid to help you, I'm busy.",,Player.IsRestrained()
 21,0,Let me think about it.,Of course.  Do you need anything else?,,
 22,23,I'm already dressed like that.,(She nods.) For how long you wish to commit yourself?,,IsWearingPatientClothes()
 22,23,Can you help me to change?,I certainly can.  (She helps you to get dressed as a patient.)  For how long you wish to commit yourself?,"WearPatientClothes(""Player"")",!IsWearingPatientClothes()
@@ -44,6 +46,8 @@ ClubSlave,,(Leave her.),,DialogLeave(),
 24,25,Where do I start?,"By wearing this.  (She straps a straitjacket on you.)  Patients like you must be kept under control.  Now carry on, you know the place.","PlayerJacket(""Normal"")","DialogReputationLess(""Asylum"", -50)"
 24,25,Here we go again.,"You know the drill.  (She straps a straitjacket on you.)  Patients like you must be kept under control.  Now carry on, you know the place.","PlayerJacket(""Normal"")","DialogReputationLess(""Asylum"", -50)"
 25,0,Thanks.  (Leave her.),,DialogLeave(),
+26,0,"Yes, please.",Here you go.  (She helps you to get dressed as a patient.) Do you need anything else?,"WearPatientClothes(""Player"")",
+26,0,"No, I changed my mind.",Of course.  Do you need anything else?,,
 30,31,"Yes, I want to transfer from patient to nurse.",Perfect!  We need staff to take care of our patients.  Are you ready to work now?,,
 30,0,Let me think about it.,Of course.  Do you need anything else?,,
 31,32,I'm ready to work right now.,"Great!  But before you enter, you must wear the nurse uniform.",,!Player.IsRestrained()


### PR DESCRIPTION
This changes asylum chatroom access for patients.
You no longer need to be committed patient to access the rooms, having proper clothing is enough.
( But you must have non-zero reputation, so you must have commited yourself in the past )
Also adds dialog option to get clothes from nurse without committing yourself.

Reason:
Currently the Asylum is almost dead. If attempting to enter it didn't lock you up for 15 minutes, maybe more people would try to do so.