### PR TITLE
Bugfix: Fixes casing for asset paths in the Kinky Dungeon minigame

### DIFF
--- a/BondageClub/Screens/MiniGame/KinkyDungeon/KinkyDungeonDraw.js
+++ b/BondageClub/Screens/MiniGame/KinkyDungeon/KinkyDungeonDraw.js
@@ -70,7 +70,7 @@ function KinkyDungeonDrawGame() {
 						else if (rows[R+CamY][X+CamX] == "S") sprite = "StairsUp"
 						else if (rows[R+CamY][X+CamX] == "s") sprite = "StairsDown"
 							
-						DrawImageZoomCanvas("Screens/Minigame/KinkyDungeon/Floor" + KinkyDungeonMapIndex[MiniGameKinkyDungeonCheckpoint] + "/" + sprite + ".png", KinkyDungeonContext, 0, 0, KinkyDungeonSpriteSize, KinkyDungeonSpriteSize, X*KinkyDungeonGridSizeDisplay, R*KinkyDungeonGridSizeDisplay, KinkyDungeonGridSizeDisplay, KinkyDungeonGridSizeDisplay, false)
+						DrawImageZoomCanvas("Screens/MiniGame/KinkyDungeon/Floor" + KinkyDungeonMapIndex[MiniGameKinkyDungeonCheckpoint] + "/" + sprite + ".png", KinkyDungeonContext, 0, 0, KinkyDungeonSpriteSize, KinkyDungeonSpriteSize, X*KinkyDungeonGridSizeDisplay, R*KinkyDungeonGridSizeDisplay, KinkyDungeonGridSizeDisplay, KinkyDungeonGridSizeDisplay, false)
 					}
 				}
 				
