### PR TITLE
Bugfix: Ensures expression remove timers get removed when the expression is

### DIFF
--- a/BondageClub/Scripts/Character.js
+++ b/BondageClub/Scripts/Character.js
@@ -1073,6 +1073,7 @@ function CharacterSetFacialExpression(C, AssetGroup, Expression, Timer, Color) {
 				if (C.Appearance[A].Property.Expression != Expression) {
 					C.Appearance[A].Property.Expression = Expression;
 					if (Color && CommonColorIsValid(Color)) C.Appearance[A].Color = Color;
+					if (Expression == null && Timer == null) delete C.Appearance[A].Property.RemoveTimer;
 					CharacterRefresh(C);
 					if (CurrentScreen == "ChatRoom") {
 						if (C.ID == 0) ChatRoomCharacterItemUpdate(C, AssetGroup);

--- a/BondageClub/Scripts/Character.js
+++ b/BondageClub/Scripts/Character.js
@@ -1070,10 +1070,11 @@ function CharacterSetFacialExpression(C, AssetGroup, Expression, Timer, Color) {
 		if ((C.Appearance[A].Asset.Group.Name == AssetGroup) && (C.Appearance[A].Asset.Group.AllowExpression)) {
 			if ((Expression == null) || (C.Appearance[A].Asset.Group.AllowExpression.indexOf(Expression) >= 0)) {
 				if (!C.Appearance[A].Property) C.Appearance[A].Property = {};
+				// Delete any existing removal timer
+				delete C.Appearance[A].Property.RemoveTimer;
 				if (C.Appearance[A].Property.Expression != Expression) {
 					C.Appearance[A].Property.Expression = Expression;
 					if (Color && CommonColorIsValid(Color)) C.Appearance[A].Color = Color;
-					if (Expression == null && Timer == null) delete C.Appearance[A].Property.RemoveTimer;
 					CharacterRefresh(C);
 					if (CurrentScreen == "ChatRoom") {
 						if (C.ID == 0) ChatRoomCharacterItemUpdate(C, AssetGroup);


### PR DESCRIPTION
## Summary

This is something that gets flagged by the new validation. If an expression is set with a `RemoveTimer`, but the player then manually changes their expression back to default, the remove timer isn't removed, which causes validation errors.

This PR modifies the `CharacterSetFacialExpression` function so that whenever an expression is changed, any existing `RemoveTimer` is deleted before changing the expression (and if a new `RemoveTimer` should be set, that still happens). This should prevent these validation warnings, and also fix a bug where manually setting an expression whilst a `RemoveTimer` is in effect causes the new expression to reset when the `RemoveTimer` expires.