### PR TITLE
Custom Tag Regex Fix

### DIFF
--- a/BondageClub/Screens/Inventory/ItemNeckAccessories/CustomCollarTag.js/CustomCollarTag.js
+++ b/BondageClub/Screens/Inventory/ItemNeckAccessories/CustomCollarTag.js/CustomCollarTag.js
@@ -1,5 +1,5 @@
 "use strict";
-var InventoryItemNeckAccessoriesCustomCollarTagAllowedChars = /^[a-zA-Z0-9 ~!]*$/gm;
+var InventoryItemNeckAccessoriesCustomCollarTagAllowedChars = /^[a-zA-Z0-9 ~!]*$/m;
 // Loads the item extension properties
 function InventoryItemNeckAccessoriesCustomCollarTagLoad() {
     var C = CharacterGetCurrent();

--- a/BondageClub/Screens/Inventory/ItemNeckAccessories/CustomCollarTag.js/CustomCollarTag.js
+++ b/BondageClub/Screens/Inventory/ItemNeckAccessories/CustomCollarTag.js/CustomCollarTag.js
@@ -1,5 +1,5 @@
 "use strict";
-var InventoryItemNeckAccessoriesCustomCollarTagAllowedChars = /^[a-zA-Z0-9 ~!]*$/m;
+var InventoryItemNeckAccessoriesCustomCollarTagAllowedChars = /^[a-zA-Z0-9 ~!]*$/;
 // Loads the item extension properties
 function InventoryItemNeckAccessoriesCustomCollarTagLoad() {
     var C = CharacterGetCurrent();


### PR DESCRIPTION
When the text of a Custom Collar Tag or Electronic Tag was checked for invalid characters, the lastIndex property was updated to the end of the string since the global flag was unnecessarily included. This made the next test fail and revert the text to the default "Tag" even though the custom text was unchanged and still valid.