### PR TITLE
Bugfix: Validation refinements

### DIFF
--- a/BondageClub/Scripts/Validation.js
+++ b/BondageClub/Scripts/Validation.js
@@ -14,6 +14,7 @@ const ValidationTimerLockProperties = ["MemberNumberList", "RemoveTimer"];
 const ValidationAllLockProperties = ValidationLockProperties
 	.concat(["EnableRandomInput"])
 	.concat(ValidationTimerLockProperties);
+const ValidationModifiableProperties = ValidationAllLockProperties.concat(["Expression"]);
 
 /**
  * Creates the appearance update parameters used to validate an appearance diff, based on the provided target character
@@ -64,7 +65,7 @@ function ValidationResolveAppearanceDiff(previousItem, newItem, params) {
 	}
 	let { item, valid } = result;
 	// If the diff has resolved to an item, sanitize its properties
-	if (item) valid = valid && !ValidationSanitizeProperties(params.C, item);
+	if (item) valid = !ValidationSanitizeProperties(params.C, item) && valid;
 	return { item, valid };
 }
 
@@ -219,16 +220,17 @@ function ValidationResolveModifyDiff(previousItem, newItem, params) {
 			valid = false;
 		}
 
-		// Block changing properties, but exclude lock-related properties, as they get handled separately
+		// Block changing properties, but exclude modifiable and lock-related properties, as they get handled separately
 		const previousKeys = Object.keys(previousProperty)
-			.filter(key => !ValidationAllLockProperties.includes(key));
-		const newKeys = Object.keys(newProperty).filter(key => !ValidationAllLockProperties.includes(key));
+			.filter(key => !ValidationModifiableProperties.includes(key));
+		const newKeys = Object.keys(newProperty).filter(key => !ValidationModifiableProperties.includes(key));
 
 		previousKeys.forEach(key => {
 			valid = valid && !ValidationCopyProperty(previousProperty, newProperty, key);
 		});
 		newKeys.forEach((key) => {
 			if (!previousKeys.includes(key)) {
+				console.warn(`Invalid modification of property "${key}" for item ${warningSuffix}`)
 				valid = false;
 				delete newProperty[key];
 			}
@@ -450,16 +452,24 @@ function ValidationSanitizeProperties(C, item) {
 
 	// Sanitize various properties
 	let changed = ValidationSanitizeEffects(C, item);
-	changed = changed || ValidationSanitizeBlocks(C, item);
-	changed = changed || ValidationSanitizeStringArray(property, "Hide");
+	changed = ValidationSanitizeBlocks(C, item) || changed;
+	changed = ValidationSanitizeStringArray(property, "Hide") || changed;
 
 	const asset = item.Asset;
 
 	// If the property has a type, it needs to be in the asset's AllowType array
 	const allowType = asset.AllowType || [];
 	if (property.Type != null && !allowType.includes(property.Type)) {
-		console.warn("Removing invalid type:", property.Type);
+		console.warn(`Removing invalid type "${property.Type}" from ${asset.Name}`);
 		delete property.Type;
+		changed = true;
+	}
+
+	// If the property has an expression, it needs to be in the asset or group's AllowExpression array
+	const allowExpression = asset.AllowExpression || asset.Group.AllowExpression || [];
+	if (property.Expression != null && !allowExpression.includes(property.Expression)) {
+		console.warn(`Removing invalid expression "${property.Expression}" from ${asset.Name}`);
+		delete property.Expression;
 		changed = true;
 	}
 
@@ -479,7 +489,7 @@ function ValidationSanitizeProperties(C, item) {
 	if (property.Type == null) {
 		["SetPose", "Difficulty", "SelfUnlock", "Hide"].forEach(P => {
 			if (property[P] != null) {
-				console.warn("Removing invalid property:", P);
+				console.warn(`Removing invalid property "${P}" from ${asset.Name}`);
 				delete property[P];
 				changed = true;
 			}
@@ -500,17 +510,19 @@ function ValidationSanitizeProperties(C, item) {
 function ValidationSanitizeEffects(C, item) {
 	const property = item.Property;
 	let changed = ValidationSanitizeStringArray(property, "Effect");
-	changed = changed || ValidationSanitizeLock(C, item);
+	changed = ValidationSanitizeLock(C, item) || changed;
 
 	// If there is no Effect array, no further sanitization is needed
 	if (!Array.isArray(property.Effect)) return changed;
 
+	const assetEffect = item.Asset.Effect || [];
 	const allowEffect = item.Asset.AllowEffect || [];
 	property.Effect = property.Effect.filter((effect) => {
 		// The Lock effect is handled by ServerSanitizeLock
 		if (effect === "Lock") return true;
 		// All other effects must be included in the AllowEffect array to be permitted
-		else if (!allowEffect.includes(effect)) {
+		else if (!assetEffect.includes(effect) && !allowEffect.includes(effect)) {
+			console.warn(`Filtering out invalid Effect entry on ${item.Asset.Name}:`, effect);
 			changed = true;
 			return false;
 		} else return true;
@@ -645,7 +657,7 @@ function ValidationSanitizeLock(C, item) {
 
 /**
  * Sanitizes the `Block` array on an item's Property object, if present. This ensures that it is a valid array of
- * strings, and that each item in the array is present in the asset's `AllowBlock` array.
+ * strings, and that each item in the array is present in the either the asset's `Block` or `AllowBlock` array.
  * @param {Character} C - The character on whom the item is equipped
  * @param {Item} item - The item whose `Block` property should be sanitized
  * @returns {boolean} - TRUE if the item's `Block` property was modified as part of the sanitization process
@@ -658,10 +670,12 @@ function ValidationSanitizeBlocks(C, item) {
 	// If there is no Block array, no further sanitization is needed
 	if (!Array.isArray(property.Block)) return changed;
 
+	const assetBlock = item.Asset.Block || [];
 	const allowBlock = item.Asset.AllowBlock || [];
 	// Any Block entry must be included in the AllowBlock list to be permitted
 	property.Block = property.Block.filter((block) => {
-		if (!allowBlock.includes(block)) {
+		if (!assetBlock.includes(block) && !allowBlock.includes(block)) {
+			console.warn(`Filtering out invalid Block entry on ${item.Asset.Name}:`, block);
 			changed = true;
 			return false;
 		} else return true;
@@ -684,7 +698,7 @@ function ValidationSanitizeStringArray(property, key) {
 	if (Array.isArray(value)) {
 		value.filter(str => {
 			if (typeof str !== "string") {
-				console.warn(`Filtering out invalid ${key}:`, str);
+				console.warn(`Filtering out invalid ${key} entry:`, str);
 				changed = true;
 				return false;
 			} else {
@@ -711,6 +725,10 @@ function ValidationDeleteLock(Property) {
 	if (Property) {
 		ValidationAllLockProperties.forEach(key => {
 			if (Property[key] != null) {
+				// Special casing for RemoveTimer because it is used for both locks and expressions :(
+				if (key === "RemoveTimer" && Property.Expression != null) return;
+				// Otherwise remove the property
+				console.warn("Removing invalid lock property:", key);
 				delete Property[key];
 				changed = true;
 			}
@@ -718,6 +736,7 @@ function ValidationDeleteLock(Property) {
 		if (Array.isArray(Property.Effect)) {
 			Property.Effect = Property.Effect.filter(E => {
 				if (E === "Lock") {
+					console.warn("Filtering out invalid Lock effect");
 					changed = true;
 					return false;
 				} else return true;


### PR DESCRIPTION
## Summary

This includes a handful of fixes and refinements to the validation code:
* Fixes an issue where property sanitization would sometimes short-circuit out of the method before fully sanitizing all properties
* Fixes a long-standing issue that's been around since #1387 was merged, where players' expressions wouldn't reset after a temporary change (e.g. item-triggered expression changes)
* Sanitization now validates the `Expression` property of items according to the asset/group's `AllowExpression` array
* Sanitization now allows effects and block entries that are in the asset's `Effect` and `Block` arrays as well as their `AllowEffect` and `AllowBlock` arrays
* Adds a few more warning log statements to make it clear what is causing appearance updates to be invalid