### PR TITLE
Beta-fix: Remove Friendlist sorting

### DIFF
--- a/BondageClub/Screens/Character/FriendList/FriendList.js
+++ b/BondageClub/Screens/Character/FriendList/FriendList.js
@@ -256,7 +256,7 @@ function FriendListLoadFriendList(data) {
 
 	if (mode === "Friends") {
 		// In Friend List mode, we show the friend list and allow doing beeps
-		for (const friend of data.sort((a, b) => a.MemberName.localeCompare(b.MemberName))) {
+		for (const friend of data) {
 			FriendListContent += "<div class='FriendListRow'>";
 			FriendListContent += `<div class='FriendListTextColumn FriendListFirstColumn'> ${friend.MemberName} </div>`;
 			FriendListContent += `<div class='FriendListTextColumn'> ${friend.MemberNumber} </div>`;


### PR DESCRIPTION
In #2299 I fixed friendlist sorting, so it works as it was originally intended. This change removes the sort altogether.

Players however seem to prefer old way the friendlist was sorted (in order it was created on server - lovers&submissives first, everyone else in order they were added into friendlist)

This is temporary fix, until more stable sorting using actual friend types will be done.