### PR TITLE
Immersion: Chat room names and descriptions are garbled while blind

### DIFF
--- a/BondageClub/Screens/Character/FriendList/FriendList.js
+++ b/BondageClub/Screens/Character/FriendList/FriendList.js
@@ -192,6 +192,9 @@ function FriendListChatSearch(room) {
 	FriendListExit();
 	ElementValue("InputSearch", room);
 	ChatSearchQuery();
+	// Change the text box so the player still cant read it
+	ElementValue("InputSearch", ChatSearchMuffle(room));
+	
 }
 
 /**
@@ -264,7 +267,7 @@ function FriendListLoadFriendList(data) {
 			if (friend.ChatRoomName.startsWith("-")) {
 				FriendListContent += `<div class='FriendListTextColumn'> ${friend.ChatRoomName.replace("-Private-", PrivateRoomCaption)} </div>`;
 			} else {
-				const Caption = `${friend.ChatRoomSpace ? friend.ChatRoomSpace.replace("Asylum", SpaceAsylumCaption) + " - " : ''} ${friend.ChatRoomName}`;
+				const Caption = `${friend.ChatRoomSpace ? friend.ChatRoomSpace.replace("Asylum", SpaceAsylumCaption) + " - " : ''} ${ChatSearchMuffle(friend.ChatRoomName)}`;
 				if (FriendListReturn === "ChatSearch" && ChatRoomSpace === (friend.ChatRoomSpace || "")) {
 					FriendListContent += `<div class='FriendListLinkColumn' onClick='FriendListChatSearch("${friend.ChatRoomName}")'> ${Caption} </div>`;
 				} else {

--- a/BondageClub/Screens/Character/Preference/Preference.js
+++ b/BondageClub/Screens/Character/Preference/Preference.js
@@ -371,6 +371,7 @@ function PreferenceInitPlayer() {
 	if (typeof C.ImmersionSettings.ReturnToChatRoom !== "boolean") C.ImmersionSettings.ReturnToChatRoom = false;
 	if (typeof C.ImmersionSettings.ReturnToChatRoomAdmin !== "boolean") C.ImmersionSettings.ReturnToChatRoomAdmin = false;
 	if (typeof C.ImmersionSettings.SenseDepMessages !== "boolean") C.ImmersionSettings.SenseDepMessages = false;
+	if (typeof C.ImmersionSettings.ChatRoomMuffle !== "boolean") C.ImmersionSettings.ChatRoomMuffle = false;
 
 	// Misc
 	if (typeof C.LastChatRoom !== "string") C.LastChatRoom = "";
@@ -468,6 +469,7 @@ function PreferenceInitPlayer() {
 		C.ImmersionSettings.ReturnToChatRoom = true;
 		C.ImmersionSettings.ReturnToChatRoomAdmin = true;
 		C.ImmersionSettings.SenseDepMessages = true;
+		C.ImmersionSettings.ChatRoomMuffle = true;
 		C.OnlineSharedSettings.AllowPlayerLeashing = true;
 	}
 	
@@ -844,8 +846,10 @@ function PreferenceSubscreenImmersionRun() {
 		if (Player.ImmersionSettings.ReturnToChatRoom)
 			DrawCheckbox(1300, 592, 64, 64, TextGet("ReturnToChatRoomAdmin"), Player.ImmersionSettings.ReturnToChatRoomAdmin);
 		DrawCheckbox(500, 672, 64, 64, TextGet("StimulationEvents"), Player.ImmersionSettings.StimulationEvents);
+		DrawCheckbox(500, 752, 64, 64, TextGet("ChatRoomMuffle"), Player.ImmersionSettings.ChatRoomMuffle);
 		DrawCheckbox(500, 832, 64, 64, TextGet("ImmersionLockSetting"), Player.GameplaySettings.ImmersionLockSetting);
 		DrawCheckbox(1300, 192, 64, 64, TextGet("SenseDepMessages"), Player.ImmersionSettings.SenseDepMessages);
+		
 		DrawText(TextGet("SensDepSetting"), 800, 228, "Black", "Gray");
 		MainCanvas.textAlign = "center";
 		DrawBackNextButton(500, 192, 250, 64, TextGet(Player.GameplaySettings.SensDepChatLog), "White", "",
@@ -897,6 +901,9 @@ function PreferenceSubscreenImmersionClick() {
 				Player.ImmersionSettings.SenseDepMessages = !Player.ImmersionSettings.SenseDepMessages;
 		if (MouseIn(500, 672, 64, 64) && (!Player.GameplaySettings.ImmersionLockSetting || (!Player.IsRestrained())))
 				Player.ImmersionSettings.StimulationEvents = !Player.ImmersionSettings.StimulationEvents;
+		if (MouseIn(500, 752, 64, 64) && (!Player.GameplaySettings.ImmersionLockSetting || (!Player.IsRestrained())))
+				Player.ImmersionSettings.ChatRoomMuffle = !Player.ImmersionSettings.ChatRoomMuffle;
+			
 		if (MouseIn(500, 832, 64, 64) && (!Player.GameplaySettings.ImmersionLockSetting || (!Player.IsRestrained())))
 			Player.GameplaySettings.ImmersionLockSetting = !Player.GameplaySettings.ImmersionLockSetting;
 

--- a/BondageClub/Screens/Character/Preference/Text_Preference.csv
+++ b/BondageClub/Screens/Character/Preference/Text_Preference.csv
@@ -114,6 +114,7 @@ SenseDepMessages,Hide others' messages
 ImmersionLocked,All immersion settings are maxed out under the Extreme difficulty mode
 BlockGaggedOOC,Prevent OOC & whispers while gagged
 StimulationEvents,Events while plugged or vibed
+ChatRoomMuffle,Garble chat room names and descriptions while blind
 SensDepSetting,Sensory deprivation setting
 SensDepLight,Light
 SensDepNames,Hide names

--- a/BondageClub/Screens/Online/ChatAdmin/ChatAdmin.js
+++ b/BondageClub/Screens/Online/ChatAdmin/ChatAdmin.js
@@ -49,6 +49,12 @@ function ChatAdminLoad() {
 	if (!ChatRoomPlayerIsAdmin()) {
 		document.getElementById("InputName").setAttribute("disabled", "disabled");
 		document.getElementById("InputDescription").setAttribute("disabled", "disabled");
+		
+		// We also garble them if possible
+		ElementValue("InputName", ChatSearchMuffle(ChatAdminTemporaryData ? ChatAdminTemporaryData.Name : ChatRoomData.Name, true));
+		ElementValue("InputDescription", ChatSearchMuffle(ChatAdminTemporaryData ? ChatAdminTemporaryData.Description : ChatRoomData.Description, true));
+		
+		
 		document.getElementById("InputAdminList").setAttribute("disabled", "disabled");
 		document.getElementById("InputBanList").setAttribute("disabled", "disabled");
 		document.getElementById("InputSize").setAttribute("disabled", "disabled");

--- a/BondageClub/Screens/Online/ChatSearch/ChatSearch.js
+++ b/BondageClub/Screens/Online/ChatSearch/ChatSearch.js
@@ -195,7 +195,10 @@ function ChatSearchNormalDraw() {
 function ChatSearchMuffle(Text) {
 	let ret = Text;
 	if (Player.ImmersionSettings && Player.ImmersionSettings.ChatRoomMuffle && Player.GetBlindLevel() > 0) {
-		return SpeechGarbleByGagLevel(Player.GetBlindLevel() * Player.GetBlindLevel(), Text, true)
+		ret = SpeechGarbleByGagLevel(Player.GetBlindLevel() * Player.GetBlindLevel(), Text, true)
+		if (ret.length == 0)
+			return "...";
+		return ret;
 	}
 	return ret
 }

--- a/BondageClub/Screens/Online/ChatSearch/ChatSearch.js
+++ b/BondageClub/Screens/Online/ChatSearch/ChatSearch.js
@@ -121,8 +121,8 @@ function ChatSearchNormalDraw() {
 			var IsFull = ChatSearchResult[C].MemberCount >= ChatSearchResult[C].MemberLimit;
 			var HasBlock = CharacterHasBlockedItem(Player, ChatSearchResult[C].BlockCategory);
 			DrawButton(X, Y, 630, 85, "", (HasBlock && IsFull ? "#884444" : HasBlock ? "#FF9999" : HasFriends && IsFull ? "#448855" : HasFriends ? "#CFFFCF" : IsFull ? "#666" : "White"), null, null, IsFull);
-			DrawTextFit((ChatSearchResult[C].Friends != null && ChatSearchResult[C].Friends.length > 0 ? "(" + ChatSearchResult[C].Friends.length + ") " : "") + ChatSearchResult[C].Name + " - " + ChatSearchResult[C].Creator + " " + ChatSearchResult[C].MemberCount + "/" + ChatSearchResult[C].MemberLimit + "", X + 315, Y + 25, 620, "black");
-			DrawTextFit(ChatSearchResult[C].Description, X + 315, Y + 62, 620, "black");
+			DrawTextFit((ChatSearchResult[C].Friends != null && ChatSearchResult[C].Friends.length > 0 ? "(" + ChatSearchResult[C].Friends.length + ") " : "") + ChatSearchMuffle(ChatSearchResult[C].Name) + " - " + ChatSearchMuffle(ChatSearchResult[C].Creator) + " " + ChatSearchResult[C].MemberCount + "/" + ChatSearchResult[C].MemberLimit + "", X + 315, Y + 25, 620, "black");
+			DrawTextFit(ChatSearchMuffle(ChatSearchResult[C].Description), X + 315, Y + 62, 620, "black");
 
 			// Moves the next window position
 			X = X + 660;
@@ -150,10 +150,10 @@ function ChatSearchNormalDraw() {
 
 				// Builds the friend list as hover text
 				if (MouseIn(X, Y, 630, 85) && ChatSearchResult[C].Friends != null && ChatSearchResult[C].Friends.length > 0) {
-					DrawTextWrap(TextGet("FriendsInRoom") + " " + ChatSearchResult[C].Name, (X > 1000) ? 685 : X + 660, ListY, 630, Height, "black", "#FFFF88", 1);
+					DrawTextWrap(TextGet("FriendsInRoom") + " " + ChatSearchMuffle(ChatSearchResult[C].Name), (X > 1000) ? 685 : X + 660, ListY, 630, Height, "black", "#FFFF88", 1);
 					ListY += Height;
 					for (let F = 0; F < ChatSearchResult[C].Friends.length; F++) {
-						DrawTextWrap(ChatSearchResult[C].Friends[F].MemberName + " (" + ChatSearchResult[C].Friends[F].MemberNumber + ")", (X > 1000) ? 685 : X + 660, ListY, 630, Height, "black", "#FFFF88", 1);
+						DrawTextWrap(ChatSearchMuffle(ChatSearchResult[C].Friends[F].MemberName + " (" + ChatSearchResult[C].Friends[F].MemberNumber + ")"), (X > 1000) ? 685 : X + 660, ListY, 630, Height, "black", "#FFFF88", 1);
 						ListY += Height;
 					}
 				}
@@ -187,6 +187,22 @@ function ChatSearchNormalDraw() {
 }
 
 /**
+ * 
+ * Garbles based on immersion settings
+ * @ Text (string) - The text to garble
+ * @returns {void} - Nothing
+ */
+function ChatSearchMuffle(Text) {
+	let ret = Text;
+	if (Player.ImmersionSettings && Player.ImmersionSettings.ChatRoomMuffle && Player.GetBlindLevel() > 0) {
+		return SpeechGarbleByGagLevel(Player.GetBlindLevel() * Player.GetBlindLevel(), Text, true)
+	}
+	return ret
+}
+ 
+
+
+/**
  * Draws the list of rooms in permission mode.
  * @returns {void} - Nothing
  */
