### PR TITLE
Kidnap Dress Up Fix

### DIFF
--- a/BondageClub/Screens/MiniGame/Kidnap/Kidnap.js
+++ b/BondageClub/Screens/MiniGame/Kidnap/Kidnap.js
@@ -141,7 +141,7 @@ function KidnapAIMove() {
 
 /**
  * Validates or checks if a given upper hand move type is available.
- * @param {string} MoveType - The type of move to check for or perform
+ * @param {number} MoveType - The type of move to check for or perform
  * @param {boolean} DoMove - Whether or not the move is being performed
  * @returns {boolean} - Returns TRUE if the upper hand move type is available
  */
@@ -299,17 +299,18 @@ function KidnapSelectMove(PlayerMove) {
  * @returns {void} - Nothing
  */
 function KidnapSelectMoveUpperHand(PlayerMove) {
+	const MoveName = KidnapUpperHandMoveType[PlayerMove];
 
 	// Stripping or undoing something is automatic
-	if ((PlayerMove == 0) || (PlayerMove == 4) || (PlayerMove == 5) || (PlayerMove == 6) || (PlayerMove == 7))
+	if ((MoveName === "Cloth") || (MoveName === "UndoCloth") || (MoveName === "UndoItemFeet") || (MoveName === "UndoItemMouth"))
 		if (KidnapUpperHandMoveAvailable(PlayerMove, true))
 			KidnapSetMode("SelectMove");
 
 	// Apply an item enters another mode with a focused group
-	if ((PlayerMove == 1) || (PlayerMove == 2) || (PlayerMove == 3))
+	if ((MoveName === "ItemFeet") || (MoveName === "ItemMouth"))
 		if (KidnapUpperHandMoveAvailable(PlayerMove, false))
 			for (let A = 0; A < AssetGroup.length; A++)
-				if (AssetGroup[A].Name == KidnapUpperHandMoveType[PlayerMove]) {
+				if (AssetGroup[A].Name === MoveName) {
 					KidnapOpponent.FocusGroup = AssetGroup[A];
 					KidnapInventoryBuild();
 					KidnapSetMode("SelectItem");
@@ -317,7 +318,7 @@ function KidnapSelectMoveUpperHand(PlayerMove) {
 				}
 
 	// Mercy is always available
-	if (PlayerMove == KidnapUpperHandMoveType.indexOf("Mercy")) KidnapSetMode("SelectMove");
+	if (MoveName === "Mercy") KidnapSetMode("SelectMove");
 }
 
 /**


### PR DESCRIPTION
The kidnap game's function to process a selected upper move wasn't updated to account for the new move list. The only move that was actually affected was UndoCloth (Dress Back Up) which was doing nothing when selected.