### PR TITLE
Bugfix: Properly enables partial appearance rollbacks

### DIFF
--- a/BondageClub/Screens/Character/Login/Login.js
+++ b/BondageClub/Screens/Character/Login/Login.js
@@ -485,7 +485,7 @@ function LoginResponse(C) {
 			LoginDifficulty();
 
 			// Loads the player character model and data
-			Player.Appearance = ServerAppearanceLoadFromBundle(Player, C.AssetFamily, C.Appearance, C.MemberNumber).appearance;
+			ServerAppearanceLoadFromBundle(Player, C.AssetFamily, C.Appearance, C.MemberNumber)
 			InventoryLoad(Player, C.Inventory);
 			LogLoad(C.Log);
 			ReputationLoad(C.Reputation);

--- a/BondageClub/Screens/Room/Private/Private.js
+++ b/BondageClub/Screens/Room/Private/Private.js
@@ -692,14 +692,12 @@ function PrivateLoadCharacter(C) {
 		if (PrivateCharacter[C].Title != null) N.Title = PrivateCharacter[C].Title;
 		if (PrivateCharacter[C].AssetFamily != null) N.AssetFamily = PrivateCharacter[C].AssetFamily;
 		if (PrivateCharacter[C].Appearance != null) {
-			const loadedAppearance = ServerAppearanceLoadFromBundle(N, PrivateCharacter[C].AssetFamily, PrivateCharacter[C].Appearance);
-			N.Appearance = loadedAppearance.appearance;
-			updateRequired = updateRequired || !loadedAppearance.updateValid;
+			const updateValid = ServerAppearanceLoadFromBundle(N, PrivateCharacter[C].AssetFamily, PrivateCharacter[C].Appearance)
+			updateRequired = updateRequired || !updateValid;
 		}
 		if (PrivateCharacter[C].AppearanceFull != null) {
-			const loadedAppearance = ServerAppearanceLoadFromBundle(N, PrivateCharacter[C].AssetFamily, PrivateCharacter[C].AppearanceFull);
-			N.AppearanceFull = loadedAppearance.appearance;
-			updateRequired = updateRequired || !loadedAppearance.updateValid;
+			const updateValid = ServerAppearanceLoadFromBundle(N, PrivateCharacter[C].AssetFamily, PrivateCharacter[C].AppearanceFull, null, true)
+			updateRequired = updateRequired || !updateValid;
 		}
 		if (PrivateCharacter[C].Trait != null) N.Trait = PrivateCharacter[C].Trait.slice();
 		if (PrivateCharacter[C].Cage != null) N.Cage = PrivateCharacter[C].Cage;

--- a/BondageClub/Scripts/Character.js
+++ b/BondageClub/Scripts/Character.js
@@ -371,7 +371,7 @@ function CharacterOnlineRefresh(Char, data, SourceMemberNumber) {
 	Char.LimitedItems = Array.isArray(data.LimitedItems) ? data.LimitedItems : [];
 	if (Char.ID != 0 && Array.isArray(data.WhiteList)) Char.WhiteList = data.WhiteList;
 	if (Char.ID != 0 && Array.isArray(data.BlackList)) Char.BlackList = data.BlackList;
-	Char.Appearance = ServerAppearanceLoadFromBundle(Char, "Female3DCG", data.Appearance, SourceMemberNumber).appearance;
+	ServerAppearanceLoadFromBundle(Char, "Female3DCG", data.Appearance, SourceMemberNumber);
 	if (Char.ID == 0) LoginValidCollar();
 	if ((Char.ID != 0) && ((Char.MemberNumber == SourceMemberNumber) || (Char.Inventory == null) || (Char.Inventory.length == 0))) InventoryLoad(Char, data.Inventory);
 	CharacterLoadEffect(Char);

--- a/BondageClub/Scripts/Server.js
+++ b/BondageClub/Scripts/Server.js
@@ -301,9 +301,11 @@ function ServerAppearanceBundle(Appearance) {
  * @param {string} AssetFamily - Family of assets used for the appearance array
  * @param {AppearanceBundle} Bundle - Bundled appearance
  * @param {number} SourceMemberNumber - Member number of the user who triggered the change
- * @returns {void} - Nothing
+ * @param {boolean} AppearanceFull - Whether or not the appearance should be assigned to an NPC's AppearanceFull
+ * property
+ * @returns {boolean} - Whether or not the appearance bundle update contained invalid items
  */
-function ServerAppearanceLoadFromBundle(C, AssetFamily, Bundle, SourceMemberNumber) {
+function ServerAppearanceLoadFromBundle(C, AssetFamily, Bundle, SourceMemberNumber, AppearanceFull) {
 	const appearanceDiffs = ServerBuildAppearanceDiff(AssetFamily, C.Appearance, Bundle);
 	ServerAddRequiredAppearance(AssetFamily, appearanceDiffs);
 
@@ -319,12 +321,18 @@ function ServerAppearanceLoadFromBundle(C, AssetFamily, Bundle, SourceMemberNumb
 			return { appearance, updateValid };
 		}, { appearance: [], updateValid: true });
 
+	if (AppearanceFull) {
+		C.AppearanceFull = appearance;
+	} else {
+		C.Appearance = appearance;
+	}
+
 	// If the appearance update was invalid, send another update to correct any issues
 	if (!updateValid && C.ID === 0) {
 		console.warn("Invalid appearance update bundle received. Updating with sanitized appearance.");
 		ChatRoomCharacterUpdate(C);
 	}
-	return { appearance, updateValid };
+	return updateValid;
 }
 
 /**


### PR DESCRIPTION
## Summary

This was something I'd intended to implement in the original validation change, but it's come to my attention that there was an issue with the way it was implemented. For the most part, this issue should only affect those using console, but there may be some edge cases where it causes unexpected behaviour in the standard game.

Currently, when an invalid appearance bundle is received, the character's full appearance is rolled back, rather than just the items that were invalid. Additionally, I'd intended for partial rollbacks to work on a per-item basis - for example, if an item is added with a lock that is blocked on the player in a single update, I'd intended to only roll back the lock part of that update, and permit the item to be equipped without a lock, but this isn't what happens right now. The final appearance bundle was being resolved correctly, but wouldn't get applied until _after_ the rollback update, which invalidated the creation of the validated bundle, and could result in appearance desynchronization between players in a chatroom. This PR addresses that by ensuring that the sanitized appearance bundle is applied _before_ the rollback happens.