### PR TITLE
Bugfix: Allows the null type to have properties

### DIFF
--- a/BondageClub/Scripts/Validation.js
+++ b/BondageClub/Scripts/Validation.js
@@ -486,7 +486,7 @@ function ValidationSanitizeProperties(C, item) {
 	}
 
 	// Remove invalid properties from non-typed items
-	if (property.Type == null) {
+	if (property.Type == null && (!asset.AllowType || !asset.AllowType.length)) {
 		["SetPose", "Difficulty", "SelfUnlock", "Hide"].forEach(P => {
 			if (property[P] != null) {
 				console.warn(`Removing invalid property "${P}" from ${asset.Name}`);

--- a/BondageClub/Scripts/Validation.js
+++ b/BondageClub/Scripts/Validation.js
@@ -486,7 +486,7 @@ function ValidationSanitizeProperties(C, item) {
 	}
 
 	// Remove invalid properties from non-typed items
-	if (property.Type == null && (!asset.AllowType || !asset.AllowType.length)) {
+	if (!asset.AllowType || !asset.AllowType.length) {
 		["SetPose", "Difficulty", "SelfUnlock", "Hide"].forEach(P => {
 			if (property[P] != null) {
 				console.warn(`Removing invalid property "${P}" from ${asset.Name}`);


### PR DESCRIPTION
## Summary

This fixes an issue where extended items whose `null` type has properties would get rolled back when the `null` type is selected. This happens on a handful of items (e.g. the metal cuffs), and as far as I can tell has happened since before the recent validation changes, but the properties would get silently deleted previously, meaning that these items probably did not work entirely as intended.

Eventually, I want to replace this particular block with slightly more rigid validation, but for now this doesn't really open the game up to any issues that weren't already available before (e.g. the ability to hide arbitrary items).