### PR TITLE
Nose access change for blindfolds

### DIFF
--- a/BondageClub/Assets/Female3DCG/Female3DCG.js
+++ b/BondageClub/Assets/Female3DCG/Female3DCG.js
@@ -3559,7 +3559,6 @@ var AssetFemale3DCG = [
 		Left: 150,
 		Top: 20,
 		Zone: [[175, 0, 150, 65]],
-		Block: ["ItemNose"],
 		Activity: ["Bite", "Kiss", "Slap", "Caress", "TakeCare", "Pet", "Pull", "Rub", "Nod", "Wiggle"],
 		Asset: [
 			{ Name: "ClothBlindfold", Value: 15, Time: 5, DefaultColor: "#A0A0A0", Hide: ["Glasses"], Effect: ["BlindLight", "Prone"] },


### PR DESCRIPTION
Altered access to the nose when a blindfold is on, so it makes more sense visually.
This will allow the changing of items on the nose when most blindfolds are on. This does not change the blindfolds that visually cover the nose.