### PR TITLE
Bugfix: Chatroom messages for the pet bed

### DIFF
--- a/BondageClub/Screens/Character/Player/Dialog_Player.csv
+++ b/BondageClub/Screens/Character/Player/Dialog_Player.csv
@@ -1944,8 +1944,8 @@ SpreaderMetalPoseWide,,,Wide,,
 SelectPetBedType,,,Change blanket,,
 PetBedTypeBlanket,,,Add blanket
 PetBedTypeNoBlanket,,,Remove blanket
-PetBedSetBlanket,,,SourceCharacter adds a blanket onto DestinationCharacter.,,
-PetBedSetNoBlanket,,,SourceCharacter removes the blanket from DestinationCharacter.,,
+PetBedSetBlanket,,,SourceCharacter gives TargetCharacter a blanket.,,
+PetBedSetNoBlanket,,,SourceCharacter removes the blanket from TargetCharacter.,,
 NotificationTitleChatMessage,,,Chat Message,,
 NotificationTitleChatJoin,,,Joined Room,,
 NotificationTitleBeep,,,Beep,,

--- a/BondageClub/Screens/Inventory/ItemDevices/PetBed/PetBed.js
+++ b/BondageClub/Screens/Inventory/ItemDevices/PetBed/PetBed.js
@@ -37,8 +37,8 @@ function InventoryItemDevicesPetBedClick() {
 	ExtendedItemClick(InventoryItemDevicesPetBedOptions);
 }
 
-function InventoryItemDevicesPetBedAction(C, Option) {
-	var msg = "PedBedSet" + Option.Name;
+function InventoryItemDevicesPetBedPublishAction(C, Option) {
+	var msg = "PetBedSet" + Option.Name;
 	var Dictionary = [
 		{ Tag: "SourceCharacter", Text: Player.Name, MemberNumber: Player.MemberNumber },
 		{ Tag: "TargetCharacter", Text: C.Name, MemberNumber: C.MemberNumber },


### PR DESCRIPTION
## Summary

The pet bed would previously not display chatroom messages when changing type, despite messages existing in `Dialog_Player.csv`. This was due to a typo in the function name. I also made some slight edits to the chat messages themselves to ensure that the tags worked correctly, and to make the wording flow a little better.