### PR TITLE
Lock Key-List change fix

### DIFF
--- a/BondageClub/Scripts/Validation.js
+++ b/BondageClub/Scripts/Validation.js
@@ -14,7 +14,8 @@ const ValidationRestrictedLockProperties = ["EnableRandomInput", "RemoveItem", "
 const ValidationTimerLockProperties = ["MemberNumberList", "RemoveTimer"];
 const ValidationAllLockProperties = ValidationBasicLockProperties
 	.concat(ValidationRestrictedLockProperties)
-	.concat(ValidationTimerLockProperties);
+	.concat(ValidationTimerLockProperties)
+	.concat(["MemberNumberListKeys"]);
 const ValidationModifiableProperties = ValidationAllLockProperties.concat(["Expression"]);
 
 /**

--- a/BondageClub/Scripts/Validation.js
+++ b/BondageClub/Scripts/Validation.js
@@ -7,7 +7,7 @@ const ValidationDefaultCombinationNumber = "0000";
 const ValidationDefaultPassword = "UNLOCK";
 const ValidationRemoveTimerToleranceMs = 5000;
 const ValidationBasicLockProperties = [
-	"LockedBy", "LockMemberNumber", "CombinationNumber", "MemberNumberListKeys", "Password", "Hint", "LockSet",
+	"LockedBy", "LockMemberNumber", "CombinationNumber", "Password", "Hint", "LockSet",
 	"LockPickSeed",
 ];
 const ValidationRestrictedLockProperties = ["EnableRandomInput", "RemoveItem", "ShowTimer"];


### PR DESCRIPTION
MemberNumberListKeys (used for High Security Padlocks) was listed as a basic lock property meaning it couldn't be changed after being initially set, which should actually be possible.