### PR TITLE
Cleanup: Scripts formatting (Part 1 - little edits)

### DIFF
--- a/BondageClub/Scripts/Activity.js
+++ b/BondageClub/Scripts/Activity.js
@@ -25,7 +25,7 @@ function ActivityDictionaryLoad() {
 	// Tries to read it from cache first
 	var FullPath = "Screens/Character/Preference/ActivityDictionary.csv";
 	var TranslationPath = FullPath.replace(".csv", "_" + TranslationLanguage + ".txt");
-	
+
 	if (CommonCSVCache[FullPath]) {
 		ActivityDictionary = JSON.parse(JSON.stringify(CommonCSVCache[FullPath]));
 	} else {
@@ -37,27 +37,27 @@ function ActivityDictionaryLoad() {
 			}
 		});
 	}
-	
+
 	// If a translation file is available, we open the txt file and keep it in cache
-	if (TranslationAvailable(TranslationPath)) 
+	if (TranslationAvailable(TranslationPath))
 		CommonGet(TranslationPath, function () {
 			if (this.status == 200) {
 				TranslationCache[TranslationPath] = TranslationParseTXT(this.responseText);
 				ActivityTranslate(TranslationPath);
 			}
 		});
-		
+
 	ActivityTranslate(TranslationPath);
 }
 
 /**
  * Translates the activity dictionary.
- * @param {string} CachePath - Path to the language cache. 
+ * @param {string} CachePath - Path to the language cache.
  */
