### PR TITLE
Bugfix: Improves character clumsiness calculation

### DIFF
--- a/BondageClub/Scripts/Character.js
+++ b/BondageClub/Scripts/Character.js
@@ -1267,8 +1267,10 @@ function CharacterGetDarkFactor(C, eyesOnly = false) {
  */
 function CharacterGetClumsiness(C) {
 	let clumsiness = 0;
-	if (!C.CanInteract()) clumsiness += 2;
+	if (!C.CanInteract()) clumsiness += 1;
+	const armItem = InventoryGet(C, "ItemArms");
+	if (armItem && armItem.Asset.IsRestraint && InventoryItemHasEffect(armItem, "Block")) clumsiness += 2;
 	const handItem = InventoryGet(C, "ItemHands");
-	if (handItem && handItem.Asset.IsRestraint) clumsiness += 3;
+	if (handItem && handItem.Asset.IsRestraint && InventoryItemHasEffect(handItem, "Block")) clumsiness += 3;
 	return Math.min(clumsiness, 5);
 }


### PR DESCRIPTION
## Summary

This makes a few refinements to clumsiness calculation for the combination lock. In particular, it now ensures that hand items have the `Block` effect, so that the Futuristic Mittens in glove mode don't trigger clumsiness.