### PR TITLE
Blindfold nose access

### DIFF
--- a/BondageClub/Assets/Female3DCG/Female3DCG.js
+++ b/BondageClub/Assets/Female3DCG/Female3DCG.js
@@ -3559,7 +3559,6 @@ var AssetFemale3DCG = [
 		Left: 150,
 		Top: 20,
 		Zone: [[175, 0, 150, 65]],
-		Block: ["ItemNose"],
 		Activity: ["Bite", "Kiss", "Slap", "Caress", "TakeCare", "Pet", "Pull", "Rub", "Nod", "Wiggle"],
 		Asset: [
 			{ Name: "ClothBlindfold", Value: 15, Time: 5, DefaultColor: "#A0A0A0", Hide: ["Glasses"], Effect: ["BlindLight", "Prone"] },


### PR DESCRIPTION
Fixing the nose access so when a blindfold is on you can still access the nose when it is visible.
This will make it so that the nose is no longer blocked when you can still see it, such as with the blackout lenses.
Does not affect the pantyhose, duct tape, leather slim mask, leather slim mask open eyes, leather slim mask open mouth, or web blindfold.