### PR TITLE
Re-added support for the Restrain Property

### DIFF
--- a/BondageClub/Scripts/Validation.js
+++ b/BondageClub/Scripts/Validation.js
@@ -475,8 +475,8 @@ function ValidationSanitizeProperties(C, item) {
 		}
 	}
 
-	// Remove invalid properties from non-typed items
-	if (property.Type == null) {
+	// Remove invalid properties from non-typed & non-restrain items
+	if (property.Type == null && property.Restrain == null) {
 		["SetPose", "Difficulty", "SelfUnlock", "Hide"].forEach(P => {
 			if (property[P] != null) {
 				console.warn("Removing invalid property:", P);
@@ -549,11 +549,6 @@ function ValidationSanitizeLock(C, item) {
 
 	// Remove any invalid lock member number
 	const lockNumber = property.LockMemberNumber;
-	if (lockNumber != null && typeof lockNumber !== "number") {
-		console.warn("Removing invalid lock member number:", lockNumber);
-		delete property.LockMemberNumber;
-		changed = true;
-	}
 
 	// The character's member number is always valid on a lock
 	if (lockNumber !== C.MemberNumber) {


### PR DESCRIPTION
Re-added support for the Restrain Property. As while it is not used by items anymore. Having it allows those that use console to enhance their experience, while also minimising risks to other people.

As it currently is everything that could be done before can still be done, but doing so is much more risky and likely to break something. While yes this only effects those that use console, it allows greater diversity in RP oppotunities. Such as being able to hide things, set poses etc. Once again I would like to say that all of this is still possible, but doing so is now MUCH more likely to cause negative effects/outcomes.

I also removed the new validation of the lock member number since non number locks are used in the game currently. Off the top of my head the Nursery uses text instead of member numbers. And to my knowledge allowing stings in the lock member number doesn't have any negative consequence.