### PR TITLE
Lock Timer Validation Fix

### DIFF
--- a/BondageClub/Scripts/Validation.js
+++ b/BondageClub/Scripts/Validation.js
@@ -629,10 +629,10 @@ function ValidationSanitizeLock(C, item) {
 	}
 
 	// Sanitize timer lock remove timers
-	if (asset.RemoveTimer > 0 && typeof property.RemoveTimer === "number") {
+	if (lock.Asset.RemoveTimer > 0 && typeof property.RemoveTimer === "number") {
 		// Ensure the lock's remove timer doesn't exceed the maximum for that lock type
 		if (property.RemoveTimer - ValidationRemoveTimerToleranceMs > CurrentTime + lock.Asset.MaxTimer * 1000) {
-			property.RemoveTimer = Math.round(CurrentTime + lock.Asset.RemoveTimer * 1000);
+			property.RemoveTimer = Math.round(CurrentTime + lock.Asset.MaxTimer * 1000);
 			changed = true;
 		}
 	} else if (property.RemoveTimer != null) {


### PR DESCRIPTION
Timer locks were dropping the "Time left" property and displaying null/NaN due to an error in the lock validation.
I also changed the max-time-exceeded correction to apply the lock's max time instead of its default time, since normal non-consoled time additions managed to occasionally exceed this max time.