### PR TITLE
Pleasure Panties Password Fail fix

### DIFF
--- a/BondageClub/Screens/Inventory/ItemPelvis/SciFiPleasurePanties/SciFiPleasurePanties.js
+++ b/BondageClub/Screens/Inventory/ItemPelvis/SciFiPleasurePanties/SciFiPleasurePanties.js
@@ -215,3 +215,7 @@ function InventoryItemPelvisSciFiPleasurePantiesShockTrigger() {
     CharacterSetFacialExpression(C, "Blush", "ShockLow", 15);
     CharacterSetFacialExpression(C, "Eyes", "Closed", 5);
 }
+
+function InventoryItemPelvisSciFiPleasurePantiesExit() {
+	InventoryItemMouthFuturisticPanelGagExitAccessDenied()
+}


### PR DESCRIPTION
Interacting with the Sci-Fi Pleasure Panties when they're locked with an unopenable lock shows the usual futuristic item's "Enter Password" screen. However clicking 'Log in' and exiting this screen was not removing the input field.