@@ -120,12 +120,12 @@ function KinkyDungeonDrawGame() {
 					
 					if (KinkyDungeonSpellValid)
 						if (KinkyDungeonTargetingSpell.projectile)
-							DrawImageZoomCanvas("Screens/Minigame/KinkyDungeon/Target.png",
+							DrawImageZoomCanvas("Screens/MiniGame/KinkyDungeon/Target.png",
 								KinkyDungeonContext, 0, 0, KinkyDungeonSpriteSize, KinkyDungeonSpriteSize,
 								(KinkyDungeonMoveDirection.x + KinkyDungeonPlayerEntity.x - CamX)*KinkyDungeonGridSizeDisplay, (KinkyDungeonMoveDirection.y + KinkyDungeonPlayerEntity.y - CamY)*KinkyDungeonGridSizeDisplay,
 								KinkyDungeonGridSizeDisplay, KinkyDungeonGridSizeDisplay, false)
 						else
-							DrawImageZoomCanvas("Screens/Minigame/KinkyDungeon/Target.png",
+							DrawImageZoomCanvas("Screens/MiniGame/KinkyDungeon/Target.png",
 								KinkyDungeonContext, 0, 0, KinkyDungeonSpriteSize, KinkyDungeonSpriteSize,
 								(KinkyDungeonTargetX - CamX)*KinkyDungeonGridSizeDisplay, (KinkyDungeonTargetY - CamY)*KinkyDungeonGridSizeDisplay,
 								KinkyDungeonGridSizeDisplay, KinkyDungeonGridSizeDisplay, false)	
@@ -177,18 +177,18 @@ function KinkyDungeonDrawGame() {
 				MainCanvas.textAlign = "center";
 				
 				var i = 1
-				DrawButton(x, y, ButtonWidth, ButtonWidth, "", "White", "Screens/Minigame/KinkyDungeon/Struggle.png", "");
+				DrawButton(x, y, ButtonWidth, ButtonWidth, "", "White", "Screens/MiniGame/KinkyDungeon/Struggle.png", "");
 				if (!sg.blocked) {
 					var toolSprite = (sg.lock != "") ? ((sg.lock != "Jammed") ? "Key" : "LockJam") : "Buckle"
-					DrawButton(x + ((!sg.left) ? -(ButtonWidth)*i : (ButtonWidth)*i), y, ButtonWidth, ButtonWidth, "", "White", "Screens/Minigame/KinkyDungeon/" + toolSprite + ".png", ""); i++;
-					if (KinkyDungeonLockpicks > 0 && sg.lock != "") {DrawButton(x + ((!sg.left) ? -(ButtonWidth)*i : (ButtonWidth)*i), y, ButtonWidth, ButtonWidth, "", "White", "Screens/Minigame/KinkyDungeon/UseTool.png", ""); i++;}
-					if (KinkyDungeonNormalBlades > 0 || KinkyDungeonEnchantedBlades > 0) {DrawButton(x + ((!sg.left) ? -(ButtonWidth)*i : (ButtonWidth)*i), y, ButtonWidth, ButtonWidth, "", "White", "Screens/Minigame/KinkyDungeon/Cut.png", ""); i++;}
+					DrawButton(x + ((!sg.left) ? -(ButtonWidth)*i : (ButtonWidth)*i), y, ButtonWidth, ButtonWidth, "", "White", "Screens/MiniGame/KinkyDungeon/" + toolSprite + ".png", ""); i++;
+					if (KinkyDungeonLockpicks > 0 && sg.lock != "") {DrawButton(x + ((!sg.left) ? -(ButtonWidth)*i : (ButtonWidth)*i), y, ButtonWidth, ButtonWidth, "", "White", "Screens/MiniGame/KinkyDungeon/UseTool.png", ""); i++;}
+					if (KinkyDungeonNormalBlades > 0 || KinkyDungeonEnchantedBlades > 0) {DrawButton(x + ((!sg.left) ? -(ButtonWidth)*i : (ButtonWidth)*i), y, ButtonWidth, ButtonWidth, "", "White", "Screens/MiniGame/KinkyDungeon/Cut.png", ""); i++;}
 				}
 			}
 
 		if (KinkyDungeonStruggleGroups.length > 0) {
-			if (KinkyDungeonDrawStruggle) DrawButton(510, 925, 120, 60, "", "White", "Screens/Minigame/KinkyDungeon/HideTrue.png", "");
-			else DrawButton(510, 925, 120, 60, "", "White", "Screens/Minigame/KinkyDungeon/HideFalse.png", "");
+			if (KinkyDungeonDrawStruggle) DrawButton(510, 925, 120, 60, "", "White", "Screens/MiniGame/KinkyDungeon/HideTrue.png", "");
+			else DrawButton(510, 925, 120, 60, "", "White", "Screens/MiniGame/KinkyDungeon/HideFalse.png", "");
 		}
 		
 		//DrawButton(650, 925, 250, 60, TextGet("KinkyDungeonInventory"), "White", "", "");
@@ -198,19 +198,19 @@ function KinkyDungeonDrawGame() {
 			var spell = KinkyDungeonSpells[KinkyDungeonSpellChoices[0]]
 			DrawText(TextGet("KinkyDungeonSpell"+ spell.name), 1275, 835, color, "silver")
 			DrawText("(" + Math.ceil(KinkyDungeonGetCost(spell.level)) + ")", 1275, 870, color, "silver")
-			DrawButton(1230, 895, 90, 90, "", "White", "Screens/Minigame/KinkyDungeon/Spell1.png", "");
+			DrawButton(1230, 895, 90, 90, "", "White", "Screens/MiniGame/KinkyDungeon/Spell1.png", "");
 		}
 		if (KinkyDungeonSpells[KinkyDungeonSpellChoices[1]]) {
 			var spell = KinkyDungeonSpells[KinkyDungeonSpellChoices[1]]
 			DrawText(TextGet("KinkyDungeonSpell"+ spell.name), 1525, 835, color, "silver")
 			DrawText("(" + Math.ceil(KinkyDungeonGetCost(spell.level)) + ")", 1525, 870, color, "silver")
-			DrawButton(1480, 895, 90, 90, "", "White", "Screens/Minigame/KinkyDungeon/Spell2.png", "");
+			DrawButton(1480, 895, 90, 90, "", "White", "Screens/MiniGame/KinkyDungeon/Spell2.png", "");
 		}
 		if (KinkyDungeonSpells[KinkyDungeonSpellChoices[2]]) {
 			var spell = KinkyDungeonSpells[KinkyDungeonSpellChoices[2]]
 			DrawText(TextGet("KinkyDungeonSpell"+ spell.name), 1775, 835, color, "silver")
 			DrawText("(" + Math.ceil(KinkyDungeonGetCost(spell.level)) + ")", 1775, 870, color, "silver")
-			DrawButton(1730, 895, 90, 90, "", "White", "Screens/Minigame/KinkyDungeon/Spell3.png", "");
+			DrawButton(1730, 895, 90, 90, "", "White", "Screens/MiniGame/KinkyDungeon/Spell3.png", "");
 		}
 	} else if (KinkyDungeonDrawState == "Magic") {
 		DrawButton(925, 925, 250, 60, TextGet("KinkyDungeonGame"), "White", "", "");

--- a/BondageClub/Screens/MiniGame/KinkyDungeon/KinkyDungeonEnemies.js
+++ b/BondageClub/Screens/MiniGame/KinkyDungeon/KinkyDungeonEnemies.js
@@ -36,13 +36,13 @@ function KinkyDungeonDrawEnemies(canvasOffsetX, canvasOffsetY, CamX, CamY) {
 		var enemy = KinkyDungeonEntities[E]
 		var sprite = enemy.Enemy.name
 		if (KinkyDungeonEntities[E].x >= CamX && KinkyDungeonEntities[E].y >= CamY && KinkyDungeonEntities[E].x < CamX + KinkyDungeonGridWidthDisplay && KinkyDungeonEntities[E].y < CamY + KinkyDungeonGridHeightDisplay) {
-			DrawImageZoomCanvas("Screens/Minigame/KinkyDungeon/Enemies/" + sprite + ".png",
+			DrawImageZoomCanvas("Screens/MiniGame/KinkyDungeon/Enemies/" + sprite + ".png",
 				KinkyDungeonContext, 0, 0, KinkyDungeonSpriteSize, KinkyDungeonSpriteSize,
 				(KinkyDungeonEntities[E].x - CamX)*KinkyDungeonGridSizeDisplay, (KinkyDungeonEntities[E].y - CamY)*KinkyDungeonGridSizeDisplay,
 				KinkyDungeonGridSizeDisplay, KinkyDungeonGridSizeDisplay, false)
 				
 			if (enemy.stun > 0) {
-				DrawImageZoomCanvas("Screens/Minigame/KinkyDungeon/Stun.png",
+				DrawImageZoomCanvas("Screens/MiniGame/KinkyDungeon/Stun.png",
 					KinkyDungeonContext, 0, 0, KinkyDungeonSpriteSize, KinkyDungeonSpriteSize,
 					(KinkyDungeonEntities[E].x - CamX)*KinkyDungeonGridSizeDisplay, (KinkyDungeonEntities[E].y - CamY)*KinkyDungeonGridSizeDisplay,
 					KinkyDungeonGridSizeDisplay, KinkyDungeonGridSizeDisplay, false)
@@ -64,7 +64,7 @@ function KinkyDungeonDrawEnemiesWarning(canvasOffsetX, canvasOffsetY, CamX, CamY
 				var tx = enemy.x + enemy.warningTiles[T].x
 				var ty = enemy.y + enemy.warningTiles[T].y
 				if (tx >= CamX && ty >= CamY && tx < CamX + KinkyDungeonGridWidthDisplay && ty < CamY + KinkyDungeonGridHeightDisplay && KinkyDungeonNoEnemy(tx, ty) && KinkyDungeonMovableTilesEnemy.includes(KinkyDungeonMapGet(tx, ty))) {
-					DrawImageZoomCanvas("Screens/Minigame/KinkyDungeon/Warning.png",
+					DrawImageZoomCanvas("Screens/MiniGame/KinkyDungeon/Warning.png",
 						KinkyDungeonContext, 0, 0, KinkyDungeonSpriteSize, KinkyDungeonSpriteSize,
 						(tx - CamX)*KinkyDungeonGridSizeDisplay, (ty - CamY)*KinkyDungeonGridSizeDisplay,
 						KinkyDungeonGridSizeDisplay, KinkyDungeonGridSizeDisplay, false)

--- a/BondageClub/Screens/MiniGame/KinkyDungeon/KinkyDungeonFight.js
+++ b/BondageClub/Screens/MiniGame/KinkyDungeon/KinkyDungeonFight.js
@@ -184,7 +184,7 @@ function KinkyDungeonDrawFight(canvasOffsetX, canvasOffsetY, CamX, CamY) {
 			
 		}
 		
-		var Img = DrawGetImage("Screens/Minigame/KinkyDungeon/Bullets/" + sprite + ".png", 0, 0)
+		var Img = DrawGetImage("Screens/MiniGame/KinkyDungeon/Bullets/" + sprite + ".png", 0, 0)
 		
 		var spriteContext = spriteCanvas.getContext("2d")
 		var direction = Math.atan2(KinkyDungeonBullets[E].vy, KinkyDungeonBullets[E].vx)

--- a/BondageClub/Screens/MiniGame/KinkyDungeon/KinkyDungeonItem.js
+++ b/BondageClub/Screens/MiniGame/KinkyDungeon/KinkyDungeonItem.js
@@ -56,7 +56,7 @@ function KinkyDungeonDrawItems(canvasOffsetX, canvasOffsetY, CamX, CamY) {
 		var item = KinkyDungeonGroundItems[E]
 		var sprite = item.name
 		if (KinkyDungeonGroundItems[E].x >= CamX && KinkyDungeonGroundItems[E].y >= CamY && KinkyDungeonGroundItems[E].x < CamX + KinkyDungeonGridWidthDisplay && KinkyDungeonGroundItems[E].y < CamY + KinkyDungeonGridHeightDisplay) {
-			DrawImageZoomCanvas("Screens/Minigame/KinkyDungeon/Items/" + sprite + ".png",
+			DrawImageZoomCanvas("Screens/MiniGame/KinkyDungeon/Items/" + sprite + ".png",
 				KinkyDungeonContext, 0, 0, KinkyDungeonSpriteSize, KinkyDungeonSpriteSize,
 				(KinkyDungeonGroundItems[E].x - CamX)*KinkyDungeonGridSizeDisplay, (KinkyDungeonGroundItems[E].y - CamY)*KinkyDungeonGridSizeDisplay,
 				KinkyDungeonGridSizeDisplay, KinkyDungeonGridSizeDisplay, false)

--- a/BondageClub/Screens/MiniGame/KinkyDungeon/KinkyDungeonMagic.js
+++ b/BondageClub/Screens/MiniGame/KinkyDungeon/KinkyDungeonMagic.js
@@ -271,7 +271,7 @@ function KinkyDungeonTestWhite(x) {
 };
 
 function KinkyDungeonDrawMagic() {
-	DrawImageZoomCanvas("Screens/Minigame/KinkyDungeon/MagicBook.png", MainCanvas, 0, 0, 640, 483, canvasOffsetX, canvasOffsetY, 640*KinkyDungeonBookScale, 483*KinkyDungeonBookScale, false)
+	DrawImageZoomCanvas("Screens/MiniGame/KinkyDungeon/MagicBook.png", MainCanvas, 0, 0, 640, 483, canvasOffsetX, canvasOffsetY, 640*KinkyDungeonBookScale, 483*KinkyDungeonBookScale, false)
 	
 	if (KinkyDungeonSpells[KinkyDungeonCurrentPage]) {
 		var spell = KinkyDungeonSpells[KinkyDungeonCurrentPage]


### PR DESCRIPTION
## Summary

The Kinky Dungeon was using `Minigame` instead of `MiniGame` in asset paths, resulting in 404 errors when trying to load assets.