### PR TITLE
Kicked during Kinky Dungeon fix

### DIFF
--- a/BondageClub/Scripts/Server.js
+++ b/BondageClub/Scripts/Server.js
@@ -177,7 +177,8 @@ function ServerPlayerIsInChatRoom() {
 		|| ((CurrentScreen == "Title") && (InformationSheetPreviousScreen == "ChatRoom"))
 		|| ((CurrentScreen == "OnlineProfile") && (InformationSheetPreviousScreen == "ChatRoom"))
 		|| ((CurrentScreen == "FriendList") && (InformationSheetPreviousScreen == "ChatRoom") && (FriendListReturn == null))
-		|| ((CurrentScreen == "Preference") && (InformationSheetPreviousScreen == "ChatRoom"));
+		|| ((CurrentScreen == "Preference") && (InformationSheetPreviousScreen == "ChatRoom"))
+		|| ((CurrentModule == "MiniGame") && (DialogGamingPreviousRoom == "ChatRoom"));
 }
 
 /** Sends a message with the given data to the server via socket.emit */


### PR DESCRIPTION
If a player was playing the Kinky Dungeon minigame in a chat room and got kicked by an admin, on finishing their game they would still be in the room from their viewpoint but couldn't interact with anything. 
They will now be interrupted and immediately exit to the chat search screen as normal.