@@ -203,8 +219,8 @@ function ChatSearchPermissionDraw() {
 			let Hover = (MouseX >= X) && (MouseX <= X + 630) && (MouseY >= Y) && (MouseY <= Y + 85) && !CommonIsMobile;
 			// Draw the room rectangle
 			DrawRect(X, Y, 630, 85, isIgnored ? (Hover ? "red" : "pink") : ( Hover ? "green" : "lime"));
-			DrawTextFit((ChatSearchResult[C].Friends != null && ChatSearchResult[C].Friends.length > 0 ? "(" + ChatSearchResult[C].Friends.length + ") " : "") + ChatSearchResult[C].Name + " - " + ChatSearchResult[C].Creator + " " + ChatSearchResult[C].MemberCount + "/" + ChatSearchResult[C].MemberLimit + "", X + 315, Y + 25, 620, "black");
-			DrawTextFit(ChatSearchResult[C].Description, X + 315, Y + 62, 620, "black");
+			DrawTextFit((ChatSearchResult[C].Friends != null && ChatSearchResult[C].Friends.length > 0 ? "(" + ChatSearchResult[C].Friends.length + ") " : "") + ChatSearchMuffle(ChatSearchResult[C].Name) + " - " + ChatSearchMuffle(ChatSearchResult[C].Creator) + " " + ChatSearchResult[C].MemberCount + "/" + ChatSearchResult[C].MemberLimit + "", X + 315, Y + 25, 620, "black");
+			DrawTextFit(ChatSearchMuffle(ChatSearchResult[C].Description), X + 315, Y + 62, 620, "black");
 
 			// Moves the next window position
 			X = X + 660;

--- a/BondageClub/Scripts/Character.js
+++ b/BondageClub/Scripts/Character.js
@@ -731,7 +731,7 @@ function CharacterLoadCanvas(C) {
 	if (C.Hooks && typeof C.Hooks.get == "function") {
 		let hooks = C.Hooks.get("BeforeSortLayers");
 		if (hooks)
-			hooks.forEach((hook) => hook(C)); // If there's a hook, call it
+		    hooks.forEach((hook) => hook(C)); // If there's a hook, call it
 	}
 
 	// Generates a layer array from the character's appearance array, sorted by drawing order
@@ -741,7 +741,7 @@ function CharacterLoadCanvas(C) {
 	if (C.Hooks && typeof C.Hooks.get == "function") {
 		let hooks = C.Hooks.get("AfterLoadCanvas");
 		if (hooks)
-			hooks.forEach((hook) => hook(C)); // If there's a hook, call it
+		    hooks.forEach((hook) => hook(C)); // If there's a hook, call it
 	}
 	
 	// Sets the total height modifier for that character

--- a/BondageClub/Scripts/Character.js
+++ b/BondageClub/Scripts/Character.js
@@ -731,7 +731,7 @@ function CharacterLoadCanvas(C) {
 	if (C.Hooks && typeof C.Hooks.get == "function") {
 		let hooks = C.Hooks.get("BeforeSortLayers");
 		if (hooks)
-		    hooks.forEach((hook) => hook(C)); // If there's a hook, call it
+			hooks.forEach((hook) => hook(C)); // If there's a hook, call it
 	}
 
 	// Generates a layer array from the character's appearance array, sorted by drawing order
@@ -741,7 +741,7 @@ function CharacterLoadCanvas(C) {
 	if (C.Hooks && typeof C.Hooks.get == "function") {
 		let hooks = C.Hooks.get("AfterLoadCanvas");
 		if (hooks)
-		    hooks.forEach((hook) => hook(C)); // If there's a hook, call it
+			hooks.forEach((hook) => hook(C)); // If there's a hook, call it
 	}
 	
 	// Sets the total height modifier for that character

--- a/BondageClub/Scripts/Speech.js
+++ b/BondageClub/Scripts/Speech.js
@@ -73,12 +73,8 @@ function SpeechGetGagLevel(C, AssetGroup) {
  * @returns {string} - Returns the dialog after speech effects were processed (Garbling, Stuttering, Baby talk)
  */
 function SpeechGarble(C, CD, NoDeaf) {
-
-	// Variables to build the new string and check if we are in a parentheses
-	var NS = "";
-	var Par = false;
-	if (CD == null) CD = "";
-	var GagEffect = 0;
+	let GagEffect = 0;
+	let NS = CD
 	GagEffect += SpeechGetGagLevel(C, "ItemMouth");
 	GagEffect += SpeechGetGagLevel(C, "ItemMouth2");
 	GagEffect += SpeechGetGagLevel(C, "ItemMouth3");
@@ -87,12 +83,43 @@ function SpeechGarble(C, CD, NoDeaf) {
 	GagEffect += SpeechGetGagLevel(C, "ItemNeck");
 	GagEffect += SpeechGetGagLevel(C, "ItemDevices");
 	GagEffect += SpeechGetGagLevel(C, "ItemHoodAddon");
+	
+	if (C.ID != 0 && !NoDeaf) {
+		if (Player.GetDeafLevel() >= 7) GagEffect = Math.max(GagEffect, 20);
+		else if (Player.GetDeafLevel() >= 6) GagEffect = Math.max(GagEffect, 16);
+		else if (Player.GetDeafLevel() >= 5) GagEffect = Math.max(GagEffect, 12);
+		else if (Player.GetDeafLevel() >= 4) GagEffect = Math.max(GagEffect, 8);
+		else if (Player.GetDeafLevel() >= 3) GagEffect = Math.max(GagEffect, 6);
+		else if (Player.GetDeafLevel() >= 2) GagEffect = Math.max(GagEffect, 4);
+		else if (Player.GetDeafLevel() >= 1) GagEffect = Math.max(GagEffect, 2);
+	}	
+	
+	if (GagEffect > 0) NS = SpeechGarbleByGagLevel(GagEffect, CD);
+	
+	// No gag effect, we return the regular text
+	NS = SpeechStutter(C, NS);
+	NS = SpeechBabyTalk(C, NS);
+	
+	return NS;
+}
+
+/**
+ * The core of the speech garble function, usable without being tied to a specific character
+ * @param {Int} GagEffect - The gag level of the speech
+ * @param {string} CD - The character's dialog to alter
+ */
+function SpeechGarbleByGagLevel(GagEffect, CD, IgnoreOOC) {
+
+	// Variables to build the new string and check if we are in a parentheses
+	var NS = "";
+	var Par = false;
+	if (CD == null) CD = "";
 
 	// GagTotal4 always returns mmmmm and muffles some frequent letters entirely, 75% least frequent letters
-	if (GagEffect >= 20  || ((C.ID != 0) && (Player.GetDeafLevel() >= 7 && !NoDeaf))) {
+	if (GagEffect >= 20) {
 		for (let L = 0; L < CD.length; L++) {
 			var H = CD.charAt(L).toLowerCase();
-			if (H == "(") Par = true;
+			if (H == "(" && !IgnoreOOC) Par = true;
 			if (Par) NS = NS + CD.charAt(L);
 			else {
 				if (H == " " || H == "." || H == "?" || H == "!" || H == "~" || H == "-") NS = NS + H;
@@ -102,16 +129,14 @@ function SpeechGarble(C, CD, NoDeaf) {
 
 			if (H == ")") Par = false;
 		}
-		NS = SpeechStutter(C, NS);
-		NS = SpeechBabyTalk(C, NS);
 		return NS;
 	}
 
 	// GagTotal3 always returns mmmmm and muffles some relatively frequent letters entirely, 50% least frequent letters
-	if (GagEffect >= 16  || ((C.ID != 0) && (Player.GetDeafLevel() >= 6 && !NoDeaf))) {
+	if (GagEffect >= 16) {
 		for (let L = 0; L < CD.length; L++) {
 			let H = CD.charAt(L).toLowerCase();
-			if (H == "(") Par = true;
+			if (H == "(" && !IgnoreOOC) Par = true;
 			if (Par) NS = NS + CD.charAt(L);
 			else {
 				if (H == " " || H == "." || H == "?" || H == "!" || H == "~" || H == "-") NS = NS + H;
@@ -121,16 +146,14 @@ function SpeechGarble(C, CD, NoDeaf) {
 
 			if (H == ")") Par = false;
 		}
-		NS = SpeechStutter(C, NS);
-		NS = SpeechBabyTalk(C, NS);
 		return NS;
 	}
 
 	// GagTotal2 always returns mmmmm and muffles some less frequent letters entirely; 25% least frequent letters
-	if (GagEffect >= 12  || ((C.ID != 0) && (Player.GetDeafLevel() >= 5 && !NoDeaf))) {
+	if (GagEffect >= 12) {
 		for (let L = 0; L < CD.length; L++) {
 			let H = CD.charAt(L).toLowerCase();
-			if (H == "(") Par = true;
+			if (H == "(" && !IgnoreOOC) Par = true;
 			if (Par) NS = NS + CD.charAt(L);
 			else {
 				if (H == " " || H == "." || H == "?" || H == "!" || H == "~" || H == "-") NS = NS + H;
@@ -140,16 +163,14 @@ function SpeechGarble(C, CD, NoDeaf) {
 
 			if (H == ")") Par = false;
 		}
-		NS = SpeechStutter(C, NS);
-		NS = SpeechBabyTalk(C, NS);
 		return NS;
 	}	
 
 	// Total gags always returns mmmmm
-	if ((GagEffect >= 8) || ((C.ID != 0) && (Player.GetDeafLevel() >= 4 && !NoDeaf))) {
+	if (GagEffect >= 8) {
 		for (let L = 0; L < CD.length; L++) {
 			let H = CD.charAt(L).toLowerCase();
-			if (H == "(") Par = true;
+			if (H == "(" && !IgnoreOOC) Par = true;
 			if (Par) NS = NS + CD.charAt(L);
 			else {
 				if (H == " " || H == "." || H == "?" || H == "!" || H == "~" || H == "-") NS = NS + H;
@@ -158,8 +179,6 @@ function SpeechGarble(C, CD, NoDeaf) {
 
 			if (H == ")") Par = false;
 		}
-		NS = SpeechStutter(C, NS);
-		NS = SpeechBabyTalk(C, NS);
 		return NS;
 	}
 
@@ -167,7 +186,7 @@ function SpeechGarble(C, CD, NoDeaf) {
 	if (GagEffect >= 7) {
 		for (let L = 0; L < CD.length; L++) {
 			let H = CD.charAt(L).toLowerCase();
-			if (H == "(") Par = true;
+			if (H == "(" && !IgnoreOOC) Par = true;
 			if (!Par) {
 
 				// Regular characters
@@ -193,16 +212,14 @@ function SpeechGarble(C, CD, NoDeaf) {
 			} else NS = NS + CD.charAt(L);
 			if (H == ")") Par = false;
 		}
-		NS = SpeechStutter(C, NS);
-		NS = SpeechBabyTalk(C, NS);
 		return NS;
 	}
 	
 	// Heavy garble - Almost no letter stays the same
-	if ((GagEffect >= 6) || ((C.ID != 0) && (Player.GetDeafLevel() >= 3 && !NoDeaf))) {
+	if (GagEffect >= 6) {
 		for (let L = 0; L < CD.length; L++) {
 			let H = CD.charAt(L).toLowerCase();
-			if (H == "(") Par = true;
+			if (H == "(" && !IgnoreOOC) Par = true;
 			if (!Par) {
 
 				// Regular characters
@@ -230,8 +247,6 @@ function SpeechGarble(C, CD, NoDeaf) {
 			} else NS = NS + CD.charAt(L);
 			if (H == ")") Par = false;
 		}
-		NS = SpeechStutter(C, NS);
-		NS = SpeechBabyTalk(C, NS);
 		return NS;
 	}
 
@@ -239,7 +254,7 @@ function SpeechGarble(C, CD, NoDeaf) {
 	if (GagEffect >= 5) {
 		for (let L = 0; L < CD.length; L++) {
 			let H = CD.charAt(L).toLowerCase();
-			if (H == "(") Par = true;
+			if (H == "(" && !IgnoreOOC) Par = true;
 			if (!Par) {
 
 				// Regular characters
@@ -267,16 +282,14 @@ function SpeechGarble(C, CD, NoDeaf) {
 			} else NS = NS + CD.charAt(L);
 			if (H == ")") Par = false;
 		}
-		NS = SpeechStutter(C, NS);
-		NS = SpeechBabyTalk(C, NS);
 		return NS;
 	}
 	
 	// Normal garble, keep vowels and a few letters the same
-	if ((GagEffect >= 4) || ((C.ID != 0) && (Player.GetDeafLevel() >= 2 && !NoDeaf))) {
+	if (GagEffect >= 4) {
 		for (let L = 0; L < CD.length; L++) {
 			let H = CD.charAt(L).toLowerCase();
-			if (H == "(") Par = true;
+			if (H == "(" && !IgnoreOOC) Par = true;
 			if (!Par) {
 
 				// Regular characters
@@ -310,8 +323,6 @@ function SpeechGarble(C, CD, NoDeaf) {
 			} else NS = NS + CD.charAt(L);
 			if (H == ")") Par = false;
 		}
-		NS = SpeechStutter(C, NS);
-		NS = SpeechBabyTalk(C, NS);
 		return NS;
 	}
 
@@ -319,7 +330,7 @@ function SpeechGarble(C, CD, NoDeaf) {
 	if (GagEffect >= 3) {
 		for (let L = 0; L < CD.length; L++) {
 			let H = CD.charAt(L).toLowerCase();
-			if (H == "(") Par = true;
+			if (H == "(" && !IgnoreOOC) Par = true;
 			if (!Par) {
 
 				// Regular characters
@@ -353,16 +364,14 @@ function SpeechGarble(C, CD, NoDeaf) {
 			} else NS = NS + CD.charAt(L);
 			if (H == ")") Par = false;
 		}
-		NS = SpeechStutter(C, NS);
-		NS = SpeechBabyTalk(C, NS);
 		return NS;
 	}
 	
 	// Light garble, half of the letters stay the same
-	if ((GagEffect >= 2) || ((C.ID != 0) && (Player.GetDeafLevel() >= 1 && !NoDeaf))) {
+	if (GagEffect >= 2) {
 		for (let L = 0; L < CD.length; L++) {
 			let H = CD.charAt(L).toLowerCase();
-			if (H == "(") Par = true;
+			if (H == "(" && !IgnoreOOC) Par = true;
 			if (!Par) {
 
 				// Regular characters
@@ -396,8 +405,6 @@ function SpeechGarble(C, CD, NoDeaf) {
 			} else NS = NS + CD.charAt(L);
 			if (H == ")") Par = false;
 		}
-		NS = SpeechStutter(C, NS);
-		NS = SpeechBabyTalk(C, NS);
 		return NS;
 	}
 	
@@ -405,7 +412,7 @@ function SpeechGarble(C, CD, NoDeaf) {
 	if (GagEffect >= 1) {
 		for (let L = 0; L < CD.length; L++) {
 			let H = CD.charAt(L).toLowerCase();
-			if (H == "(") Par = true;
+			if (H == "(" && !IgnoreOOC) Par = true;
 			if (!Par) {
 
 				// Regular characters
@@ -436,14 +443,10 @@ function SpeechGarble(C, CD, NoDeaf) {
 			} else NS = NS + CD.charAt(L);
 			if (H == ")") Par = false;
 		}
-		NS = SpeechStutter(C, NS);
-		NS = SpeechBabyTalk(C, NS);
 		return NS;
 	}
 
-	// No gag effect, we return the regular text
-	CD = SpeechStutter(C, CD);
-	CD = SpeechBabyTalk(C, CD);
+	
 	return CD;
 
 }


### PR DESCRIPTION
Adds a new immersion option, allowing chat room names and descriptions (plus the names of friends in them) to be garbled.

This required a refactoring of SpeechGarble. I have split SpeechGarble into two functions, one containing the base functionality based on a level of GagEffect, and one that assigns GagEffect based on either deafness (if the character is another player) or gagged level of the player.