### PR TITLE
Bugfix: Fixes incorrect appearance update rollbacks

### DIFF
--- a/BondageClub/Scripts/Validation.js
+++ b/BondageClub/Scripts/Validation.js
@@ -206,7 +206,7 @@ function ValidationResolveModifyDiff(previousItem, newItem, params) {
 	if (!ValidationCanAddItem(newItem, params)) {
 		const warningSuffix = ValidationItemWarningMessage(previousItem, params);
 		// Block changing the color of non-clothing appearance items/cosplay items if the target does not permit that
-		if (newItem.Color !== previousItem.Color) {
+		if (!CommonColorsEqual(newItem.Color, previousItem.Color)) {
 			console.warn(`Invalid modification of color for item ${warningSuffix}`);
 			newItem.Color = previousItem.Color;
 			valid = false;


### PR DESCRIPTION
## Summary

There was an error in `Validation.js` where item colors were being compared incorrectly, resulting in rollbacks for valid appearance updates (see screenshot), especially when cosplay/body items were multi-colored. This uses a more complete comparison for item colors which should prevent these false alarms.

![Validation reports](https://cdn.discordapp.com/attachments/830485218276147222/830506952257568828/unknown.png)