### PR TITLE
Item Color Layer Order Fix

### DIFF
--- a/BondageClub/Screens/Character/ItemColor/ItemColor.js
+++ b/BondageClub/Screens/Character/ItemColor/ItemColor.js
@@ -524,7 +524,7 @@ function ItemColorStateBuild(c, item, x, y, width, height, includeResetButton) {
 				colorIndex: groupMap[key].reduce((min, layer) => Math.min(min, layer.ColorIndex), Infinity),
 			};
 		})
-		.sort((g1, g2) => g1.colorIndex = g2.colorIndex);
+		.sort((g1, g2) => g1.colorIndex > g2.colorIndex);
 
 	if (item.Asset.AllowColorizeAll) {
 		colorGroups.unshift({ name: null, layers: [], colorIndex: -1 });


### PR DESCRIPTION
When opening the color menu for an item with multiple colorable layers, the order the layers appeared in was inconsistent depending on the browser. In Chrome they were the expected order, while on Firefox they were in reverse.