### PR TITLE
Notifications Improvements

### DIFF
--- a/BondageClub/Screens/Character/Preference/Preference.js
+++ b/BondageClub/Screens/Character/Preference/Preference.js
@@ -422,10 +422,21 @@ function PreferenceInitPlayer() {
 	if (typeof NS.Beeps !== "object") NS.Beeps = PreferenceInitNotificationSetting(NS.Beeps, defaultAudio, NotificationAlertType.POPUP);
 	if (typeof NS.Chat !== "undefined") { NS.ChatMessage = NS.Chat; delete NS.Chat; }
 	if (typeof NS.ChatMessage !== "object") NS.ChatMessage = PreferenceInitNotificationSetting(NS.ChatMessage, defaultAudio);
-	if (typeof NS.ChatMessage.IncludeActions !== "boolean") NS.ChatMessage.IncludeActions = false;
-	if (typeof NS.ChatActions !== undefined) delete NS.ChatActions;
+	if (typeof NS.ChatMessage.IncludeActions === "boolean") {
+		// Convert old version of settings
+		const chatMessagesEnabled = NS.ChatMessage.AlertType !== NotificationAudioType.NONE;
+		NS.ChatMessage.Normal = chatMessagesEnabled;
+		NS.ChatMessage.Whisper = chatMessagesEnabled;
+		NS.ChatMessage.Activity = chatMessagesEnabled && NS.ChatMessage.IncludeActions;
+		delete NS.ChatMessage.IncludeActions;
+	}
+	if (typeof NS.ChatMessage.Normal !== "boolean") NS.ChatMessage.Normal = true;
+	if (typeof NS.ChatMessage.Whisper !== "boolean") NS.ChatMessage.Whisper = true;
+	if (typeof NS.ChatMessage.Activity !== "boolean") NS.ChatMessage.Activity = false;
+	if (typeof NS.ChatActions !== "undefined") delete NS.ChatActions;
 	if (typeof NS.ChatJoin !== "object") NS.ChatJoin = PreferenceInitNotificationSetting(NS.ChatJoin, defaultAudio);
-	if (NS.ChatJoin.Enabled !== undefined) {
+	if (typeof NS.ChatJoin.Enabled !== "undefined") {
+		// Convert old version of settings
 		NS.ChatJoin.AlertType = NS.ChatJoin.Enabled ? NotificationAlertType.TITLEPREFIX : NotificationAlertType.NONE;
 		NS.ChatJoin.Audio = NotificationAudioType.NONE;
 		delete NS.ChatJoin.Enabled;
@@ -434,7 +445,7 @@ function PreferenceInitPlayer() {
 	if (typeof NS.ChatJoin.Lovers !== "boolean") NS.ChatJoin.Lovers = false;
 	if (typeof NS.ChatJoin.Friendlist !== "boolean") NS.ChatJoin.Friendlist = false;
 	if (typeof NS.ChatJoin.Subs !== "boolean") NS.ChatJoin.Subs = false;
-	if (typeof NS.Audio !== undefined) delete NS.Audio;
+	if (typeof NS.Audio !== "undefined") delete NS.Audio;
 	if (typeof NS.Disconnect !== "object") NS.Disconnect = PreferenceInitNotificationSetting(NS.Disconnect, defaultAudio);
 	if (typeof NS.Larp !== "object") NS.Larp = PreferenceInitNotificationSetting(NS.Larp, defaultAudio, NotificationEventType.NONE);
 	if (typeof NS.Test !== "object") NS.Test = PreferenceInitNotificationSetting(NS.Test, defaultAudio, NotificationAlertType.TITLEPREFIX);
@@ -1794,6 +1805,7 @@ function PreferenceSubscreenNotificationsRun() {
 	// Left-aligned text controls
 	MainCanvas.textAlign = "left";
 	const NS = Player.NotificationSettings;
+
 	DrawText(TextGet("NotificationsPreferences"), 500, 125, "Black", "Gray");
 	DrawText(TextGet("NotificationsExplanation"), 500, 190, "Black", "Gray");
 	DrawEmptyRect(1190, 92, 510, 125, "Black", 2);
@@ -1801,32 +1813,40 @@ function PreferenceSubscreenNotificationsRun() {
 	DrawText(TextGet("NotificationsAudioExplanation1"), 1275, 125, "Black", "Gray");
 	DrawText(TextGet("NotificationsAudioExplanation2"), 1200, 190, "Black", "Gray");
 	PreferenceNotificationsDrawSetting(500, 235, TextGet("NotificationsBeeps"), NS.Beeps);
+
 	PreferenceNotificationsDrawSetting(500, 315, TextGet("NotificationsChatMessage"), NS.ChatMessage);
+	DrawText(TextGet("NotificationsOnly"), 550, 427, "Black", "Gray");
 	if (NS.ChatMessage.AlertType > 0) {
-		DrawCheckbox(1260, 315, 64, 64, TextGet("NotificationsChatActions"), NS.ChatMessage.IncludeActions);
+		DrawCheckbox(700, 395, 64, 64, TextGet("NotificationsChatMessageNormal"), NS.ChatMessage.Normal);
+		DrawCheckbox(1150, 395, 64, 64, TextGet("NotificationsChatMessageWhisper"), NS.ChatMessage.Whisper);
+		DrawCheckbox(1500, 395, 64, 64, TextGet("NotificationsChatMessageActivity"), NS.ChatMessage.Activity);
 	} else {
-		DrawCheckboxDisabled(1250, 315, 64, 64, TextGet("NotificationsChatActions"));
+		DrawCheckboxDisabled(700, 395, 64, 64, TextGet("NotificationsChatMessageNormal"));
+		DrawCheckboxDisabled(1150, 395, 64, 64, TextGet("NotificationsChatMessageWhisper"));
+		DrawCheckboxDisabled(1500, 395, 64, 64, TextGet("NotificationsChatMessageActivity"));
 	}
-	PreferenceNotificationsDrawSetting(500, 395, TextGet("NotificationsChatJoin"), NS.ChatJoin);
-	DrawText(TextGet("NotificationsChatJoinOnly"), 550, 507, "Black", "Gray");
+
+	PreferenceNotificationsDrawSetting(500, 475, TextGet("NotificationsChatJoin"), NS.ChatJoin);
+	DrawText(TextGet("NotificationsOnly"), 550, 587, "Black", "Gray");
 	if (NS.ChatJoin.AlertType > 0) {
-		DrawCheckbox(700, 475, 64, 64, TextGet("NotificationsChatJoinOwner"), NS.ChatJoin.Owner);
-		DrawCheckbox(980, 475, 64, 64, TextGet("NotificationsChatJoinLovers"), NS.ChatJoin.Lovers);
-		DrawCheckbox(1260, 475, 64, 64, TextGet("NotificationsChatJoinFriendlist"), NS.ChatJoin.Friendlist);
-		DrawCheckbox(1540, 475, 64, 64, TextGet("NotificationsChatJoinSubs"), NS.ChatJoin.Subs);
+		DrawCheckbox(700, 555, 64, 64, TextGet("NotificationsChatJoinOwner"), NS.ChatJoin.Owner);
+		DrawCheckbox(980, 555, 64, 64, TextGet("NotificationsChatJoinLovers"), NS.ChatJoin.Lovers);
+		DrawCheckbox(1260, 555, 64, 64, TextGet("NotificationsChatJoinFriendlist"), NS.ChatJoin.Friendlist);
+		DrawCheckbox(1540, 555, 64, 64, TextGet("NotificationsChatJoinSubs"), NS.ChatJoin.Subs);
 	} else {
-		DrawCheckboxDisabled(700, 475, 64, 64, TextGet("NotificationsChatJoinOwner"));
-		DrawCheckboxDisabled(980, 475, 64, 64, TextGet("NotificationsChatJoinLovers"));
-		DrawCheckboxDisabled(1260, 475, 64, 64, TextGet("NotificationsChatJoinFriendlist"));
-		DrawCheckboxDisabled(1540, 475, 64, 64, TextGet("NotificationsChatJoinSubs"));
+		DrawCheckboxDisabled(700, 555, 64, 64, TextGet("NotificationsChatJoinOwner"));
+		DrawCheckboxDisabled(980, 555, 64, 64, TextGet("NotificationsChatJoinLovers"));
+		DrawCheckboxDisabled(1260, 555, 64, 64, TextGet("NotificationsChatJoinFriendlist"));
+		DrawCheckboxDisabled(1540, 555, 64, 64, TextGet("NotificationsChatJoinSubs"));
 	}
-	PreferenceNotificationsDrawSetting(500, 555, TextGet("NotificationsDisconnect"), NS.Disconnect);
-	PreferenceNotificationsDrawSetting(500, 635, TextGet("NotificationsLarp"), NS.Larp);
+
+	PreferenceNotificationsDrawSetting(500, 635, TextGet("NotificationsDisconnect"), NS.Disconnect);
+	PreferenceNotificationsDrawSetting(500, 715, TextGet("NotificationsLarp"), NS.Larp);
 	PreferenceNotificationsDrawSetting(500, 820, "", NS.Test);
 	MainCanvas.textAlign = "center";
 
 	// Test buttons
-	DrawEmptyRect(500, 795, 1400, 0, "Black", 1);
+	DrawEmptyRect(500, 800, 1400, 0, "Black", 1);
 	DrawButton(800, 820, 450, 64, TextGet("NotificationsTestRaise"), "White");
 	DrawButton(1286, 820, 450, 64, TextGet("NotificationsTestReset"), "White");
 }
@@ -1864,19 +1884,24 @@ function PreferenceSubscreenNotificationsClick() {
 	// Checkboxes
 	const NS = Player.NotificationSettings;
 	PreferenceNotificationsClickSetting(500, 235, NS.Beeps, NotificationEventType.BEEP);
+
 	PreferenceNotificationsClickSetting(500, 315, NS.ChatMessage, NotificationEventType.CHATMESSAGE);
-	if (MouseIn(1260, 315, 64, 64) && NS.ChatMessage.AlertType > 0) {
-		NS.ChatMessage.IncludeActions = !NS.ChatMessage.IncludeActions;
+	if (NS.ChatMessage.AlertType > 0) {
+		if (MouseIn(700, 395, 64, 64)) NS.ChatMessage.Normal = !NS.ChatMessage.Normal;
+		if (MouseIn(1150, 395, 64, 64)) NS.ChatMessage.Whisper = !NS.ChatMessage.Whisper;
+		if (MouseIn(1500, 395, 64, 64)) NS.ChatMessage.Activity = !NS.ChatMessage.Activity;
 	}
-	PreferenceNotificationsClickSetting(500, 395, NS.ChatJoin, NotificationEventType.CHATJOIN);
+
+	PreferenceNotificationsClickSetting(500, 475, NS.ChatJoin, NotificationEventType.CHATJOIN);
 	if (NS.ChatJoin.AlertType > 0) {
-		if (MouseIn(700, 475, 64, 64)) NS.ChatJoin.Owner = !NS.ChatJoin.Owner;
-		if (MouseIn(980, 475, 64, 64)) NS.ChatJoin.Lovers = !NS.ChatJoin.Lovers;
-		if (MouseIn(1260, 475, 64, 64)) NS.ChatJoin.Friendlist = !NS.ChatJoin.Friendlist;
-		if (MouseIn(1540, 475, 64, 64)) NS.ChatJoin.Subs = !NS.ChatJoin.Subs;
+		if (MouseIn(700, 555, 64, 64)) NS.ChatJoin.Owner = !NS.ChatJoin.Owner;
+		if (MouseIn(980, 555, 64, 64)) NS.ChatJoin.Lovers = !NS.ChatJoin.Lovers;
+		if (MouseIn(1260, 555, 64, 64)) NS.ChatJoin.Friendlist = !NS.ChatJoin.Friendlist;
+		if (MouseIn(1540, 555, 64, 64)) NS.ChatJoin.Subs = !NS.ChatJoin.Subs;
 	}
-	PreferenceNotificationsClickSetting(500, 555, NS.Disconnect, NotificationEventType.DISCONNECT);
-	PreferenceNotificationsClickSetting(500, 635, NS.Larp, NotificationEventType.LARP);
+
+	PreferenceNotificationsClickSetting(500, 635, NS.Disconnect, NotificationEventType.DISCONNECT);
+	PreferenceNotificationsClickSetting(500, 715, NS.Larp, NotificationEventType.LARP);
 	PreferenceNotificationsClickSetting(500, 820, NS.Test);
 
 	// Test buttons

--- a/BondageClub/Screens/Character/Preference/Text_Preference.csv
+++ b/BondageClub/Screens/Character/Preference/Text_Preference.csv
@@ -267,11 +267,13 @@ NotificationsAlertType2,Popup
 NotificationsExplanation,Raise notifications for missed events:
 NotificationsAudioExplanation1,: Play a sound for only
 NotificationsAudioExplanation2,the first occurrence of an event
+NotificationsOnly,Only:
 NotificationsBeeps,Beeps
 NotificationsChatMessage,Messages in chat rooms
-NotificationsChatActions,Include item/activity messages
+NotificationsChatMessageNormal,Normal Messages
+NotificationsChatMessageWhisper,Whispers
+NotificationsChatMessageActivity,Items/Activities
 NotificationsChatJoin,Players entering chat rooms
-NotificationsChatJoinOnly,Only:
 NotificationsChatJoinOwner,Owner
 NotificationsChatJoinLovers,Lovers
 NotificationsChatJoinFriendlist,Friends

--- a/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
+++ b/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
@@ -1793,8 +1793,8 @@ function ChatRoomMessage(data) {
 						AudioPlayContent(data);
 
 					// Raise a notification if required
-					if (data.Type === "Action" && IsPlayerInvolved)
-						ChatRoomNotificationRaiseChatMessage(SenderCharacter, msg, true);
+					if (data.Type === "Action" && IsPlayerInvolved && Player.NotificationSettings.ChatMessage.Activity)
+						ChatRoomNotificationRaiseChatMessage(SenderCharacter, msg);
 				}
 			}
 
@@ -1834,7 +1834,9 @@ function ChatRoomMessage(data) {
 						return;
 					}
 
-					ChatRoomNotificationRaiseChatMessage(SenderCharacter, chatMsg, false);
+					if ((data.Type === "Chat" && Player.NotificationSettings.ChatMessage.Normal)
+						|| (data.Type === "Whisper" && Player.NotificationSettings.ChatMessage.Whisper))
+						ChatRoomNotificationRaiseChatMessage(SenderCharacter, chatMsg);
 				}
 				else if (data.Type == "Emote") {
 					if (HideOthersMessages && !msg.toLowerCase().includes(Player.Name.toLowerCase())) {
@@ -1853,7 +1855,8 @@ function ChatRoomMessage(data) {
 					}
 					else msg = "*" + SenderCharacter.Name + " " + msg + "*";
 
-					ChatRoomNotificationRaiseChatMessage(SenderCharacter, msg, false);
+					if (Player.NotificationSettings.ChatMessage.Normal)
+						ChatRoomNotificationRaiseChatMessage(SenderCharacter, msg);
 				}
 				else if (data.Type == "Action") msg = "(" + msg + ")";
 				else if (data.Type == "ServerMessage") msg = "<b>" + msg + "</b>";
@@ -1893,8 +1896,8 @@ function ChatRoomMessage(data) {
 				if ((Player.ChatSettings != null) && (Player.ChatSettings.ShowActivities != null) && !Player.ChatSettings.ShowActivities) return;
 
 				// Raise a notification if required
-				if (TargetMemberNumber === Player.MemberNumber)
-					ChatRoomNotificationRaiseChatMessage(SenderCharacter, msg, true);
+				if (TargetMemberNumber === Player.MemberNumber && Player.NotificationSettings.ChatMessage.Activity)
+					ChatRoomNotificationRaiseChatMessage(SenderCharacter, msg);
 			}
 
 			// Adds the message and scrolls down unless the user has scrolled up
@@ -3116,13 +3119,11 @@ function ChatRoomNotificationNewMessageVisible() {
  * Raise a notification for the new chat message if required
  * @param {Character} C - The character that sent the message
  * @param {string} msg - The text of the message
- * @param {boolean} isAction - If TRUE the chat message was an automatic action or activity rather than a manually typed message
  * @returns {void} - Nothing
  */
-function ChatRoomNotificationRaiseChatMessage(C, msg, isAction) {
+function ChatRoomNotificationRaiseChatMessage(C, msg) {
 	if (C.ID !== 0
 		&& Player.NotificationSettings.ChatMessage.AlertType !== NotificationAlertType.NONE
-		&& (!isAction || Player.NotificationSettings.ChatMessage.IncludeActions)
 		&& !ChatRoomNotificationNewMessageVisible())
 	{
 		NotificationRaise(NotificationEventType.CHATMESSAGE, { body: msg, character: C, useCharAsIcon: true });

--- a/BondageClub/Scripts/Notification.js
+++ b/BondageClub/Scripts/Notification.js
@@ -43,9 +43,9 @@ const NotificationAudioType = {
 /**
  * A class to track the state of each notification event type and handle actions based on the player's settings
  */
-class NotificationEvent {
+class NotificationEventHandler {
 	/**
-	 * Creates a new NotificationEvent for the specified event type
+	 * Creates a new NotificationEventHandler for the specified event type
 	 * @param {NotificationEventType} eventType - The
 	 * @param {NotificationSetting} settings - The player settings corresponding to the event type
 	 */
@@ -62,11 +62,14 @@ class NotificationEvent {
 	 * @returns {void} - Nothing
 	 */
 	raise(data) {
-		const raise = this.settings.AlertType !== NotificationAlertType.NONE;
-		if (raise) {
+		if (this.settings.AlertType !== NotificationAlertType.NONE) {
 			this.raisedCount++;
 			if (this.settings.AlertType === NotificationAlertType.POPUP) {
-				this.raisePopup(data);
+				if (NotificationPopupsEnabled(this.eventType, data)) {
+					this.raisePopup(data);
+				} else {
+					NotificationTitleUpdate();
+				}
 			}
 			else if (this.settings.AlertType === NotificationAlertType.TITLEPREFIX) {
 				NotificationTitleUpdate();
@@ -83,31 +86,35 @@ class NotificationEvent {
 	 * @returns {void} - Nothing
 	 */
 	raisePopup(data) {
-		if (NotificationPopupsEnabled()) {
-			// Determine the popup's options based on the data passed into the event raise call
-			let icon = "Icons/Logo.png";
-			let titleStart = "";
-			let titleEnd = "";
-			let C = data.character;
-			if (!C && data.memberNumber) C = Character.find(C => C.MemberNumber === data.memberNumber);
-			if (C && 'icon' in Notification.prototype) icon = DrawCharacterSegment(C, 168, 50, 164, 164).toDataURL("image/png");
-			if (data.characterName) titleStart = data.characterName + " - ";
-			else if (C) titleStart = C.Name + " - ";
-			if (data.chatRoomName) titleEnd = DialogFindPlayer("NotificationTitleFromRoom").replace("ChatRoomName", "'" + data.chatRoomName + "'");
+		// Determine the popup's options based on the data passed into the event raise call
+		let icon = "Icons/Logo.png";
+		let titleStart = "";
+		let titleEnd = "";
+		let C = data.character;
+		if (!C && data.memberNumber) C = Character.find(C => C.MemberNumber === data.memberNumber);
+		if (C && 'icon' in Notification.prototype) icon = DrawCharacterSegment(C, 168, 50, 164, 164).toDataURL("image/png");
+		if (data.characterName) titleStart = data.characterName + " - ";
+		else if (C) titleStart = C.Name + " - ";
+		if (data.chatRoomName) titleEnd = DialogFindPlayer("NotificationTitleFromRoom").replace("ChatRoomName", "'" + data.chatRoomName + "'");
 			
-			// Define the (supported) options of the popup and create it
-			let title = titleStart + DialogFindPlayer("NotificationTitle" + this.eventType) + titleEnd;
-			let options = {};
-			if ('silent' in Notification.prototype) options.silent = !this.playAudio(true);
-			if ('body' in Notification.prototype && data.body) options.body = data.body;
-			if ('renotify' in Notification.prototype) options.renotify = true;
-			if ('tag' in Notification.prototype) options.tag = "BondageClub" + this.eventType;
-			if ('icon' in Notification.prototype) options.icon = icon;
-			if ('data' in Notification.prototype) options.data = this.eventType;
-			this.popup = new Notification(title, options);
-			if ('onclick' in Notification.prototype && 'data' in Notification.prototype) {
-				this.popup.onclick = function () { NotificationReset(this.data); };
-			}
+		// Define the (supported) options of the popup and create it
+		let title = titleStart + DialogFindPlayer("NotificationTitle" + this.eventType) + titleEnd;
+		let options = {};
+		if ('silent' in Notification.prototype) options.silent = !this.playAudio(true);
+		if ('body' in Notification.prototype && data.body) options.body = data.body;
+		if ('renotify' in Notification.prototype) options.renotify = true;
+		if ('tag' in Notification.prototype) options.tag = "BondageClub" + this.eventType;
+		if ('icon' in Notification.prototype) options.icon = icon;
+		if ('data' in Notification.prototype) options.data = this.eventType;
+
+		// Create the notification
+		this.popup = new Notification(title, options);
+		if ('onclick' in Notification.prototype) {
+			this.popup.onclick = function () {
+				if ('data' in Notification.prototype) NotificationReset(this.data);
+				window.focus();
+				this.close();
+			};
 		}
 	}
 
@@ -117,19 +124,17 @@ class NotificationEvent {
 	 * @returns {boolean} - Whether audio should be played
 	 */
 	playAudio(usingPopup) {
-		let playAudio = false;
 		if (this.settings.Audio === NotificationAudioType.NONE) {
-			playAudio = false;
+			return false;
 		} else if (this.eventType === NotificationEventType.BEEP && Player.AudioSettings.PlayBeeps) {
-			playAudio = false; // Sound already played in ServerAccountBeep()
+			return false; // Sound already played in ServerAccountBeep()
 		} else if (this.settings.AlertType === NotificationAlertType.POPUP && !usingPopup && 'silent' in Notification.prototype) {
-			playAudio = false; // The popup will play the sound instead
+			return false; // The popup will play the sound instead
 		} else if (this.settings.Audio === NotificationAudioType.FIRST && this.raisedCount === 1) {
-			playAudio = true;
+			return true;
 		} else if (this.settings.Audio === NotificationAudioType.REPEAT) {
-			playAudio = true;
+			return true;
 		}
-		return playAudio;
 	}
 
 	/**
@@ -146,7 +151,7 @@ class NotificationEvent {
 	}
 }
 
-let NotificationEvents;
+let NotificationEventHandlers;
 var NotificationAlertTypeList = [];
 var NotificationAudioTypeList = [];
 
@@ -155,14 +160,14 @@ var NotificationAudioTypeList = [];
  * @returns {void} - Nothing
  */
 function NotificationLoad() {
-	// Create a dictionary mapping the event types to instances of the class
-	NotificationEvents = {};
-	NotificationEvents[NotificationEventType.CHATMESSAGE] = new NotificationEvent(NotificationEventType.CHATMESSAGE, Player.NotificationSettings.ChatMessage);
-	NotificationEvents[NotificationEventType.CHATJOIN] = new NotificationEvent(NotificationEventType.CHATJOIN, Player.NotificationSettings.ChatJoin);
-	NotificationEvents[NotificationEventType.BEEP] = new NotificationEvent(NotificationEventType.BEEP, Player.NotificationSettings.Beeps);
-	NotificationEvents[NotificationEventType.DISCONNECT] = new NotificationEvent(NotificationEventType.DISCONNECT, Player.NotificationSettings.Disconnect);
-	NotificationEvents[NotificationEventType.TEST] = new NotificationEvent(NotificationEventType.TEST, Player.NotificationSettings.Test);
-	NotificationEvents[NotificationEventType.LARP] = new NotificationEvent(NotificationEventType.LARP, Player.NotificationSettings.Larp);
+	// Create the list of event handlers
+	NotificationEventHandlers = {};
+	NotificationEventHandlerSetup(NotificationEventType.CHATMESSAGE, Player.NotificationSettings.ChatMessage);
+	NotificationEventHandlerSetup(NotificationEventType.CHATJOIN, Player.NotificationSettings.ChatJoin);
+	NotificationEventHandlerSetup(NotificationEventType.BEEP, Player.NotificationSettings.Beeps);
+	NotificationEventHandlerSetup(NotificationEventType.DISCONNECT, Player.NotificationSettings.Disconnect);
+	NotificationEventHandlerSetup(NotificationEventType.TEST, Player.NotificationSettings.Test);
+	NotificationEventHandlerSetup(NotificationEventType.LARP, Player.NotificationSettings.Larp);
 
 	// Create the alert and audio type lists for the Preferences screen
 	NotificationAlertTypeList.push(NotificationAlertType.NONE);
@@ -172,14 +177,23 @@ function NotificationLoad() {
 }
 
 /**
+ * Create a handler instance to track and handle notifications of that event type
+ * @param {NotificationEventType} eventType
+ * @param {NotificationSetting} setting
+ */
+function NotificationEventHandlerSetup(eventType, setting) {
+	NotificationEventHandlers[eventType] = new NotificationEventHandler(eventType, setting);
+}
+
+/**
  * Create a new notification
  * @param {NotificationEventType} eventType - The type of event that occurred
  * @param {object} [data={}] - Data relating to the event that can be passed into a popup
  * @returns {void} - Nothing
  */
 function NotificationRaise(eventType, data = {}) {
-	if (NotificationEvents) {
-		NotificationEvents[eventType].raise(data);
+	if (NotificationEventHandlers) {
+		NotificationEventHandlers[eventType].raise(data);
 	}
 }
 
@@ -189,8 +203,8 @@ function NotificationRaise(eventType, data = {}) {
  * @returns {void} - Nothing
  */
 function NotificationReset(eventType) {
-	if (NotificationEvents) {
-		NotificationEvents[eventType].reset(true);
+	if (NotificationEventHandlers) {
+		NotificationEventHandlers[eventType].reset(true);
 	}
 }
 
@@ -199,15 +213,17 @@ function NotificationReset(eventType) {
  * @returns {void} - Nothing
  */
 function NotificationResetAll() {
-	Object.values(NotificationEvents).forEach(N => N.reset(false));
+	Object.values(NotificationEventHandlers).forEach(N => N.reset(false));
 	NotificationTitleUpdate();
 }
 
 /** 
  * Returns whether popup notifications are permitted
+ * @param {NotificationEventType} eventType - The type of event that occurred
+ * @param {object} [data={}] - Data relating to the event that can be passed into a popup
  * @returns {boolean} - Whether popups can appear
  */
-function NotificationPopupsEnabled() {
+function NotificationPopupsEnabled(eventType, data) {
 	if (!("Notification" in window)) {
 		return false;
 	} else if (Notification.permission === "granted") {
@@ -215,7 +231,11 @@ function NotificationPopupsEnabled() {
 	} else if (Notification.permission === 'denied') {
 		return false;
 	} else if (Notification.permission === 'default') {
-		Notification.requestPermission();
+		Notification.requestPermission().then(() => {
+			if (Notification.permission === "granted") {
+				NotificationRaise(eventType, data);
+			}
+		});
 		return false;
 	} else {
 		return false;
@@ -227,7 +247,7 @@ function NotificationPopupsEnabled() {
  * @returns {void} - Nothing
  */
 function NotificationTitleUpdate() {
-	const totalRaisedCount = Object.values(NotificationEvents).reduce((a, b) => a + b.raisedCount, 0);
+	const totalRaisedCount = Object.values(NotificationEventHandlers).reduce((a, b) => a + b.raisedCount, 0);
 	const titlePrefix = totalRaisedCount === 0 ? "" : "(" + totalRaisedCount.toString() + ") ";
 	document.title = titlePrefix + "Bondage Club";
 }


### PR DESCRIPTION
- In the chat messages notification settings players can now separately select Normal Messages, Whispers and Items/Activities to be included or excluded.
- If a popup notification is expected but isn't available for some reason, the "(1) in title" notification will now occur in its place. This covers situations like a user switching from a device that supports popups to one that doesn't.
- If the user was prompted by their browser to allow or block notifications, the particular popup that triggered this request would not appear. Now it will appear after the permissions request is completed (if the user selected Allow).
- Added steps to the popup's onclick to ensure that it refocuses on the game on all OS's.