-function ActivityTranslate(CachePath) { 
+function ActivityTranslate(CachePath) {
 	if (!Array.isArray(TranslationCache[CachePath])) return;
-	
-	for (let T = 0; T < ActivityDictionary.length; T++) { 
+
+	for (let T = 0; T < ActivityDictionary.length; T++) {
 		if (ActivityDictionary[T][1]) {
 			let indexText = TranslationCache[CachePath].indexOf(ActivityDictionary[T][1].trim());
 			if (indexText >= 0) {
@@ -80,7 +80,7 @@ function ActivityDictionaryText(KeyWord) {
 }
 
 /**
- * Builds the possible dialog activity options based on the character settings 
+ * Builds the possible dialog activity options based on the character settings
  * @param {Character} C - The character for which to build the activity dialog options
  * @return {void} - Nothing
  */
@@ -157,7 +157,7 @@ function ActivityDialogBuild(C) {
  * @param {Character} C - The character on which the activity is performed
  * @param {string} A - The activity performed
  * @param {string} Z - The group/zone name where the activity was performed
- * @param {number} [count=1] - If the activity is done repeatedly, this defines the number of times, the activity is done. 
+ * @param {number} [count=1] - If the activity is done repeatedly, this defines the number of times, the activity is done.
  * If you don't want an activity to modify arousal, set this parameter to '0'
  * @return {void} - Nothing
  */
@@ -185,7 +185,7 @@ function ActivityEffect(S, C, A, Z, Count) {
  * @param {Character} C - The character on which the activity is performed
  * @param {number} Amount - The base amount of arousal to add
  * @param {string} Z - The group/zone name where the activity was performed
- * @param {number} [count=1] - If the activity is done repeatedly, this defines the number of times, the activity is done. 
+ * @param {number} [count=1] - If the activity is done repeatedly, this defines the number of times, the activity is done.
  * If you don't want an activity to modify arousal, set this parameter to '0'
  * @return {void} - Nothing
  */
@@ -457,17 +457,17 @@ function ActivityTimerProgress(C, Progress) {
 	// Decrease the vibratorlevel to 0 if not being aroused, while also updating the change time to reset the vibrator animation
 	if (Progress < 0) {
 		if (C.ArousalSettings.VibratorLevel != 0) {
-			C.ArousalSettings.VibratorLevel = 0
-			C.ArousalSettings.ChangeTime = CommonTime()
+			C.ArousalSettings.VibratorLevel = 0;
+			C.ArousalSettings.ChangeTime = CommonTime();
 		}
 	}
-	
+
 	if (C.ArousalSettings.Progress < 0) C.ArousalSettings.Progress = 0;
 	if (C.ArousalSettings.Progress > 100) C.ArousalSettings.Progress = 100;
-	
+
 	// Update the recent change time, so that on other player's screens the character's arousal meter will vibrate again when vibes start
 	if (C.ArousalSettings.Progress == 0) {
-		C.ArousalSettings.ChangeTime = CommonTime()
+		C.ArousalSettings.ChangeTime = CommonTime();
 	}
 
 	// Out of orgasm mode, it can affect facial expressions at every 10 steps
@@ -481,7 +481,7 @@ function ActivityTimerProgress(C, Progress) {
 }
 
 /**
- * Set the current vibrator level for drawing purposes 
+ * Set the current vibrator level for drawing purposes
  * @param {Character} C - Character for which the timer is progressing
  * @param {number} Level - Level from 0 to 4 (higher = more vibration)
  * @returns {void} - Nothing
@@ -489,8 +489,8 @@ function ActivityTimerProgress(C, Progress) {
 function ActivityVibratorLevel(C, Level) {
 	if (C.ArousalSettings != null) {
 		if (Level != C.ArousalSettings.VibratorLevel) {
-			C.ArousalSettings.VibratorLevel = Level
-			C.ArousalSettings.ChangeTime = CommonTime()
+			C.ArousalSettings.VibratorLevel = Level;
+			C.ArousalSettings.ChangeTime = CommonTime();
 		}
 	}
 }
@@ -527,8 +527,8 @@ function ActivityRun(C, Activity) {
 
 	if (C.ID == 0) {
 		if (Activity.MakeSound) {
-			AutoPunishGagActionFlag = true
-			AutoShockGagActionFlag = true
+			AutoPunishGagActionFlag = true;
+			AutoShockGagActionFlag = true;
 		}
 	}
 
@@ -547,9 +547,9 @@ function ActivityRun(C, Activity) {
 		ServerSend("ChatRoomChat", { Content: ((C.ID == 0) ? "ChatSelf-" : "ChatOther-") + C.FocusGroup.Name + "-" + Activity.Name, Type: "Activity", Dictionary: Dictionary });
 
 		if (C.ID == 0 && Activity.Name.indexOf("Struggle") >= 0 )
-			
-			ChatRoomStimulationMessage("StruggleAction")
-		
+
+			ChatRoomStimulationMessage("StruggleAction");
+
 		// Exits from dialog to see the result
 		DialogLeave();
 

--- a/BondageClub/Scripts/AfkTimer.js
+++ b/BondageClub/Scripts/AfkTimer.js
@@ -1,4 +1,4 @@
-"use strict"
+"use strict";
 
 var AfkTimerIncrementMs = 1000 * 60; // 1 minutes
 var AfkTimerTimout = 5; // AfkTimerIncrementMs * 5  ==> 5 minutes
@@ -54,7 +54,7 @@ function AfkTimerStop() {
 
 /**
  * Enables or disables the afk timer. Is called, when the player changes her settings in the preferences dialog
- * @param {boolean} Enabled - Determines, wether the afk timer will be enabled (true) or disabled (false). 
+ * @param {boolean} Enabled - Determines, wether the afk timer will be enabled (true) or disabled (false).
  * @returns {void} - Nothing
  */
 function AfkTimerSetEnabled(Enabled) {

--- a/BondageClub/Scripts/Asset.js
+++ b/BondageClub/Scripts/Asset.js
@@ -77,7 +77,7 @@ function AssetGroupAdd(NewAssetFamily, NewAsset) {
 		FreezeActivePose: Array.isArray(NewAsset.FreezeActivePose) ? NewAsset.FreezeActivePose : [],
 		PreviewZone: NewAsset.PreviewZone,
 		DynamicGroupName: NewAsset.DynamicGroupName || NewAsset.Group,
-	}
+	};
 	AssetGroup.push(A);
 	AssetCurrentGroup = A;
 }
@@ -156,13 +156,13 @@ function AssetAdd(NewAsset, ExtendedConfig) {
 		BodyCosplay: (NewAsset.BodyCosplay == null) ? AssetCurrentGroup.BodyCosplay : NewAsset.BodyCosplay,
 		OverrideBlinking: (NewAsset.OverrideBlinking == null) ? false : NewAsset.OverrideBlinking,
 		DialogSortOverride: NewAsset.DialogSortOverride,
-		DynamicDescription: (typeof NewAsset.DynamicDescription === 'function') ? NewAsset.DynamicDescription : function () { return this.Description },
-		DynamicPreviewIcon: (typeof NewAsset.DynamicPreviewIcon === 'function') ? NewAsset.DynamicPreviewIcon : function () { return "" },
-		DynamicAllowInventoryAdd: (typeof NewAsset.DynamicAllowInventoryAdd === 'function') ? NewAsset.DynamicAllowInventoryAdd : function () { return true },
-		DynamicExpressionTrigger: (typeof NewAsset.DynamicExpressionTrigger === 'function') ? NewAsset.DynamicExpressionTrigger : function () { return this.ExpressionTrigger },
-		DynamicName: (typeof NewAsset.DynamicName === 'function') ? NewAsset.DynamicName : function () { return this.Name },
+		DynamicDescription: (typeof NewAsset.DynamicDescription === 'function') ? NewAsset.DynamicDescription : function () { return this.Description; },
+		DynamicPreviewIcon: (typeof NewAsset.DynamicPreviewIcon === 'function') ? NewAsset.DynamicPreviewIcon : function () { return ""; },
+		DynamicAllowInventoryAdd: (typeof NewAsset.DynamicAllowInventoryAdd === 'function') ? NewAsset.DynamicAllowInventoryAdd : function () { return true; },
+		DynamicExpressionTrigger: (typeof NewAsset.DynamicExpressionTrigger === 'function') ? NewAsset.DynamicExpressionTrigger : function () { return this.ExpressionTrigger; },
+		DynamicName: (typeof NewAsset.DynamicName === 'function') ? NewAsset.DynamicName : function () { return this.Name; },
 		DynamicGroupName: (NewAsset.DynamicGroupName || AssetCurrentGroup.DynamicGroupName),
-		DynamicActivity: (typeof NewAsset.DynamicActivity === 'function') ? NewAsset.DynamicActivity : function () { return NewAsset.Activity },
+		DynamicActivity: (typeof NewAsset.DynamicActivity === 'function') ? NewAsset.DynamicActivity : function () { return NewAsset.Activity; },
 		DynamicAudio: (typeof NewAsset.DynamicAudio === 'function') ? NewAsset.DynamicAudio : null,
 		CharacterRestricted: typeof NewAsset.CharacterRestricted === 'boolean' ? NewAsset.CharacterRestricted : false,
 		AllowRemoveExclusive: typeof NewAsset.AllowRemoveExclusive === 'boolean' ? NewAsset.CharacterRestricted : false,
@@ -181,7 +181,7 @@ function AssetAdd(NewAsset, ExtendedConfig) {
 		AllowExpression: NewAsset.AllowExpression,
 		MirrorExpression: NewAsset.MirrorExpression,
 		FixedPosition: typeof NewAsset.FixedPosition === 'boolean' ? NewAsset.FixedPosition : false,
-	}
+	};
 	if (A.MinOpacity > A.Opacity) A.MinOpacity = A.Opacity;
 	if (A.MaxOpacity < A.Opacity) A.MaxOpacity = A.Opacity;
 	A.Layer = AssetBuildLayer(NewAsset, A);
@@ -460,7 +460,7 @@ function AssetGetActivity(Family, Name) {
  * @param {Array.<{Name: string, Group: string}>} AssetArray - The arrays of items to clean
  * @returns {Array.<{Name: string, Group: string}>} - The cleaned up array
  */
-function AssetCleanArray(AssetArray) { 
+function AssetCleanArray(AssetArray) {
 	var CleanArray = [];
 	// Only save the existing items
 	for (let A = 0; A < Asset.length; A++)

--- a/BondageClub/Scripts/Audio.js
+++ b/BondageClub/Scripts/Audio.js
@@ -70,7 +70,6 @@ var AudioActions = [
 		IsAction: (data) => ["FuturisticPanelGagMouthSetLightBall", "FuturisticPanelGagMouthSetBall", "FuturisticPanelGagMouthSetPadded", "FuturisticPanelGagMouthSetPlug"].find(A => data.Content.includes(A)),
 		Sound: "SciFiPump"
 	},
-	
 	{
 		IsAction: (data) => ["deflates", "Sucloosens"].find(A => data.Content.includes(A)),
 		Sound: "Deflation"
@@ -98,7 +97,7 @@ var AudioActions = [
 	{
 		IsAction: (data) => ["FuturisticChastityBeltSetPunish", "FuturisticPanelGagMouthSetAutoPunish", "SciFiPleasurePantiesBeep"].find(A => data.Content.includes(A)),
 		GetAudioInfo: AudioSciFiBeepSounds
-	},	
+	},
 	{
 		IsAction: (data) => ["FuturisticPanelGagMouthSetAutoInflate"].find(A => data.Content.includes(A)),
 		Sound: "Inflation"
@@ -134,7 +133,7 @@ function AudioPlayInstantSound(src, volume) {
 }
 
 /**
- * Begins to play a sound when applying/removing an item 
+ * Begins to play a sound when applying/removing an item
  * @param {string} SourceFile - Source of the audio file to play
  * @returns {void} - Nothing
  */
@@ -148,7 +147,7 @@ function AudioDialogStart(SourceFile) {
 }
 
 /**
- * Stops playing the sound when done applying/removing an item 
+ * Stops playing the sound when done applying/removing an item
  * @returns {void} - Nothing
  */
 function AudioDialogStop() {
@@ -206,7 +205,7 @@ function AudioGetFileName(sound) {
 /**
  * Processes which sound should be played for items
  * @param {object} data - Data content triggering the potential sound
- * @returns {[string, number]} - he name of the sound to play, followed by the noise modifier 
+ * @returns {[string, number]} - he name of the sound to play, followed by the noise modifier
  */
 function AudioPlayAssetSound(data) {
 	var NextAsset = data.Dictionary.find((el) => el.Tag == "NextAsset");
@@ -216,9 +215,9 @@ function AudioPlayAssetSound(data) {
 	if (!NextAsset || !NextAsset.AssetName || !NextAssetGroup || !NextAssetGroup.AssetGroupName) return [FileName, 0];
 
 	var Asset = AssetGet("Female3DCG", NextAssetGroup.AssetGroupName, NextAsset.AssetName);
-	
+
 	if (!Asset) return [FileName, 0];
-	
+
 	if (Asset.DynamicAudio) {
 		var Char = ChatRoomCharacter.find((C) => C.MemberNumber == data.Sender);
 		FileName = Char ? Asset.DynamicAudio(Char) : "";
@@ -230,7 +229,7 @@ function AudioPlayAssetSound(data) {
 /**
  * Processes the sound for vibrators
  * @param {object} data - Represents the chat message received
- * @returns {[string, number]} - The name of the sound to play, followed by the noise modifier 
+ * @returns {[string, number]} - The name of the sound to play, followed by the noise modifier
  */
 function AudioVibratorSounds(data) {
 	var Sound = "";
@@ -268,11 +267,11 @@ function AudioVibratorSounds(data) {
 
 function AudioSciFiBeepSounds() {
 	var AudioRandomNumber = Math.random();
-	
+
 	if (AudioRandomNumber < 0.33) {
-		return ["SciFiBeeps1", 4]
+		return ["SciFiBeeps1", 4];
 	} else if (AudioRandomNumber > 0.67) {
-		return ["SciFiBeeps2", 4]
+		return ["SciFiBeeps2", 4];
 	}
 	return ["SciFiBeeps3", 4];
 }

--- a/BondageClub/Scripts/ColorPicker.js
+++ b/BondageClub/Scripts/ColorPicker.js
@@ -52,7 +52,7 @@ function ColorPickerRemoveEventListener() {
 
 /**
  * When the touch/mouse event begins to be registered. On mobile we only fire it once
- * @param {Event} Event - The touch/mouse event 
+ * @param {Event} Event - The touch/mouse event
  * @returns {void} - Nothing
  */
 function ColorPickerStartPick(Event) {
@@ -102,7 +102,7 @@ function ColorPickerEndPick() {
 
 /**
  * Gets the coordinates of the current event on the canvas
- * @param {Event} Event - The touch/mouse event 
+ * @param {Event} Event - The touch/mouse event
  * @returns {{X: number, Y: number}} - Coordinates of the click/touch event on the canvas
  */
 function ColorPickerGetCoordinates(Event) {
@@ -120,7 +120,7 @@ function ColorPickerGetCoordinates(Event) {
 
 /**
  * Sets the picked hue based on the Event coordinates on the canvas
- * @param {Event} Event - The touch/mouse event 
+ * @param {Event} Event - The touch/mouse event
  * @returns {void} - Nothing
  */
 function ColorPickerPickHue(Event) {
@@ -132,7 +132,7 @@ function ColorPickerPickHue(Event) {
 
 /**
  * Sets the picked saturation (SV) based on the Event coordinates on the canvas
- * @param {Event} Event - The touch/mouse event 
+ * @param {Event} Event - The touch/mouse event
  * @returns {void} - Nothing
  */
 function ColorPickerPickSV(Event) {
@@ -150,7 +150,7 @@ function ColorPickerPickSV(Event) {
 
 /**
  * Sets the picked HSV from the color pallet
- * @param {Event} Event - The touch/mouse event 
+ * @param {Event} Event - The touch/mouse event
  * @returns {void} - Nothing
  */
 function ColorPickerSelectFromPallete(Event) {
@@ -215,7 +215,7 @@ function ColorPickerCSSColorEquals(Color1, Color2) {
  * @returns {void} - Nothing
  */
 function ColorPickerDraw(X, Y, Width, Height, Src, Callback) {
-    
+
     // Calculate Layout
     ColorPickerLayout.HueBarHeight = ColorPickerHueBarHeight;
     ColorPickerLayout.HueBarOffset = Y;
@@ -288,13 +288,13 @@ function ColorPickerDraw(X, Y, Width, Height, Src, Callback) {
 
     // Draw S/V Panel
     DrawRect(X, SVPanelOffset, Width, SVPanelHeight, ColorPickerHSVToCSS({ H: HSV.H, S: 1, V: 1 }));
-    
+
     Grad = MainCanvas.createLinearGradient(X, SVPanelOffset, X + Width, SVPanelOffset);
     Grad.addColorStop(0, "rgba(255, 255, 255, 1)");
     Grad.addColorStop(1, "rgba(255, 255, 255, 0)");
     MainCanvas.fillStyle = Grad;
     MainCanvas.fillRect(X, SVPanelOffset, Width, SVPanelHeight);
-    
+
     Grad = MainCanvas.createLinearGradient(X, SVPanelOffset, X, SVPanelOffset + SVPanelHeight);
     Grad.addColorStop(0, "rgba(0, 0, 0, 0)");
     Grad.addColorStop(1, "rgba(0, 0, 0, 1)");
@@ -329,7 +329,7 @@ function ColorPickerDraw(X, Y, Width, Height, Src, Callback) {
  */
 function ColorPickerCSSToHSV(Color, DefaultHSV) {
     Color = Color || "#FFFFFF";
-    var M = Color.match(/^#(([0-9a-f]{3})|([0-9a-f]{6}))$/i)
+    var M = Color.match(/^#(([0-9a-f]{3})|([0-9a-f]{6}))$/i);
     var R, G, B;
     if (M) {
         var GRP = M[1];
@@ -359,8 +359,8 @@ function ColorPickerCSSToHSV(Color, DefaultHSV) {
         H = 0;
     } else {
         if (Max == R) {
-            H = (G - B) / D + (G < B ? 6 : 0); 
-        } else if (Max == G) { 
+            H = (G - B) / D + (G < B ? 6 : 0);
+        } else if (Max == G) {
             H = (B - R) / D + 2;
         } else {
             H = (R - G) / D + 4;
@@ -374,7 +374,7 @@ function ColorPickerCSSToHSV(Color, DefaultHSV) {
 /**
  * Converts a HSV object into a valid hex code to use in the css
  * @param {HSVColor} HSV - HSV value to convert
- * @returns {HexColor} - Hex color code corresponding to the given HSV 
+ * @returns {HexColor} - Hex color code corresponding to the given HSV
  */
 function ColorPickerHSVToCSS(HSV) {
     var R, G, B;
@@ -393,7 +393,7 @@ function ColorPickerHSVToCSS(HSV) {
         case 4: R = T; G = P; B = V; break;
         case 5: R = V; G = P; B = Q; break;
     }
-  
+
     var RS = Math.floor(R * 255).toString(16).toUpperCase();
     var GS = Math.floor(G * 255).toString(16).toUpperCase();
     var BS = Math.floor(B * 255).toString(16).toUpperCase();

--- a/BondageClub/Scripts/Common.js
+++ b/BondageClub/Scripts/Common.js
@@ -36,15 +36,15 @@ const CommonChatTags = {
 	TARGET_CHAR: "TargetCharacter",
 	TARGET_CHAR_NAME: "TargetCharacterName",
 	ASSET_NAME: "AssetName",
-}
+};
 
 String.prototype.replaceAt=function(index, character) {
 	return this.substr(0, index) + character + this.substr(index+character.length);
-}
+};
 
 /**
- * A map of keys to common font stack definitions. Each stack definition is a	
- * two-item array whose first item is an ordered list of fonts, and whose	
+ * A map of keys to common font stack definitions. Each stack definition is a
+ * two-item array whose first item is an ordered list of fonts, and whose
  * second item is the generic fallback font family (e.g. sans-serif, serif,
  * etc.)
  * @constant
@@ -308,7 +308,7 @@ function CommonDynamicFunctionParams(FunctionName) {
 	var closedParenthesisIndex = FunctionName.indexOf(")", openParenthesisIndex);
 	var Params = FunctionName.substring(openParenthesisIndex + 1, closedParenthesisIndex).split(",");
 	for (let P = 0; P < Params.length; P++)
-		Params[P] = Params[P].trim().replace('"', '').replace('"', '')
+		Params[P] = Params[P].trim().replace('"', '').replace('"', '');
 	FunctionName = FunctionName.substring(0, openParenthesisIndex);
 	if ((FunctionName.indexOf("Dialog") != 0) && (FunctionName.indexOf("Inventory") != 0) && (FunctionName.indexOf(CurrentScreen) != 0)) FunctionName = CurrentScreen + FunctionName;
 
@@ -375,7 +375,7 @@ function CommonCallFunctionByNameWarn(FunctionName/*, ...args */) {
  * @returns {void} - Nothing
  */
 function CommonSetScreen(NewModule, NewScreen) {
-	var prevScreen = CurrentScreen
+	var prevScreen = CurrentScreen;
 	CurrentModule = NewModule;
 	CurrentScreen = NewScreen;
 	CurrentDarkFactor = 1.0;
@@ -385,7 +385,7 @@ function CommonSetScreen(NewModule, NewScreen) {
 	if (typeof window[CurrentScreen + "Load"] === "function")
 		CommonDynamicFunction(CurrentScreen + "Load()");
 	if (prevScreen == "ChatSearch" || prevScreen == "ChatCreate")
-		ChatRoomStimulationMessage("Walk")
+		ChatRoomStimulationMessage("Walk");
 	if (ControllerActive == true) {
 		ClearButtons();
 	}
@@ -525,7 +525,7 @@ function CommonDebounce(func, wait) {
 	};
 }
 /**
- * Creates a simple memoizer. 
+ * Creates a simple memoizer.
  * The memoized function does calculate its result exactly once and from that point on, uses
  * the result stored in a local cache to speed up things.
  * @param {function} func - The function to memoize
@@ -552,7 +552,7 @@ function CommonMemoize(func) {
 	// add a clear cache method
 	memoized.clearCache = function () {
 		memo = {};
-	}
+	};
 	return memoized;
 } // CommonMemoize
 

--- a/BondageClub/Scripts/CommonDraw.js
+++ b/BondageClub/Scripts/CommonDraw.js
@@ -158,7 +158,7 @@ function CommonDrawAppearanceBuild(C, {
 			}
 		}
 		Y += YFixedOffset;
-		
+
 		// If we must apply alpha masks to the current image as it is being drawn
 		Layer.Alpha.forEach(AlphaDef => {
 			// If no groups are defined and the character's pose matches one of the allowed poses (or no poses are defined)
@@ -210,7 +210,7 @@ function CommonDrawAppearanceBuild(C, {
 
 
 		// Before drawing hook, receives all processed data. Any of them can be overriden if returned inside an object.
-		// CAREFUL! The dynamic function should not contain heavy computations, and should not have any side effects. 
+		// CAREFUL! The dynamic function should not contain heavy computations, and should not have any side effects.
 		// Watch out for object references.
 		if (A.DynamicBeforeDraw && (!Player.GhostList || Player.GhostList.indexOf(C.MemberNumber) == -1)) {
 			const DrawingData = {
@@ -333,7 +333,7 @@ function CommonDrawAppearanceBuild(C, {
 		}
 
 		// After drawing hook, receives all processed data.
-		// CAREFUL! The dynamic function should not contain heavy computations, and should not have any side effects. 
+		// CAREFUL! The dynamic function should not contain heavy computations, and should not have any side effects.
 		// Watch out for object references.
 		if (A.DynamicAfterDraw && (!Player.GhostList || Player.GhostList.indexOf(C.MemberNumber) == -1)) {
 			const DrawingData = {

--- a/BondageClub/Scripts/Drawing.js
+++ b/BondageClub/Scripts/Drawing.js
@@ -152,8 +152,8 @@ function DrawGetImageOnError(Img, IsAsset) {
  */
 function DrawArousalGlow(X, Y, Zoom, Level, Animated, AnimFactor, Orgasm) {
 	if (!Orgasm) {
-		let Rx = 0
-		let Ry = 0
+		let Rx = 0;
+		let Ry = 0;
 
 		if (Level > 0 && Animated) {
 			Rx = -(1 + AnimFactor * Level / 2) + (2 + AnimFactor * Level) * Math.random();
@@ -195,13 +195,13 @@ function DrawArousalMeter(C, X, Y, Zoom) {
 				ActivitySetArousal(C, C.ArousalSettings.Progress);
 
 				if (C.ArousalSettings != null && Player.ArousalSettings.VFX != "VFXInactive" && C.ArousalSettings.Progress > 0 && ((C.ArousalSettings.Active == "Automatic") || (C.ArousalSettings.Active == "Hybrid"))) {
-					let Progress = 0
+					let Progress = 0;
 					if (!((C.ArousalSettings.VibratorLevel == null) || (typeof C.ArousalSettings.VibratorLevel !== "number") || isNaN(C.ArousalSettings.VibratorLevel))) {
-						Progress = C.ArousalSettings.VibratorLevel
+						Progress = C.ArousalSettings.VibratorLevel;
 					}
 
 					if (Progress > 0) { // -1 is disabled
-						const max_time = 5000 // 5 seconds
+						const max_time = 5000; // 5 seconds
 						DrawArousalGlow(X + ((C.ArousalZoom ? 50 : 90) * Zoom), Y + ((C.ArousalZoom ? 200 : 400) * Zoom), C.ArousalZoom ? Zoom : Zoom * 0.2, Progress, Player.ArousalSettings.VFX == "VFXAnimated" || (Player.ArousalSettings.VFX == "VFXAnimatedTemp" && C.ArousalSettings.ChangeTime != null && CommonTime() - C.ArousalSettings.ChangeTime < max_time), Math.max(0, (max_time + C.ArousalSettings.ChangeTime - CommonTime()) / max_time), ((C.ArousalSettings.OrgasmTimer != null) && (typeof C.ArousalSettings.OrgasmTimer === "number") && !isNaN(C.ArousalSettings.OrgasmTimer) && (C.ArousalSettings.OrgasmTimer > 0)));
 					}
 				}
@@ -227,16 +227,16 @@ function DrawArousalMeter(C, X, Y, Zoom) {
  * @returns {void} - Nothing
  */
 function DrawCharacter(C, X, Y, Zoom, IsHeightResizeAllowed, DrawCanvas) {
-	if (!DrawCanvas) DrawCanvas = MainCanvas
-	
-	var OverrideDark = CurrentModule == "MiniGame" || ((Player.Effect.includes("VRAvatars") && C.Effect.includes("VRAvatars"))) || CurrentScreen == "InformationSheet"
-	
+	if (!DrawCanvas) DrawCanvas = MainCanvas;
+
+	var OverrideDark = CurrentModule == "MiniGame" || ((Player.Effect.includes("VRAvatars") && C.Effect.includes("VRAvatars"))) || CurrentScreen == "InformationSheet";
+
 	if ((C != null) && ((C.ID == 0) || (OverrideDark || Player.GetBlindLevel() < 3 ))) {
 
-		CharacterCheckHooks(C, CurrentCharacter != null)
+		CharacterCheckHooks(C, CurrentCharacter != null);
 
 		if (ControllerActive == true) {
-			setButton(X + 100, Y + 200)
+			setButton(X + 100, Y + 200);
 		}
 
 		// If there's a fixed image to draw instead of the character
@@ -277,7 +277,7 @@ function DrawCharacter(C, X, Y, Zoom, IsHeightResizeAllowed, DrawCanvas) {
 		// If we must dark the Canvas characters
 		if ((C.ID != 0) && Player.IsBlind() && !OverrideDark) {
 			const DarkFactor = Math.min(CharacterGetDarkFactor(Player) * 2, 1);
-			
+
 			CharacterCanvas.globalCompositeOperation = "copy";
 			CharacterCanvas.drawImage(Canvas, 0, 0);
 			// Overlay black rectangle.
@@ -321,7 +321,7 @@ function DrawCharacter(C, X, Y, Zoom, IsHeightResizeAllowed, DrawCanvas) {
 			OnlineGameDrawCharacter(C, X, Y, Zoom);
 			if (C.HasHiddenItems) DrawImageZoomCanvas("Screens/Character/Player/HiddenItem.png", DrawCanvas, 0, 0, 86, 86, X + 54 * Zoom, Y + 880 * Zoom, 70 * Zoom, 70 * Zoom);
 		}
-		
+
 		// Draws the character focus zones if we need too
 		if ((C.FocusGroup != null) && (C.FocusGroup.Zone != null) && (CurrentScreen != "Preference") && (DialogColor == null)) {
 
@@ -636,7 +636,7 @@ function DrawImageCanvasColorize(Source, Canvas, X, Y, Zoom, HexColor, FullAlpha
  * @returns {boolean} - whether the image was complete or not
  */
 function DrawImageMirror(Source, X, Y) {
-	const Img = DrawGetImage(Source)
+	const Img = DrawGetImage(Source);
 	if (!Img.complete) return false;
 	if (!Img.naturalWidth) return true;
 	MainCanvas.save();
@@ -725,7 +725,7 @@ function DrawTextWrap(Text, X, Y, Width, Height, ForeColor, BackColor, MaxLine) 
 	// Sets the text size if there's a maximum number of lines
 	let TextSize;
 	if (MaxLine != null) {
-		TextSize = MainCanvas.font
+		TextSize = MainCanvas.font;
 		GetWrapTextSize(Text, Width, MaxLine);
 	}
 
@@ -1169,7 +1169,7 @@ function DrawProcess() {
 			if (DarkFactor == 1 && (CurrentCharacter != null || ShopStarted) && !CommonPhotoMode) DarkFactor = 0.5;
 		}
 		const Invert = Player.GraphicsSettings && Player.GraphicsSettings.InvertRoom && Player.IsInverted();
-		
+
 		let customBG = DrawGetCustomBackground();
 
 		if (customBG != "" && (CurrentModule != "Character" && CurrentModule != "MiniGame") && (B != "Sheet")) {

--- a/BondageClub/Scripts/Drawing3D.js
+++ b/BondageClub/Scripts/Drawing3D.js
@@ -120,7 +120,7 @@ function light(){
 //set color
 function color2(hexcolor){
 	let loader = new THREE.TextureLoader();
-	var texturehair = loader.load(`${path3d}HairFront/t005.bmp`)
+	var texturehair = loader.load(`${path3d}HairFront/t005.bmp`);
 	model.traverse( function ( child ) {
 		if ( child.isMesh ) {
 				if (model.group == "HairBack" || model.group == "HairFront"){

--- a/BondageClub/Scripts/Element.js
+++ b/BondageClub/Scripts/Element.js
@@ -182,7 +182,7 @@ function ElementCreateDropdown(ID, Options, ClickEventListener) {
 			this.nextSibling.classList.toggle("select-hide");
 		});
 		// add an event listener to the <select> tag
-		if (ClickEventListener != null) Select.addEventListener("change", ClickEventListener)
+		if (ClickEventListener != null) Select.addEventListener("change", ClickEventListener);
 		// Add alle the items to the enclosing <di>
 		CustomSelect.appendChild(Select);
 		CustomSelect.appendChild(SelectedItem);
@@ -349,7 +349,7 @@ function ElementScrollToEnd(ID) {
  */
 function ElementIsScrolledToEnd(ID) {
 	var element = document.getElementById(ID);
-	return element != null && element.scrollHeight - element.scrollTop - element.clientHeight < 1
+	return element != null && element.scrollHeight - element.scrollTop - element.clientHeight < 1;
 }
 
 /**

--- a/BondageClub/Scripts/ExtendedItem.js
+++ b/BondageClub/Scripts/ExtendedItem.js
@@ -64,7 +64,7 @@ const ExtendedXYClothes = [
 	[[1140, 400], [1385, 400], [1630, 400], [1140, 700], [1385, 700], [1630, 700]], //6 options per page
 ];
 
-/** Memoization of the requirements check 
+/** Memoization of the requirements check
  * @type {function}
 */
 const ExtendedItemRequirementCheckMessageMemo = CommonMemoize(ExtendedItemRequirementCheckMessage);
@@ -123,13 +123,13 @@ function ExtendedItemDraw(Options, DialogPrefix, OptionsPerPage, ShowImages = tr
 	const XYPositions = !Asset.Group.Clothing ? (ShowImages ? ExtendedXY : ExtendedXYWithoutImages) : ExtendedXYClothes;
 	const ImageHeight = ShowImages ? 220 : 0;
 	OptionsPerPage = OptionsPerPage || Math.min(Options.length, XYPositions.length - 1);
-	
+
 	// If we have to paginate, draw the back/next buttons
 	if (Options.length > OptionsPerPage) {
 		DrawButton(1665, 240, 90, 90, "", "White", "Icons/Prev.png");
 		DrawButton(1775, 240, 90, 90, "", "White", "Icons/Next.png");
 	}
-	
+
 	// Draw the header and item
 	DrawAssetPreview(1387, 55, Asset);
 	DrawText(DialogExtendedMessage, 1500, 375, "white", "gray");
@@ -139,7 +139,7 @@ function ExtendedItemDraw(Options, DialogPrefix, OptionsPerPage, ShowImages = tr
 		var PageOffset = I - ItemOptionsOffset;
 		var X = XYPositions[OptionsPerPage][PageOffset][0];
 		var Y = XYPositions[OptionsPerPage][PageOffset][1];
-		
+
 		var Option = Options[I];
 		var Hover = MouseIn(X, Y, 225, 55 + ImageHeight) && !CommonIsMobile;
 		var FailSkillCheck = !!ExtendedItemRequirementCheckMessageMemo(Option, IsSelfBondage);
@@ -156,7 +156,7 @@ function ExtendedItemDraw(Options, DialogPrefix, OptionsPerPage, ShowImages = tr
 			setButton(X + 112, Y + 30 + ImageHeight);
 		}
 	}
-	
+
 	// Permission mode toggle is always available
 	DrawButton(1775, 25, 90, 90, "", "White", ExtendedItemPermissionMode ? "Icons/DialogNormalMode.png" : "Icons/DialogPermissionMode.png", DialogFindPlayer(ExtendedItemPermissionMode ? "DialogNormalMode" : "DialogPermissionMode"));
 }
@@ -188,11 +188,11 @@ function ExtendedItemClick(Options, OptionsPerPage, ShowImages = true) {
 	}
 
 	// Permission toggle button
-	if (MouseIn(1775, 25, 90, 90)) { 
+	if (MouseIn(1775, 25, 90, 90)) {
 		if (ExtendedItemPermissionMode && CurrentScreen == "ChatRoom") ChatRoomCharacterUpdate(Player);
 		ExtendedItemPermissionMode = !ExtendedItemPermissionMode;
 	}
-	
+
 	// Pagination buttons
 	if (MouseIn(1665, 240, 90, 90) && Options.length > OptionsPerPage) {
 		if (ItemOptionsOffset - OptionsPerPage < 0) ExtendedItemSetOffset(OptionsPerPage * (Math.ceil(Options.length / OptionsPerPage) - 1));
@@ -202,7 +202,7 @@ function ExtendedItemClick(Options, OptionsPerPage, ShowImages = true) {
 		if (ItemOptionsOffset + OptionsPerPage >= Options.length) ExtendedItemSetOffset(0);
 		else ExtendedItemSetOffset(ItemOptionsOffset + OptionsPerPage);
 	}
-	
+
 	// Options
 	for (let I = ItemOptionsOffset; I < Options.length && I < ItemOptionsOffset + OptionsPerPage; I++) {
 		var PageOffset = I - ItemOptionsOffset;
@@ -263,7 +263,7 @@ function ExtendedItemSetType(C, Options, Option) {
 	DialogFocusItem.Property = NewProperty;
 	const IsCloth = DialogFocusItem.Asset.Group.Clothing;
 	CharacterRefresh(C, !IsCloth); // Does not sync appearance while in the wardrobe
-	
+
 	// For a restraint, we might publish an action or change the dialog of a NPC
 	if (!IsCloth) {
 		ChatRoomCharacterUpdate(C);
@@ -301,7 +301,7 @@ function ExtendedItemHandleOptionClick(C, Options, Option, IsSelfBondage) {
 	} else {
 		var BlockedOrLimited = InventoryBlockedOrLimited(C, DialogFocusItem, Option.Property.Type);
 		if (DialogFocusItem.Property.Type === Option.Property.Type || BlockedOrLimited) return;
-		
+
 		// use the unmemoized function to ensure we make a final check to the requirements
 		var RequirementMessage = ExtendedItemRequirementCheckMessage(Option, IsSelfBondage);
 		if (RequirementMessage) {

--- a/BondageClub/Scripts/GLDraw.js
+++ b/BondageClub/Scripts/GLDraw.js
@@ -1,4 +1,4 @@
-"use strict"
+"use strict";
 
 var GLDrawImageCache = new Map();
 
@@ -41,7 +41,7 @@ function GLDrawLoad() {
         GLDrawLoad();
         console.log("WebGL: Context restored.");
     }, false);
-    
+
     //console.log("WebGL Drawing enabled: '" + GLVersion + "'");
 }
 
@@ -324,7 +324,7 @@ function GLDraw2DCanvasBlink(gl, Img, X, Y, alphaMasks) { GLDraw2DCanvas(gl, Img
  * @param {number} Y - Position of the image on the Y axis
  * @param {number[][]} alphaMasks - A list of alpha masks to apply to the asset
  */
-function GLDraw2DCanvas(gl, Img, X, Y, alphaMasks) { 
+function GLDraw2DCanvas(gl, Img, X, Y, alphaMasks) {
     var TempCanvasName = Img.getAttribute("name");
     gl.textureCache.delete(TempCanvasName);
     GLDrawImageCache.set(TempCanvasName, Img);
@@ -477,7 +477,7 @@ function GLDrawHexToRGBA(color, alpha = 1) {
 /**
  * Creates the given character canvas with WebGL
  * @param {Character} C - Character to build the canvas for
- * @returns {void} - Nothing 
+ * @returns {void} - Nothing
  */
 function GLDrawAppearanceBuild(C) {
     GLDrawClearRect(GLDrawCanvas.GL, 0, 0, 1000, CanvasDrawHeight);

--- a/BondageClub/Scripts/GameLog.js
+++ b/BondageClub/Scripts/GameLog.js
@@ -29,7 +29,7 @@ function LogAdd(NewLogName, NewLogGroup, NewLogValue, Push) {
 			Name: NewLogName,
 			Group: NewLogGroup,
 			Value: NewLogValue
-		}
+		};
 		Log.push(NewLog);
 	}
 

--- a/BondageClub/Scripts/Inventory.js
+++ b/BondageClub/Scripts/Inventory.js
@@ -38,11 +38,11 @@ function InventoryAddMany(C, NewItems, Push) {
 
 	// Return if data is invalid
 	if (C == null || !Array.isArray(NewItems)) return;
-	
+
 	var ShouldSync = false;
-	
+
 	// Add each items
-	for (let NI = 0; NI < NewItems.length; NI++) { 
+	for (let NI = 0; NI < NewItems.length; NI++) {
 		// First, we check if the item already exists in the inventory, continue if it's the case
 		var ItemExists = false;
 		for (let I = 0; I < C.Inventory.length; I++)
@@ -50,8 +50,8 @@ function InventoryAddMany(C, NewItems, Push) {
 				ItemExists = true;
 				break;
 			}
-		
-		if (!ItemExists) { 
+
+		if (!ItemExists) {
 			// Create the new item for current character's asset family, group name and item name
 			var NewItem = InventoryItemCreate(C, NewItems[NI].Group, NewItems[NI].Name);
 
@@ -63,7 +63,7 @@ function InventoryAddMany(C, NewItems, Push) {
 			}
 		}
 	}
-	
+
 	// Sends the new item(s) to the server if it's for the current player and an item was added
 	if ((C.ID == 0) && ((Push == null) || Push) && ShouldSync) ServerPlayerInventorySync();
 }
@@ -459,7 +459,7 @@ function InventoryGetRandom(C, GroupName, AllowedAssets) {
 	var BlockedRank = Math.pow(2, 2);
 	var HiddenRank = Math.pow(2, 1);
 	var LimitedRank = Math.pow(2, 0);
-		
+
 	for (let A = 0; A < AssetList.length; A++)
 		if (((AssetList[A].Group.Name == GroupName && AssetList[A].Wear) || GroupName == null || GroupName == "") && (RandomOnly == false || AssetList[A].Random) && AssetList[A].Enable && InventoryAllow(C, AssetList[A].Prerequisite, false)) {
 			var CurrRank = 0;
@@ -537,13 +537,13 @@ function InventoryRemove(C, AssetGroup, Refresh) {
 * Returns TRUE if the body area (Asset Group) for a character is blocked and cannot be used
 * @param {Character} C - The character on which we validate the group
 * @param {String} GroupName - The name of the asset group (body area)
-* @param {Boolean} Activity - if TRUE check if activity is allowed on the asset group 
+* @param {Boolean} Activity - if TRUE check if activity is allowed on the asset group
 * @returns {Boolean} - TRUE if the group is blocked
 */
 function InventoryGroupIsBlocked(C, GroupName, Activity) {
 
 	if (Activity == null) Activity = false;
-	
+
 	// Default to characters focused group
 	if (GroupName == null) GroupName = C.FocusGroup.Name;
 
@@ -610,15 +610,14 @@ function InventoryItemHasEffect(Item, Effect, CheckProperties = true) {
 */
 function InventoryItemIsPickable(Item) {
 	if (!Item) return null;
-	var lock = InventoryGetLock(Item)
+	var lock = InventoryGetLock(Item);
 	if (lock && lock.Asset && lock.Asset.PickDifficulty && lock.Asset.PickDifficulty > 0) return true;
 	else return false;
-	
 }
 
 /**
  * Returns the value of a given property of an appearance item, prioritizes the Property object.
- * @param {object} Item - The appearance item to scan 
+ * @param {object} Item - The appearance item to scan
  * @param {string} PropertyName - The property name to get.
  * @param {boolean} CheckGroup - Whether or not to fall back to the item's group if the property is not found on
  * Property or Asset.
@@ -776,8 +775,8 @@ function InventoryLock(C, Item, Lock, MemberNumber, Update = true) {
 				if (Item.Property == null) Item.Property = {};
 				if (Item.Property.Effect == null) Item.Property.Effect = [];
 				if (Item.Property.Effect.indexOf("Lock") < 0) Item.Property.Effect.push("Lock");
-				
-				if (!Item.Property.MemberNumberListKeys && Lock.Asset.Name == "HighSecurityPadlock") Item.Property.MemberNumberListKeys = "" + MemberNumber
+
+				if (!Item.Property.MemberNumberListKeys && Lock.Asset.Name == "HighSecurityPadlock") Item.Property.MemberNumberListKeys = "" + MemberNumber;
 				Item.Property.LockedBy = Lock.Asset.Name;
 				if (MemberNumber != null) Item.Property.LockMemberNumber = MemberNumber;
 				if (Update) {

--- a/BondageClub/Scripts/MiniGame.js
+++ b/BondageClub/Scripts/MiniGame.js
@@ -20,7 +20,7 @@ function MiniGameLoad() {
  * @param {string} GameType - Name of the mini-game to launch
  * @param {number} Difficulty - Difficulty Ration for the mini-game
  * @param {string} ReturnFunction - Callback name to execute once the mini-game is over
- * @returns {void} - Nothing 
+ * @returns {void} - Nothing
  */
 function MiniGameStart(GameType, Difficulty, ReturnFunction) {
 	CurrentCharacter = null;

--- a/BondageClub/Scripts/NPC.js
+++ b/BondageClub/Scripts/NPC.js
@@ -1,7 +1,7 @@
 "use strict";
 /**
  * List for all possible pairs of NPC traits. A pair defines opposites.
- * @constant 
+ * @constant
  * @type {string[][]}
  */
 var NPCTrait = [
@@ -11,12 +11,12 @@ var NPCTrait = [
 	["Rude", "Polite"],
 	["Wise", "Dumb"],
 	["Serious", "Playful"],
-]
+];
 
 /**
  * Sets a specific trait for a NPC
  * @param {Character} C - NPC to set the trait for
- * @param {string} TraitName - Name of the trait to set 
+ * @param {string} TraitName - Name of the trait to set
  * @param {number} TraitValue - Value of the trait to set
  * @returns {void} - Nothing
  */
@@ -41,7 +41,7 @@ function NPCTraitGenerate(C) {
 				var NewTrait = {
 					Name: NPCTrait[T][Math.floor(Math.random() * 2)],
 					Value: Math.floor(Math.random() * 100) + 1
-				}
+				};
 				C.Trait.push(NewTrait);
 			}
 	}
@@ -104,7 +104,7 @@ function NPCTraitKeepBestOption(C, Group) {
 	if (Pos >= 0)
 		for (let D = 0; D < C.Dialog.length; D++)
 			if ((D != Pos) && (C.Dialog[D].Group != null) && (C.Dialog[D].Group == Group)) {
-				C.Dialog.splice(D, 1)
+				C.Dialog.splice(D, 1);
 				Pos--;
 				D--;
 			}
@@ -120,7 +120,7 @@ function NPCTraitDialog(C) {
 
 	// For each dialog option
 	for (let D = 0; D < C.Dialog.length; D++) {
-		if (C.Dialog[D].Group != null) NPCTraitKeepBestOption(C, C.Dialog[D].Group)
+		if (C.Dialog[D].Group != null) NPCTraitKeepBestOption(C, C.Dialog[D].Group);
 		if (C.Dialog[D].Function != null) C.Dialog[D].Function = C.Dialog[D].Function.replace("MainHall", "");
 	}
 
@@ -230,7 +230,7 @@ function NPCEventAdd(C, EventName, EventValue) {
 	var NewEvent = {
 		Name: EventName,
 		Value: EventValue
-	}
+	};
 	C.Event.push(NewEvent);
 }
 

--- a/BondageClub/Scripts/Notification.js
+++ b/BondageClub/Scripts/Notification.js
@@ -96,7 +96,7 @@ class NotificationEventHandler {
 		if (data.characterName) titleStart = data.characterName + " - ";
 		else if (C) titleStart = C.Name + " - ";
 		if (data.chatRoomName) titleEnd = DialogFindPlayer("NotificationTitleFromRoom").replace("ChatRoomName", "'" + data.chatRoomName + "'");
-			
+
 		// Define the (supported) options of the popup and create it
 		let title = titleStart + DialogFindPlayer("NotificationTitle" + this.eventType) + titleEnd;
 		let options = {};
@@ -155,7 +155,7 @@ let NotificationEventHandlers;
 var NotificationAlertTypeList = [];
 var NotificationAudioTypeList = [];
 
-/** 
+/**
  * Initialise notification variables on startup
  * @returns {void} - Nothing
  */
@@ -217,7 +217,7 @@ function NotificationResetAll() {
 	NotificationTitleUpdate();
 }
 
-/** 
+/**
  * Returns whether popup notifications are permitted
  * @param {NotificationEventType} eventType - The type of event that occurred
  * @param {object} [data={}] - Data relating to the event that can be passed into a popup

--- a/BondageClub/Scripts/Reputation.js
+++ b/BondageClub/Scripts/Reputation.js
@@ -27,7 +27,7 @@ function ReputationChange(RepType, RepValue, Push) {
 		var NewRep = {
 			Type: RepType,
 			Value: RepValue
-		}
+		};
 		if (NewRep.Value > 100) NewRep.Value = 100;
 		if (NewRep.Value < -100) NewRep.Value = -100;
 		Player.Reputation.push(NewRep);
@@ -84,7 +84,7 @@ function ReputationCharacterGet(C, RepType) {
  * Alter the reputation progress by a factor. The higher the rep, the slower it gets, a reputation is easier to break than to build. Takes the cheater version factor into account.
  * @param {string} RepType - Type/name of the reputation
  * @param {number} Value - Value of the reputation change before the factor is applied
- * @return {void} - Nothing 
+ * @return {void} - Nothing
  */
 function ReputationProgress(RepType, Value) {
 	var V = ReputationGet(RepType);

--- a/BondageClub/Scripts/Server.js
+++ b/BondageClub/Scripts/Server.js
@@ -169,7 +169,7 @@ function ServerDisconnect(data, close = false) {
 
 /**
  * Returns whether the player is currently in a chatroom or viewing a subscreen while in a chatroom
- * @returns {boolean} - True if in a chatroom 
+ * @returns {boolean} - True if in a chatroom
  */
 function ServerPlayerIsInChatRoom() {
 	return (CurrentScreen == "ChatRoom")
@@ -272,7 +272,7 @@ function ServerPlayerRelationsSync() {
 	Array.from(Player.FriendNames.keys()).forEach(k => {
 		if (!Player.FriendList.includes(k) && !Player.SubmissivesList.has(k))
 			Player.FriendNames.delete(k);
-	})
+	});
 	D.FriendNames = LZString.compressToUTF16(JSON.stringify(Array.from(Player.FriendNames)));
 	D.SubmissivesList = LZString.compressToUTF16(JSON.stringify(Array.from(Player.SubmissivesList)));
 	ServerSend("AccountUpdate", D);
@@ -533,7 +533,7 @@ function ServerAccountBeep(data) {
 			if (ServerBeep.ChatRoomName != null)
 				ServerBeep.Message = ServerBeep.Message + " " + DialogFindPlayer("InRoom") + " \"" + ServerBeep.ChatRoomName + "\" " + (data.ChatRoomSpace === "Asylum" ? DialogFindPlayer("InAsylum") : '');
 			if (data.Message) {
-				ServerBeep.Message += `; ${DialogFindPlayer("BeepWithMessage")}`
+				ServerBeep.Message += `; ${DialogFindPlayer("BeepWithMessage")}`;
 			}
 			FriendListBeepLog.push({
 				MemberNumber: data.MemberNumber,
@@ -556,17 +556,17 @@ function ServerAccountBeep(data) {
 		} else if (data.BeepType == "Leash" && ChatRoomLeashPlayer == data.MemberNumber && data.ChatRoomName) {
 			if (Player.OnlineSharedSettings && Player.OnlineSharedSettings.AllowPlayerLeashing != false && ( CurrentScreen != "ChatRoom" || !ChatRoomData || (CurrentScreen == "ChatRoom" && ChatRoomData.Name != data.ChatRoomName))) {
 				if (ChatRoomCanBeLeashedBy(data.MemberNumber, Player)) {
-					ChatRoomJoinLeash = data.ChatRoomName
-					
-					DialogLeave()
+					ChatRoomJoinLeash = data.ChatRoomName;
+
+					DialogLeave();
 					ChatRoomClearAllElements();
 					if (CurrentScreen == "ChatRoom") {
 						ServerSend("ChatRoomLeave", "");
 						CommonSetScreen("Online", "ChatSearch");
 					}
-					else ChatRoomStart("", "", "MainHall", "Introduction", BackgroundsTagList) //CommonSetScreen("Room", "ChatSearch")
+					else ChatRoomStart("", "", "MainHall", "Introduction", BackgroundsTagList); //CommonSetScreen("Room", "ChatSearch")
 				} else {
-					ChatRoomLeashPlayer = null
+					ChatRoomLeashPlayer = null;
 				}
 			}
 		}

--- a/BondageClub/Scripts/Skill.js
+++ b/BondageClub/Scripts/Skill.js
@@ -1,7 +1,7 @@
 "use strict";
 var SkillModifier = 0;
 var SkillModifierMax = 5;
-var SkillModifierMin = -10
+var SkillModifierMin = -10;
 var SkillLevelMaximum = 10;
 var SkillLevelMinimum = 0;
 var SkillBondageRatio = 1;
@@ -36,7 +36,7 @@ function SkillChange(SkillType, SkillLevel, SkillProgress, Push) {
 		Type: SkillType,
 		Level: SkillLevel,
 		Progress: SkillProgress
-	}
+	};
 	Player.Skill.push(NewSkill);
 	if ((Push == null) || Push) ServerPlayerSkillSync();
 
@@ -124,7 +124,7 @@ function SkillGetProgress(C, SkillType) {
 }
 
 /**
- * Add progress to a skill, the skill progresses slower for each level, takes into account cheaters version. 
+ * Add progress to a skill, the skill progresses slower for each level, takes into account cheaters version.
  * @param {string} SkillType - Name of the skill to add progress to
  * @param {number} SkillProgress - Progress to be made before the ratios are applied
  * @returns {void} - Nothing

--- a/BondageClub/Scripts/Speech.js
+++ b/BondageClub/Scripts/Speech.js
@@ -74,7 +74,7 @@ function SpeechGetGagLevel(C, AssetGroup) {
  */
 function SpeechGarble(C, CD, NoDeaf) {
 	let GagEffect = 0;
-	let NS = CD
+	let NS = CD;
 	GagEffect += SpeechGetGagLevel(C, "ItemMouth");
 	GagEffect += SpeechGetGagLevel(C, "ItemMouth2");
 	GagEffect += SpeechGetGagLevel(C, "ItemMouth3");
@@ -83,7 +83,7 @@ function SpeechGarble(C, CD, NoDeaf) {
 	GagEffect += SpeechGetGagLevel(C, "ItemNeck");
 	GagEffect += SpeechGetGagLevel(C, "ItemDevices");
 	GagEffect += SpeechGetGagLevel(C, "ItemHoodAddon");
-	
+
 	if (C.ID != 0 && !NoDeaf) {
 		if (Player.GetDeafLevel() >= 7) GagEffect = Math.max(GagEffect, 20);
 		else if (Player.GetDeafLevel() >= 6) GagEffect = Math.max(GagEffect, 16);
@@ -92,14 +92,14 @@ function SpeechGarble(C, CD, NoDeaf) {
 		else if (Player.GetDeafLevel() >= 3) GagEffect = Math.max(GagEffect, 6);
 		else if (Player.GetDeafLevel() >= 2) GagEffect = Math.max(GagEffect, 4);
 		else if (Player.GetDeafLevel() >= 1) GagEffect = Math.max(GagEffect, 2);
-	}	
-	
+	}
+
 	if (GagEffect > 0) NS = SpeechGarbleByGagLevel(GagEffect, CD);
-	
+
 	// No gag effect, we return the regular text
 	NS = SpeechStutter(C, NS);
 	NS = SpeechBabyTalk(C, NS);
-	
+
 	return NS;
 }
 
@@ -118,7 +118,7 @@ function SpeechGarbleByGagLevel(GagEffect, CD, IgnoreOOC) {
 	// GagTotal4 always returns mmmmm and muffles some frequent letters entirely, 75% least frequent letters
 	if (GagEffect >= 20) {
 		for (let L = 0; L < CD.length; L++) {
-			var H = CD.charAt(L).toLowerCase();
+			let H = CD.charAt(L).toLowerCase();
 			if (H == "(" && !IgnoreOOC) Par = true;
 			if (Par) NS = NS + CD.charAt(L);
 			else {
@@ -164,7 +164,7 @@ function SpeechGarbleByGagLevel(GagEffect, CD, IgnoreOOC) {
 			if (H == ")") Par = false;
 		}
 		return NS;
-	}	
+	}
 
 	// Total gags always returns mmmmm
 	if (GagEffect >= 8) {
@@ -214,7 +214,7 @@ function SpeechGarbleByGagLevel(GagEffect, CD, IgnoreOOC) {
 		}
 		return NS;
 	}
-	
+
 	// Heavy garble - Almost no letter stays the same
 	if (GagEffect >= 6) {
 		for (let L = 0; L < CD.length; L++) {
@@ -284,7 +284,7 @@ function SpeechGarbleByGagLevel(GagEffect, CD, IgnoreOOC) {
 		}
 		return NS;
 	}
-	
+
 	// Normal garble, keep vowels and a few letters the same
 	if (GagEffect >= 4) {
 		for (let L = 0; L < CD.length; L++) {
@@ -366,7 +366,7 @@ function SpeechGarbleByGagLevel(GagEffect, CD, IgnoreOOC) {
 		}
 		return NS;
 	}
-	
+
 	// Light garble, half of the letters stay the same
 	if (GagEffect >= 2) {
 		for (let L = 0; L < CD.length; L++) {
@@ -407,7 +407,7 @@ function SpeechGarbleByGagLevel(GagEffect, CD, IgnoreOOC) {
 		}
 		return NS;
 	}
-	
+
 	// Very Light garble, most of the letters stay the same
 	if (GagEffect >= 1) {
 		for (let L = 0; L < CD.length; L++) {
@@ -446,7 +446,6 @@ function SpeechGarbleByGagLevel(GagEffect, CD, IgnoreOOC) {
 		return NS;
 	}
 
-	
 	return CD;
 
 }

--- a/BondageClub/Scripts/Timer.js
+++ b/BondageClub/Scripts/Timer.js
@@ -17,7 +17,7 @@ function TimerGetTime() {
 
 /**
  * Returns a string of the time remaining on a given timer
- * @param {number} T - Time to convert to a string in ms 
+ * @param {number} T - Time to convert to a string in ms
  * @returns {string} - The time string in the DD:HH:MM:SS format (Days and hours not displayed if it contains none)
  */
 function TimerToString(T) {
@@ -33,7 +33,7 @@ function TimerToString(T) {
 
 /**
  * Returns a string of the time remaining on a given timer (Hours and minutes only)
- * @param {Date} T - Time to convert to a string in ms 
+ * @param {Date} T - Time to convert to a string in ms
  * @returns {string} - The time string in the HH:MM format
  */
 function TimerHourToString(T) {
@@ -45,7 +45,7 @@ function TimerHourToString(T) {
 
 /**
  * Check if we must remove items from characters. (Expressions, items being removed, locks, etc.)
- * @returns {void} - Nothing 
+ * @returns {void} - Nothing
  */
 function TimerInventoryRemove() {
 
@@ -93,7 +93,7 @@ function TimerInventoryRemove() {
  * @param {Character} C - Character for which we are removing an item
  * @param {string} AssetGroup - Group targeted by the removal
  * @param {number} Timer - Seconds it takes to remove the item
- * @returns {void} - Nothing 
+ * @returns {void} - Nothing
  */
 function TimerInventoryRemoveSet(C, AssetGroup, Timer) {
 	for (let E = 0; E < C.Appearance.length; E++)
@@ -125,7 +125,7 @@ function TimerPrivateOwnerBeep() {
 /**
  * Main timer process
  * @param {number} Timestamp - Time in ms of the time when the function was called
- * @returns {void} - Nothing 
+ * @returns {void} - Nothing
  */
 function TimerProcess(Timestamp) {
 
@@ -166,12 +166,12 @@ function TimerProcess(Timestamp) {
 							if (Character[C].ArousalSettings.ProgressTimer < 0) {
 								Character[C].ArousalSettings.ProgressTimer++;
 								ActivityTimerProgress(Character[C], -1);
-								ActivityVibratorLevel(Character[C], 0)
+								ActivityVibratorLevel(Character[C], 0);
 							}
 							else {
 								Character[C].ArousalSettings.ProgressTimer--;
 								ActivityTimerProgress(Character[C], 1);
-								ActivityVibratorLevel(Character[C], 4); 
+								ActivityVibratorLevel(Character[C], 4);
 							}
 						} else if (Character[C].IsEgged()) {
 
@@ -214,7 +214,7 @@ function TimerProcess(Timestamp) {
 			TimerLastArousalDecay = CurrentTime;
 			for (let C = 0; C < Character.length; C++)
 				if ((Character[C].ArousalSettings != null) && (Character[C].ArousalSettings.Active != null) && ((Character[C].ArousalSettings.Active == "Automatic") || (Character[C].ArousalSettings.Active == "Hybrid")))
-					if ((Character[C].ArousalSettings.Progress != null) && (typeof Character[C].ArousalSettings.Progress === "number") && !isNaN(Character[C].ArousalSettings.Progress) && (Character[C].ArousalSettings.Progress > 0)) 
+					if ((Character[C].ArousalSettings.Progress != null) && (typeof Character[C].ArousalSettings.Progress === "number") && !isNaN(Character[C].ArousalSettings.Progress) && (Character[C].ArousalSettings.Progress > 0))
 						if ((Character[C].ArousalSettings.ProgressTimer == null) || (typeof Character[C].ArousalSettings.ProgressTimer !== "number") || isNaN(Character[C].ArousalSettings.ProgressTimer) || (Character[C].ArousalSettings.ProgressTimer == 0)) {
 
 							// If the character is egged, we find the highest intensity factor
@@ -244,7 +244,7 @@ function TimerProcess(Timestamp) {
 
     // Launches the main again for the next frame
 	requestAnimationFrame(MainRun);
-    
+
 }
 
 /**
@@ -268,5 +268,5 @@ function TimermsToTime(s) {
 	var mins = s % 60;
 	var hrs = (s - mins) / 60;
 	return pad(hrs) + ':' + pad(mins) + ':' + pad(secs);
-	
+
 }

--- a/BondageClub/Scripts/Translation.js
+++ b/BondageClub/Scripts/Translation.js
@@ -4,7 +4,7 @@ var TranslationCache = {};
 
 /**
  * Dictionary for all supported languages and their files
- * @constant 
+ * @constant
  */
 var TranslationDictionary = [
 
@@ -365,7 +365,7 @@ function TranslationDialogArray(C, T) {
 
 /**
  * Translates a set of tags. Rerenders the login message when on the login page.
- * @param {Array.<{Tag: string, Value: string}>} S - Array of current tag-value pairs 
+ * @param {Array.<{Tag: string, Value: string}>} S - Array of current tag-value pairs
  * @param {string[]} T - The active translation dictionary
  * @returns {void} - Nothing
  */
@@ -388,7 +388,7 @@ function TranslationDialog(C) {
 		var OnlinePlayer = C.AccountName.indexOf("Online-") >= 0;
 		// Finds the full path of the translation file to use
 		var FullPath = (OnlinePlayer ? "Screens/Online/ChatRoom/Dialog_Online" :  (C.ID == 0) ? "Screens/Character/Player/Dialog_Player" : "Screens/" + CurrentModule + "/" + CurrentScreen + "/Dialog_" + C.AccountName) + "_" + TranslationLanguage + ".txt";
-			
+
 		// If the translation file is already loaded, we translate from it
 		if (TranslationCache[FullPath]) {
 			TranslationDialogArray(C, TranslationCache[FullPath]);
@@ -403,9 +403,9 @@ function TranslationDialog(C) {
 					TranslationDialogArray(C, TranslationCache[FullPath]);
 				}
 			});
-	
+
 	}
-	
+
 }
 
 /**
@@ -416,7 +416,7 @@ function TranslationDialog(C) {
 function TranslationText(Text) {
 	// If we play in a foreign language
 	if ((TranslationLanguage != null) && (TranslationLanguage.trim() != "") && (TranslationLanguage.trim().toUpperCase() != "EN")) {
-		
+
 		// Finds the full path of the translation file to use
 		var FullPath = "Screens/" + CurrentModule + "/" + CurrentScreen + "/Text_" + CurrentScreen + "_" + TranslationLanguage + ".txt";
 
@@ -457,7 +457,7 @@ function TranslationAssetProcess(T) {
  * @returns {void} - Nothing
  */
 function TranslationAsset(Family) {
-	
+
 	// If we play in a foreign language
 	if ((TranslationLanguage != null) && (TranslationLanguage.trim() != "") && (TranslationLanguage.trim().toUpperCase() != "EN")) {
 
@@ -478,9 +478,9 @@ function TranslationAsset(Family) {
 					TranslationAssetProcess(TranslationCache[FullPath]);
 				}
 			});
-	
+
 	}
-	
+
 }
 
 /**
@@ -500,7 +500,7 @@ function TranslationNextLanguage() {
 }
 
 /**
- * Loads the previous translation language from local storage if it exists 
+ * Loads the previous translation language from local storage if it exists
  * @returns {void} - Nothing
  */
 function TranslationLoad() {

--- a/BondageClub/Scripts/Validation.js
+++ b/BondageClub/Scripts/Validation.js
@@ -231,7 +231,7 @@ function ValidationResolveModifyDiff(previousItem, newItem, params) {
 		});
 		newKeys.forEach((key) => {
 			if (!previousKeys.includes(key)) {
-				console.warn(`Invalid modification of property "${key}" for item ${warningSuffix}`)
+				console.warn(`Invalid modification of property "${key}" for item ${warningSuffix}`);
 				valid = false;
 				delete newProperty[key];
 			}

--- a/BondageClub/Scripts/VibratorMode.js
+++ b/BondageClub/Scripts/VibratorMode.js
@@ -239,22 +239,22 @@ function VibratorModeClick(Options, Y) {
  */
 function VibratorModeGetOption(ModeName) {
 	var result = null;
-	
+
 	[VibratorModeSet.STANDARD, VibratorModeSet.ADVANCED].some((OptionName) => {
 		var OptionGroup = VibratorModeOptions[OptionName];
 		var Handled = OptionGroup.some((Option, I) => {
 			if ((Option.Property != null) && (Option.Property.Mode == ModeName)) {
-				result = Option
-				return true
+				result = Option;
+				return true;
 			}
 			return false;
 		});
 		return Handled;
 	});
-	
-	if (result) return result	
-	return VibratorModeOptions.Standard[0]
-	
+
+	if (result) return result;
+	return VibratorModeOptions.Standard[0];
+
 }
 
 
@@ -300,7 +300,7 @@ function VibratorModeSetDynamicProperties(Property) {
 	const NewProperty = Object.assign({}, Property);
 	if (typeof NewProperty.Intensity === "function") NewProperty.Intensity = NewProperty.Intensity();
 	if (typeof NewProperty.Effect === "function") NewProperty.Effect = NewProperty.Effect(NewProperty.Intensity);
-	else NewProperty.Effect = JSON.parse(JSON.stringify(Property.Effect || []))
+	else NewProperty.Effect = JSON.parse(JSON.stringify(Property.Effect || []));
 	return NewProperty;
 }
 


### PR DESCRIPTION
This PR has no functional effect, it only:
- Removes spaces and tabs on end of lines, where they have no effect (trailing whitespace)
- Add semicolons to where they should be
- Changes missed `var` to `let` in `SpeechGarbleByGagLevel`

To keep this cleanup small, this part only focuses on files with less than 20 edits each.