### PR TITLE
Bugfix: Lock validation fixes

### DIFF
--- a/BondageClub/Scripts/Inventory.js
+++ b/BondageClub/Scripts/Inventory.js
@@ -797,17 +797,7 @@ function InventoryLock(C, Item, Lock, MemberNumber, Update = true) {
 function InventoryUnlock(C, Item) {
 	if (typeof Item === 'string') Item = InventoryGet(C, Item);
 	if (Item && Item.Property && Item.Property.Effect) {
-		Item.Property.Effect.splice(Item.Property.Effect.indexOf("Lock"), 1);
-		delete Item.Property.LockedBy;
-		delete Item.Property.RemoveTimer;
-		delete Item.Property.LockSet;
-		delete Item.Property.Password;
-		delete Item.Property.Hint;
-		delete Item.Property.LockMemberNumber;
-		delete Item.Property.MemberNumberList;
-		delete Item.Property.MemberNumberListKeys;
-		delete Item.Property.CombinationNumber;
-		delete Item.Property.LockPickSeed;
+		ValidationDeleteLock(Item.Property, false);
 		CharacterRefresh(C);
 	}
 }

--- a/BondageClub/Scripts/Timer.js
+++ b/BondageClub/Scripts/Timer.js
@@ -58,22 +58,7 @@ function TimerInventoryRemove() {
 						var LockName = Character[C].Appearance[A].Property.LockedBy;
 
 						// Remove any lock or timer
-						delete Character[C].Appearance[A].Property.LockedBy;
-						delete Character[C].Appearance[A].Property.LockMemberNumber;
-						delete Character[C].Appearance[A].Property.RemoveTimer;
-						delete Character[C].Appearance[A].Property.MaxTimer;
-						delete Character[C].Appearance[A].Property.ShowTimer;
-						delete Character[C].Appearance[A].Property.EnableRandomInput;
-						delete Character[C].Appearance[A].Property.MemberNumberList;
-						delete Character[C].Appearance[A].Property.Password;
-						delete Character[C].Appearance[A].Property.CombinationNumber;
-						delete Character[C].Appearance[A].Property.LockSet;
-						delete Character[C].Appearance[A].Property.Hint;
-						
-						if (Character[C].Appearance[A].Property.Effect != null)
-							for (let E = 0; E < Character[C].Appearance[A].Property.Effect.length; E++)
-								if (Character[C].Appearance[A].Property.Effect[E] == "Lock")
-									Character[C].Appearance[A].Property.Effect.splice(E, 1);
+						ValidationDeleteLock(Character[C].Appearance[A].Property, false);
 
 						// If we're removing a lock and we're in a chatroom, send a chatroom message
 						if (LockName && ServerPlayerIsInChatRoom()) {


### PR DESCRIPTION
## Summary

This fixes a couple of things:
* There was an error in lock modification validation where the `RemoveItem` and `ShowTimer` lock properties were being reverted even if the player had permission to modify the lock. This resulted in some of the timer lock buttons not working properly
* When locks were removed via `InventoryUnlock` and `TimerInventoryRemove`, the `EnableRandomInput`, `RemoveItem` and `ShowTimer` properties weren't being removed, which resulted in the validation code flagging the update as invalid. These two functions now make calls to `ValidationDeleteLock`, to ensure that all lock properties are being properly deleted.