### PR TITLE
Cleanup: Scripts formatting (Part 7 - `Screens/Inventory/*` - little changes)

### DIFF
--- a/BondageClub/Screens/Inventory/ClothAccessory/BunnyCollarCuffs/BunnyCollarCuffs.js
+++ b/BondageClub/Screens/Inventory/ClothAccessory/BunnyCollarCuffs/BunnyCollarCuffs.js
@@ -9,13 +9,13 @@ var InventoryClothAccessoryBunnyCollarCuffsOptions = [
 	{
 		Name: "Collar",
 		Property: {
-			Type: "Collar", 
+			Type: "Collar",
 		},
 	},
 	{
 		Name: "Cuffs",
 		Property: {
-			Type: "Cuffs", 
+			Type: "Cuffs",
 		},
 	},
 ];

--- a/BondageClub/Screens/Inventory/ItemAddon/CeilingChain/CeilingChain.js
+++ b/BondageClub/Screens/Inventory/ItemAddon/CeilingChain/CeilingChain.js
@@ -8,8 +8,7 @@ const CeilingChainAddonOptions = [
 		Name: "Suspended",
         Property: { Type: "Suspended", Difficulty: 7,
     OverrideHeight: { Height: 30, Priority: 51, HeightRatioProportion: 0 } },
-	}, 
-	
+	},
 ];
 
 

--- a/BondageClub/Screens/Inventory/ItemAddon/CeilingRope/CeilingRope.js
+++ b/BondageClub/Screens/Inventory/ItemAddon/CeilingRope/CeilingRope.js
@@ -8,8 +8,7 @@ const CeilingRopeAddonOptions = [
 		Name: "Suspended",
         Property: { Type: "Suspended", Difficulty: 7,
     OverrideHeight: { Height: 30, Priority: 51, HeightRatioProportion: 0 } },
-	}, 
-	
+	},
 ];
 
 

--- a/BondageClub/Screens/Inventory/ItemArms/Chains/Chains.js
+++ b/BondageClub/Screens/Inventory/ItemArms/Chains/Chains.js
@@ -96,9 +96,9 @@ function InventoryItemArmsChainsPublishAction(C, Option) {
 }
 
 /**
- * The NPC dialog is for what the NPC says to you when you make a change to their restraints - the dialog lookup is on a 
- * per-NPC basis. You basically put the "AssetName" + OptionName in there to allow individual NPCs to override their default 
- * "GroupName" dialog if for example we ever wanted an NPC to react specifically to having the restraint put on them. 
+ * The NPC dialog is for what the NPC says to you when you make a change to their restraints - the dialog lookup is on a
+ * per-NPC basis. You basically put the "AssetName" + OptionName in there to allow individual NPCs to override their default
+ * "GroupName" dialog if for example we ever wanted an NPC to react specifically to having the restraint put on them.
  * That could be done by adding an "AssetName" entry (or entries) to that NPC's dialog CSV
  * @param {Character} C - The NPC to whom the restraint is applied
  * @param {Option} Option - The chosen option for this extended item

--- a/BondageClub/Screens/Inventory/ItemArms/DuctTape/DuctTape.js
+++ b/BondageClub/Screens/Inventory/ItemArms/DuctTape/DuctTape.js
@@ -107,9 +107,9 @@ function InventoryItemArmsDuctTapePublishAction(C, Option, PreviousOption) {
 }
 
 /**
- * The NPC dialog is for what the NPC says to you when you make a change to their restraints - the dialog lookup is on a 
- * per-NPC basis. You basically put the "AssetName" + OptionName in there to allow individual NPCs to override their default 
- * "GroupName" dialog if for example we ever wanted an NPC to react specifically to having the restraint put on them. 
+ * The NPC dialog is for what the NPC says to you when you make a change to their restraints - the dialog lookup is on a
+ * per-NPC basis. You basically put the "AssetName" + OptionName in there to allow individual NPCs to override their default
+ * "GroupName" dialog if for example we ever wanted an NPC to react specifically to having the restraint put on them.
  * That could be done by adding an "AssetName" entry (or entries) to that NPC's dialog CSV
  * @param {Character} C - The NPC to whom the restraint is applied
  * @param {Option} Option - The chosen option for this extended item

--- a/BondageClub/Screens/Inventory/ItemArms/FuturisticArmbinder/FuturisticArmbinder.js
+++ b/BondageClub/Screens/Inventory/ItemArms/FuturisticArmbinder/FuturisticArmbinder.js
@@ -15,7 +15,7 @@ var InventoryItemArmsFuturisticArmbinderOptions = [
 function InventoryItemArmsFuturisticArmbinderLoad() {
 	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
 	if (InventoryItemMouthFuturisticPanelGagValidate(C) !== "") {
-		InventoryItemMouthFuturisticPanelGagLoadAccessDenied()
+		InventoryItemMouthFuturisticPanelGagLoadAccessDenied();
 	} else
 	ExtendedItemLoad(InventoryItemArmsFuturisticArmbinderOptions, "SelectFuturisticArmbinderType");
 }
@@ -24,7 +24,7 @@ function InventoryItemArmsFuturisticArmbinderLoad() {
 function InventoryItemArmsFuturisticArmbinderDraw() {
 	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
 	if (InventoryItemMouthFuturisticPanelGagValidate(C) !== "") {
-		InventoryItemMouthFuturisticPanelGagDrawAccessDenied()
+		InventoryItemMouthFuturisticPanelGagDrawAccessDenied();
 	} else
 		ExtendedItemDraw(InventoryItemArmsFuturisticArmbinderOptions, "FuturisticArmbinderType");
 }
@@ -33,17 +33,17 @@ function InventoryItemArmsFuturisticArmbinderDraw() {
 function InventoryItemArmsFuturisticArmbinderClick() {
 	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
 	if (InventoryItemMouthFuturisticPanelGagValidate(C) !== "") {
-		InventoryItemMouthFuturisticPanelGagClickAccessDenied()
+		InventoryItemMouthFuturisticPanelGagClickAccessDenied();
 	} else
 		ExtendedItemClick(InventoryItemArmsFuturisticArmbinderOptions);
 }
 
 function InventoryItemArmsFuturisticArmbinderExit() {
-	InventoryItemMouthFuturisticPanelGagExitAccessDenied()
+	InventoryItemMouthFuturisticPanelGagExitAccessDenied();
 }
-	
+
 function InventoryItemArmsFuturisticArmbinderValidate(C, Option) {
-	return InventoryItemMouthFuturisticPanelGagValidate(C, Option)
+	return InventoryItemMouthFuturisticPanelGagValidate(C, Option);
 }
 
 function InventoryItemArmsFuturisticArmbinderPublishAction(C, Option) {

--- a/BondageClub/Screens/Inventory/ItemArms/FuturisticStraitjacket/FuturisticStraitjacket.js
+++ b/BondageClub/Screens/Inventory/ItemArms/FuturisticStraitjacket/FuturisticStraitjacket.js
@@ -47,7 +47,7 @@ var InventoryItemArmsFuturisticStraitjacketOptions = [
 function InventoryItemArmsFuturisticStraitjacketLoad() {
 	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
 	if (InventoryItemMouthFuturisticPanelGagValidate(C) !== "") {
-		InventoryItemMouthFuturisticPanelGagLoadAccessDenied()
+		InventoryItemMouthFuturisticPanelGagLoadAccessDenied();
 	} else
 	ExtendedItemLoad(InventoryItemArmsFuturisticStraitjacketOptions, "SelectFuturisticStraitjacketType");
 }
@@ -56,7 +56,7 @@ function InventoryItemArmsFuturisticStraitjacketLoad() {
 function InventoryItemArmsFuturisticStraitjacketDraw() {
 	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
 	if (InventoryItemMouthFuturisticPanelGagValidate(C) !== "") {
-		InventoryItemMouthFuturisticPanelGagDrawAccessDenied()
+		InventoryItemMouthFuturisticPanelGagDrawAccessDenied();
 	} else
 		ExtendedItemDraw(InventoryItemArmsFuturisticStraitjacketOptions, "FuturisticStraitjacketType");
 }
@@ -65,17 +65,17 @@ function InventoryItemArmsFuturisticStraitjacketDraw() {
 function InventoryItemArmsFuturisticStraitjacketClick() {
 	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
 	if (InventoryItemMouthFuturisticPanelGagValidate(C) !== "") {
-		InventoryItemMouthFuturisticPanelGagClickAccessDenied()
+		InventoryItemMouthFuturisticPanelGagClickAccessDenied();
 	} else
 		ExtendedItemClick(InventoryItemArmsFuturisticStraitjacketOptions);
 }
 
 function InventoryItemArmsFuturisticStraitjacketExit() {
-	InventoryItemMouthFuturisticPanelGagExitAccessDenied()
+	InventoryItemMouthFuturisticPanelGagExitAccessDenied();
 }
-	
+
 function InventoryItemArmsFuturisticStraitjacketValidate(C, Option) {
-	return InventoryItemMouthFuturisticPanelGagValidate(C, Option)
+	return InventoryItemMouthFuturisticPanelGagValidate(C, Option);
 }
 
 function InventoryItemArmsFuturisticStraitjacketPublishAction(C, Option) {

--- a/BondageClub/Screens/Inventory/ItemArms/InflatableStraightLeotard/InflatableStraightLeotard.js
+++ b/BondageClub/Screens/Inventory/ItemArms/InflatableStraightLeotard/InflatableStraightLeotard.js
@@ -23,7 +23,6 @@ var InventoryItemArmsInflatableStraightLeotardOptions = [
 			Effect: ["Block", "Prone"],
 			Difficulty: 2,
         },
-        
     },
     {
         Name: "Max",

--- a/BondageClub/Screens/Inventory/ItemArms/LeatherArmbinder/LeatherArmbinder.js
+++ b/BondageClub/Screens/Inventory/ItemArms/LeatherArmbinder/LeatherArmbinder.js
@@ -12,7 +12,7 @@ var InventoryItemArmsLeatherArmbinderOptions = [
 	{
 		Name: "WrapStrap",
 		Property: { Type: "WrapStrap", Difficulty: 3 },
-	},	
+	},
 ];
 
 // Loads the item extension properties

--- a/BondageClub/Screens/Inventory/ItemArms/LeatherCuffs/LeatherCuffs.js
+++ b/BondageClub/Screens/Inventory/ItemArms/LeatherCuffs/LeatherCuffs.js
@@ -41,7 +41,7 @@ var InventoryItemArmsLeatherCuffsOptions = [
 			SelfUnlock: false,
 		},
 	}
-]
+];
 
 /**
  * Loads the item extension properties
@@ -58,7 +58,7 @@ function InventoryItemArmsLeatherCuffsLoad() {
 function InventoryItemArmsLeatherCuffsDraw() {
 	ExtendedItemDraw(InventoryItemArmsLeatherCuffsOptions, "LeatherCuffsPose");
 }
-	
+
 /**
  * Catches the item extension clicks
  * @returns {void} - Nothing
@@ -84,9 +84,9 @@ function InventoryItemArmsLeatherCuffsPublishAction(C, Option, PreviousOption) {
 }
 
 /**
- * The NPC dialog is for what the NPC says to you when you make a change to their restraints - the dialog lookup is on a 
- * per-NPC basis. You basically put the "AssetName" + OptionName in there to allow individual NPCs to override their default 
- * "GroupName" dialog if for example we ever wanted an NPC to react specifically to having the restraint put on them. 
+ * The NPC dialog is for what the NPC says to you when you make a change to their restraints - the dialog lookup is on a
+ * per-NPC basis. You basically put the "AssetName" + OptionName in there to allow individual NPCs to override their default
+ * "GroupName" dialog if for example we ever wanted an NPC to react specifically to having the restraint put on them.
  * That could be done by adding an "AssetName" entry (or entries) to that NPC's dialog CSV
  * @param {Character} C - The NPC to whom the restraint is applied
  * @param {Option} Option - The chosen option for this extended item

--- a/BondageClub/Screens/Inventory/ItemArms/LeatherStraitJacket/LeatherStraitJacket.js
+++ b/BondageClub/Screens/Inventory/ItemArms/LeatherStraitJacket/LeatherStraitJacket.js
@@ -69,9 +69,9 @@ function InventoryItemArmsLeatherStraitJacketPublishAction (C, Option, PreviousO
 }
 
 /**
- * The NPC dialog is for what the NPC says to you when you make a change to their restraints - the dialog lookup is on a 
- * per-NPC basis. You basically put the "AssetName" + OptionName in there to allow individual NPCs to override their default 
- * "GroupName" dialog if for example we ever wanted an NPC to react specifically to having the restraint put on them. 
+ * The NPC dialog is for what the NPC says to you when you make a change to their restraints - the dialog lookup is on a
+ * per-NPC basis. You basically put the "AssetName" + OptionName in there to allow individual NPCs to override their default
+ * "GroupName" dialog if for example we ever wanted an NPC to react specifically to having the restraint put on them.
  * That could be done by adding an "AssetName" entry (or entries) to that NPC's dialog CSV
  * @param {Character} C - The NPC to whom the restraint is applied
  * @param {Option} Option - The chosen option for this extended item

--- a/BondageClub/Screens/Inventory/ItemArms/MermaidSuit/MermaidSuit.js
+++ b/BondageClub/Screens/Inventory/ItemArms/MermaidSuit/MermaidSuit.js
@@ -59,9 +59,9 @@ function InventoryItemArmsMermaidSuitPublishAction(C, Option, PreviousOption) {
 }
 
 /**
- * The NPC dialog is for what the NPC says to you when you make a change to their restraints - the dialog lookup is on a 
- * per-NPC basis. You basically put the "AssetName" + OptionName in there to allow individual NPCs to override their default 
- * "GroupName" dialog if for example we ever wanted an NPC to react specifically to having the restraint put on them. 
+ * The NPC dialog is for what the NPC says to you when you make a change to their restraints - the dialog lookup is on a
+ * per-NPC basis. You basically put the "AssetName" + OptionName in there to allow individual NPCs to override their default
+ * "GroupName" dialog if for example we ever wanted an NPC to react specifically to having the restraint put on them.
  * That could be done by adding an "AssetName" entry (or entries) to that NPC's dialog CSV
  * @param {Character} C - The NPC to whom the restraint is applied
  * @param {Option} Option - The chosen option for this extended item

--- a/BondageClub/Screens/Inventory/ItemArms/OrnateCuffs/OrnateCuffs.js
+++ b/BondageClub/Screens/Inventory/ItemArms/OrnateCuffs/OrnateCuffs.js
@@ -66,7 +66,7 @@ function InventoryItemArmsOrnateCuffsDraw() {
 function InventoryItemArmsOrnateCuffsClick() {
 	ExtendedItemClick(InventoryItemArmsOrnateCuffsOptions);
 }
-	
+
 /**
  * Publishes the message to the chat
  * @param {Character} C - The target character
@@ -84,9 +84,9 @@ function InventoryItemArmsOrnateCuffsPublishAction(C, Option, PreviousOption) {
 }
 
 /**
- * The NPC dialog is for what the NPC says to you when you make a change to their restraints - the dialog lookup is on a 
- * per-NPC basis. You basically put the "AssetName" + OptionName in there to allow individual NPCs to override their default 
- * "GroupName" dialog if for example we ever wanted an NPC to react specifically to having the restraint put on them. 
+ * The NPC dialog is for what the NPC says to you when you make a change to their restraints - the dialog lookup is on a
+ * per-NPC basis. You basically put the "AssetName" + OptionName in there to allow individual NPCs to override their default
+ * "GroupName" dialog if for example we ever wanted an NPC to react specifically to having the restraint put on them.
  * That could be done by adding an "AssetName" entry (or entries) to that NPC's dialog CSV
  * @param {Character} C - The NPC to whom the restraint is applied
  * @param {Option} Option - The chosen option for this extended item

--- a/BondageClub/Screens/Inventory/ItemArms/StraitJacket/StraitJacket.js
+++ b/BondageClub/Screens/Inventory/ItemArms/StraitJacket/StraitJacket.js
@@ -29,7 +29,7 @@ var InventoryItemArmsStraitJacketOptions = [
 			Difficulty: 9,
 		},
 	},
-]
+];
 
 /**
  * Loads the item extension properties
@@ -54,7 +54,7 @@ function InventoryItemArmsStraitJacketDraw() {
 function InventoryItemArmsStraitJacketClick() {
 	ExtendedItemClick(InventoryItemArmsStraitJacketOptions);
 }
-	
+
 /**
  * Publishes the message to the chat
  * @param {Character} C - The target character
@@ -72,9 +72,9 @@ function InventoryItemArmsStraitJacketPublishAction(C, Option, PreviousOption) {
 }
 
 /**
- * The NPC dialog is for what the NPC says to you when you make a change to their restraints - the dialog lookup is on a 
- * per-NPC basis. You basically put the "AssetName" + OptionName in there to allow individual NPCs to override their default 
- * "GroupName" dialog if for example we ever wanted an NPC to react specifically to having the restraint put on them. 
+ * The NPC dialog is for what the NPC says to you when you make a change to their restraints - the dialog lookup is on a
+ * per-NPC basis. You basically put the "AssetName" + OptionName in there to allow individual NPCs to override their default
+ * "GroupName" dialog if for example we ever wanted an NPC to react specifically to having the restraint put on them.
  * That could be done by adding an "AssetName" entry (or entries) to that NPC's dialog CSV
  * @param {Character} C - The NPC to whom the restraint is applied
  * @param {Option} Option - The chosen option for this extended item

--- a/BondageClub/Screens/Inventory/ItemArms/SturdyLeatherBelts/SturdyLeatherBelts.js
+++ b/BondageClub/Screens/Inventory/ItemArms/SturdyLeatherBelts/SturdyLeatherBelts.js
@@ -78,9 +78,9 @@ function InventoryItemArmsSturdyLeatherBeltsPublishAction(C, Option) {
 }
 
 /**
- * The NPC dialog is for what the NPC says to you when you make a change to their restraints - the dialog lookup is on a 
- * per-NPC basis. You basically put the "AssetName" + OptionName in there to allow individual NPCs to override their default 
- * "GroupName" dialog if for example we ever wanted an NPC to react specifically to having the restraint put on them. 
+ * The NPC dialog is for what the NPC says to you when you make a change to their restraints - the dialog lookup is on a
+ * per-NPC basis. You basically put the "AssetName" + OptionName in there to allow individual NPCs to override their default
+ * "GroupName" dialog if for example we ever wanted an NPC to react specifically to having the restraint put on them.
  * That could be done by adding an "AssetName" entry (or entries) to that NPC's dialog CSV
  * @param {Character} C - The NPC to whom the restraint is applied
  * @param {Option} Option - The chosen option for this extended item

--- a/BondageClub/Screens/Inventory/ItemArms/TightJacket/TightJacket.js
+++ b/BondageClub/Screens/Inventory/ItemArms/TightJacket/TightJacket.js
@@ -89,9 +89,9 @@ function InventoryItemArmsTightJacketPublishAction(C, Option) {
 }
 
 /**
- * The NPC dialog is for what the NPC says to you when you make a change to their restraints - the dialog lookup is on a 
- * per-NPC basis. You basically put the "AssetName" + OptionName in there to allow individual NPCs to override their default 
- * "GroupName" dialog if for example we ever wanted an NPC to react specifically to having the restraint put on them. 
+ * The NPC dialog is for what the NPC says to you when you make a change to their restraints - the dialog lookup is on a
+ * per-NPC basis. You basically put the "AssetName" + OptionName in there to allow individual NPCs to override their default
+ * "GroupName" dialog if for example we ever wanted an NPC to react specifically to having the restraint put on them.
  * That could be done by adding an "AssetName" entry (or entries) to that NPC's dialog CSV
  * @param {Character} C - The NPC to whom the restraint is applied
  * @param {Option} Option - The chosen option for this extended item

--- a/BondageClub/Screens/Inventory/ItemArms/TightJacketCrotch/TightJacketCrotch.js
+++ b/BondageClub/Screens/Inventory/ItemArms/TightJacketCrotch/TightJacketCrotch.js
@@ -89,9 +89,9 @@ function InventoryItemArmsTightJacketCrotchPublishAction(C, Option) {
 }
 
 /**
- * The NPC dialog is for what the NPC says to you when you make a change to their restraints - the dialog lookup is on a 
- * per-NPC basis. You basically put the "AssetName" + OptionName in there to allow individual NPCs to override their default 
- * "GroupName" dialog if for example we ever wanted an NPC to react specifically to having the restraint put on them. 
+ * The NPC dialog is for what the NPC says to you when you make a change to their restraints - the dialog lookup is on a
+ * per-NPC basis. You basically put the "AssetName" + OptionName in there to allow individual NPCs to override their default
+ * "GroupName" dialog if for example we ever wanted an NPC to react specifically to having the restraint put on them.
  * That could be done by adding an "AssetName" entry (or entries) to that NPC's dialog CSV
  * @param {Character} C - The NPC to whom the restraint is applied
  * @param {Option} Option - The chosen option for this extended item

--- a/BondageClub/Screens/Inventory/ItemArms/Web/Web.js
+++ b/BondageClub/Screens/Inventory/ItemArms/Web/Web.js
@@ -139,9 +139,9 @@ function InventoryItemArmsWebPublishAction(C, Option, PreviousOption) {
 }
 
 /**
- * The NPC dialog is for what the NPC says to you when you make a change to their restraints - the dialog lookup is on a 
- * per-NPC basis. You basically put the "AssetName" + OptionName in there to allow individual NPCs to override their default 
- * "GroupName" dialog if for example we ever wanted an NPC to react specifically to having the restraint put on them. 
+ * The NPC dialog is for what the NPC says to you when you make a change to their restraints - the dialog lookup is on a
+ * per-NPC basis. You basically put the "AssetName" + OptionName in there to allow individual NPCs to override their default
+ * "GroupName" dialog if for example we ever wanted an NPC to react specifically to having the restraint put on them.
  * That could be done by adding an "AssetName" entry (or entries) to that NPC's dialog CSV
  * @param {Character} C - The NPC to whom the restraint is applied
  * @param {Option} Option - The chosen option for this extended item

--- a/BondageClub/Screens/Inventory/ItemBoots/ToeTape/ToeTape.js
+++ b/BondageClub/Screens/Inventory/ItemBoots/ToeTape/ToeTape.js
@@ -9,7 +9,7 @@ var InventoryItemBootsToeTapeOptions = [
 		Name: "Full",
 		Property: { Type: "Full", Difficulty: 2 },
 	},
-]
+];
 
 /**
  * Loads the item extension properties
@@ -52,9 +52,9 @@ function InventoryItemBootsToeTapePublishAction(C, Option, PreviousOption) {
 }
 
 /**
- * The NPC dialog is for what the NPC says to you when you make a change to their restraints - the dialog lookup is on a 
- * per-NPC basis. You basically put the "AssetName" + OptionName in there to allow individual NPCs to override their default 
- * "GroupName" dialog if for example we ever wanted an NPC to react specifically to having the restraint put on them. 
+ * The NPC dialog is for what the NPC says to you when you make a change to their restraints - the dialog lookup is on a
+ * per-NPC basis. You basically put the "AssetName" + OptionName in there to allow individual NPCs to override their default
+ * "GroupName" dialog if for example we ever wanted an NPC to react specifically to having the restraint put on them.
  * That could be done by adding an "AssetName" entry (or entries) to that NPC's dialog CSV
  * @param {Character} C - The NPC to whom the restraint is applied
  * @param {Option} Option - The chosen option for this extended item

--- a/BondageClub/Screens/Inventory/ItemButt/AnalBeads2/AnalBeads2.js
+++ b/BondageClub/Screens/Inventory/ItemButt/AnalBeads2/AnalBeads2.js
@@ -51,11 +51,11 @@ function InventoryItemButtAnalBeads2SetBeads(Modifier) {
 
 	var beadsNum = DialogFocusItem.Property.InsertedBeads;
 
-	// Loads the correct type/asset	
+	// Loads the correct type/asset
 	DialogFocusItem.Property.Type = beadsNum > 1 ? "_" + beadsNum + "in" : ["Base"];
 	CharacterRefresh(C);
 
-	// Push Chatroom Event	
+	// Push Chatroom Event
 	var Dictionary = [];
 	Dictionary.push({ Tag: "DestinationCharacter", Text: C.Name, MemberNumber: C.MemberNumber });
 	Dictionary.push({ Tag: "SourceCharacter", Text: Player.Name, MemberNumber: Player.MemberNumber });

--- a/BondageClub/Screens/Inventory/ItemButt/AnalHook/AnalHook.js
+++ b/BondageClub/Screens/Inventory/ItemButt/AnalHook/AnalHook.js
@@ -71,9 +71,9 @@ function InventoryItemButtAnalHookPublishAction(C, Option, PreviousOption) {
 }
 
 /**
- * The NPC dialog is for what the NPC says to you when you make a change to their restraints - the dialog lookup is on a 
- * per-NPC basis. You basically put the "AssetName" + OptionName in there to allow individual NPCs to override their default 
- * "GroupName" dialog if for example we ever wanted an NPC to react specifically to having the restraint put on them. 
+ * The NPC dialog is for what the NPC says to you when you make a change to their restraints - the dialog lookup is on a
+ * per-NPC basis. You basically put the "AssetName" + OptionName in there to allow individual NPCs to override their default
+ * "GroupName" dialog if for example we ever wanted an NPC to react specifically to having the restraint put on them.
  * That could be done by adding an "AssetName" entry (or entries) to that NPC's dialog CSV
  * @param {Character} C - The NPC to whom the restraint is applied
  * @param {Option} Option - The chosen option for this extended item

--- a/BondageClub/Screens/Inventory/ItemButt/InflVibeButtPlug/InflVibeButtPlug.js
+++ b/BondageClub/Screens/Inventory/ItemButt/InflVibeButtPlug/InflVibeButtPlug.js
@@ -29,7 +29,7 @@ function InventoryItemButtInflVibeButtPlugDraw() {
 
 // Catches the item extension clicks
 function InventoryItemButtInflVibeButtPlugClick(actionPrefix) {
-	actionPrefix = actionPrefix || "InflVibeButtPlug"
+	actionPrefix = actionPrefix || "InflVibeButtPlug";
 	if (MouseIn(1885, 25, 90, 90)) DialogFocusItem = null;
 	else if (MouseIn(1200, 775, 200, 55) && (DialogFocusItem.Property.InflateLevel !== 0)) InventoryItemButtInflVibeButtPlugInflation(0 - DialogFocusItem.Property.InflateLevel, actionPrefix);
 	else if (MouseIn(1550, 775, 200, 55) && (DialogFocusItem.Property.InflateLevel !== 1)) InventoryItemButtInflVibeButtPlugInflation(1 - DialogFocusItem.Property.InflateLevel, actionPrefix);

--- a/BondageClub/Screens/Inventory/ItemDevices/BondageBench/BondageBench.js
+++ b/BondageClub/Screens/Inventory/ItemDevices/BondageBench/BondageBench.js
@@ -103,9 +103,9 @@ function InventoryItemDevicesBondageBenchPublishAction(C, Option, PreviousOption
 }
 
 /**
- * The NPC dialog is for what the NPC says to you when you make a change to their restraints - the dialog lookup is on a 
- * per-NPC basis. You basically put the "AssetName" + OptionName in there to allow individual NPCs to override their default 
- * "GroupName" dialog if for example we ever wanted an NPC to react specifically to having the restraint put on them. 
+ * The NPC dialog is for what the NPC says to you when you make a change to their restraints - the dialog lookup is on a
+ * per-NPC basis. You basically put the "AssetName" + OptionName in there to allow individual NPCs to override their default
+ * "GroupName" dialog if for example we ever wanted an NPC to react specifically to having the restraint put on them.
  * That could be done by adding an "AssetName" entry (or entries) to that NPC's dialog CSV
  * @param {Character} C - The NPC to whom the restraint is applied
  * @param {Option} Option - The chosen option for this extended item

--- a/BondageClub/Screens/Inventory/ItemDevices/Coffin/Coffin.js
+++ b/BondageClub/Screens/Inventory/ItemDevices/Coffin/Coffin.js
@@ -76,9 +76,9 @@ function InventoryItemDevicesCoffinPublishAction(C, Option) {
 }
 
 /**
- * The NPC dialog is for what the NPC says to you when you make a change to their restraints - the dialog lookup is on a 
- * per-NPC basis. You basically put the "AssetName" + OptionName in there to allow individual NPCs to override their default 
- * "GroupName" dialog if for example we ever wanted an NPC to react specifically to having the restraint put on them. 
+ * The NPC dialog is for what the NPC says to you when you make a change to their restraints - the dialog lookup is on a
+ * per-NPC basis. You basically put the "AssetName" + OptionName in there to allow individual NPCs to override their default
+ * "GroupName" dialog if for example we ever wanted an NPC to react specifically to having the restraint put on them.
  * That could be done by adding an "AssetName" entry (or entries) to that NPC's dialog CSV
  * @param {Character} C - The NPC to whom the restraint is applied
  * @param {Option} Option - The chosen option for this extended item

--- a/BondageClub/Screens/Inventory/ItemDevices/CryoCapsule/CryoCapsule.js
+++ b/BondageClub/Screens/Inventory/ItemDevices/CryoCapsule/CryoCapsule.js
@@ -76,9 +76,9 @@ function InventoryItemDevicesCryoCapsulePublishAction(C, Option) {
 }
 
 /**
- * The NPC dialog is for what the NPC says to you when you make a change to their restraints - the dialog lookup is on a 
- * per-NPC basis. You basically put the "AssetName" + OptionName in there to allow individual NPCs to override their default 
- * "GroupName" dialog if for example we ever wanted an NPC to react specifically to having the restraint put on them. 
+ * The NPC dialog is for what the NPC says to you when you make a change to their restraints - the dialog lookup is on a
+ * per-NPC basis. You basically put the "AssetName" + OptionName in there to allow individual NPCs to override their default
+ * "GroupName" dialog if for example we ever wanted an NPC to react specifically to having the restraint put on them.
  * That could be done by adding an "AssetName" entry (or entries) to that NPC's dialog CSV
  * @param {Character} C - The NPC to whom the restraint is applied
  * @param {Option} Option - The chosen option for this extended item

--- a/BondageClub/Screens/Inventory/ItemDevices/Cushion/Cushion.js
+++ b/BondageClub/Screens/Inventory/ItemDevices/Cushion/Cushion.js
@@ -12,7 +12,7 @@ var InventoryItemDevicesCushionOptions = [
 			Type: "Kneel",
 			OverrideHeight: { Height: -200, Priority: 21 },
 			OverridePriority: 1,
-			SetPose: ["Kneel"]		 
+			SetPose: ["Kneel"]
 		},
 	},
 ];

--- a/BondageClub/Screens/Inventory/ItemDevices/PetBed/PetBed.js
+++ b/BondageClub/Screens/Inventory/ItemDevices/PetBed/PetBed.js
@@ -3,19 +3,19 @@
 var InventoryItemDevicesPetBedOptions = [
 	{
 		Name: "NoBlanket",
-		Property: { 
-			Type: null 
+		Property: {
+			Type: null
 		},
 	},
 	{
 		Name: "Blanket",
-		Property: { 
-			Type: "Blanket", 
+		Property: {
+			Type: "Blanket",
 			SetPose: ["AllFours"],
 			Hide: ["ItemArms", "ItemButt", "TailStraps", "Wings"],
 			Block: [
 				"ItemArms", "ItemBreast", "ItemButt", "ItemFeet", "ItemBoots",
-				"ItemLegs", "ItemMisc", "ItemNipples", "ItemNipplesPiercings", 
+				"ItemLegs", "ItemMisc", "ItemNipples", "ItemNipplesPiercings",
 				"ItemPelvis", "ItemTorso", "ItemVulva", "ItemVulvaPiercings"
 			]
 		},

--- a/BondageClub/Screens/Inventory/ItemDevices/Pole/Pole.js
+++ b/BondageClub/Screens/Inventory/ItemDevices/Pole/Pole.js
@@ -59,9 +59,9 @@ function InventoryItemDevicesPolePublishAction(C, Option) {
 }
 
 /**
- * The NPC dialog is for what the NPC says to you when you make a change to their restraints - the dialog lookup is on a 
- * per-NPC basis. You basically put the "AssetName" + OptionName in there to allow individual NPCs to override their default 
- * "GroupName" dialog if for example we ever wanted an NPC to react specifically to having the restraint put on them. 
+ * The NPC dialog is for what the NPC says to you when you make a change to their restraints - the dialog lookup is on a
+ * per-NPC basis. You basically put the "AssetName" + OptionName in there to allow individual NPCs to override their default
+ * "GroupName" dialog if for example we ever wanted an NPC to react specifically to having the restraint put on them.
  * That could be done by adding an "AssetName" entry (or entries) to that NPC's dialog CSV
  * @param {Character} C - The NPC to whom the restraint is applied
  * @param {Option} Option - The chosen option for this extended item

--- a/BondageClub/Screens/Inventory/ItemEars/BluetoothEarbuds/BluetoothEarbuds.js
+++ b/BondageClub/Screens/Inventory/ItemEars/BluetoothEarbuds/BluetoothEarbuds.js
@@ -1,7 +1,7 @@
 "use strict";
 
 /**
- * Forwards the call to InventoryItemEarsHeadphoneEarPlugsLoad 
+ * Forwards the call to InventoryItemEarsHeadphoneEarPlugsLoad
  * @returns {void} - Nothing
  */
 function InventoryItemEarsBluetoothEarbudsLoad() {
@@ -9,7 +9,7 @@ function InventoryItemEarsBluetoothEarbudsLoad() {
 }
 
 /**
- * Forwards the call to InventoryItemEarsHeadphoneEarPlugsDraw 
+ * Forwards the call to InventoryItemEarsHeadphoneEarPlugsDraw
  * @returns {void} - Nothing
  */
 function InventoryItemEarsBluetoothEarbudsDraw() {
@@ -17,7 +17,7 @@ function InventoryItemEarsBluetoothEarbudsDraw() {
 }
 
 /**
- * Forwards the call to InventoryItemEarsHeadphoneEarPlugsClick 
+ * Forwards the call to InventoryItemEarsHeadphoneEarPlugsClick
  * @returns {void} - Nothing
  */
 function InventoryItemEarsBluetoothEarbudsClick() {
@@ -25,7 +25,7 @@ function InventoryItemEarsBluetoothEarbudsClick() {
 }
 
 /**
- * Forwards the call to InventoryItemEarsHeadphoneEarPlugsPublishAction 
+ * Forwards the call to InventoryItemEarsHeadphoneEarPlugsPublishAction
  * @param {Character} C - The target character
  * @param {Option} Option - The currently selected Option
  * @param {Option} PreviousOption - The previously selected Option
@@ -36,7 +36,7 @@ function InventoryItemEarsBluetoothEarbudsPublishAction(C, Option, PreviousOptio
 }
 
 /**
- * Forwards the call to 	InventoryItemEarsHeadphoneEarPlugsNpcDialog 
+ * Forwards the call to 	InventoryItemEarsHeadphoneEarPlugsNpcDialog
  * @param {Character} C - The NPC to whom the restraint is applied
  * @param {Option} Option - The chosen option for this extended item
  * @returns {void} - Nothing

--- a/BondageClub/Screens/Inventory/ItemEars/FuturisticEarphones/FuturisticEarphones.js
+++ b/BondageClub/Screens/Inventory/ItemEars/FuturisticEarphones/FuturisticEarphones.js
@@ -40,7 +40,7 @@ var InventoryItemEarsFuturisticEarphonesOptions = [
 function InventoryItemEarsFuturisticEarphonesLoad() {
 	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
 	if (InventoryItemMouthFuturisticPanelGagValidate(C) !== "") {
-		InventoryItemMouthFuturisticPanelGagLoadAccessDenied()
+		InventoryItemMouthFuturisticPanelGagLoadAccessDenied();
 	} else
 		ExtendedItemLoad(InventoryItemEarsFuturisticEarphonesOptions, "HeadphoneEarPlugsSelectLoudness");
 }
@@ -52,7 +52,7 @@ function InventoryItemEarsFuturisticEarphonesLoad() {
 function InventoryItemEarsFuturisticEarphonesDraw() {
 	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
 	if (InventoryItemMouthFuturisticPanelGagValidate(C) !== "") {
-		InventoryItemMouthFuturisticPanelGagDrawAccessDenied()
+		InventoryItemMouthFuturisticPanelGagDrawAccessDenied();
 	} else
 		ExtendedItemDraw(InventoryItemEarsFuturisticEarphonesOptions, "HeadphoneEarPlugsPose");
 }
@@ -65,14 +65,14 @@ function InventoryItemEarsFuturisticEarphonesDraw() {
 function InventoryItemEarsFuturisticEarphonesClick() {
 	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
 	if (InventoryItemMouthFuturisticPanelGagValidate(C) !== "") {
-		InventoryItemMouthFuturisticPanelGagClickAccessDenied()
+		InventoryItemMouthFuturisticPanelGagClickAccessDenied();
 	} else
 		ExtendedItemClick(InventoryItemEarsFuturisticEarphonesOptions);
 }
 
 
 function InventoryItemEarsFuturisticEarphonesExit() {
-	InventoryItemMouthFuturisticPanelGagExitAccessDenied()
+	InventoryItemMouthFuturisticPanelGagExitAccessDenied();
 }
 
 /**

--- a/BondageClub/Screens/Inventory/ItemEars/HeadphoneEarPlugs/HeadphoneEarPlugs.js
+++ b/BondageClub/Screens/Inventory/ItemEars/HeadphoneEarPlugs/HeadphoneEarPlugs.js
@@ -78,9 +78,9 @@ function InventoryItemEarsHeadphoneEarPlugsPublishAction(C, Option, PreviousOpti
 }
 
 /**
- * The NPC dialog is for what the NPC says to you when you make a change to their restraints - the dialog lookup is on a 
- * per-NPC basis. You basically put the "AssetName" + OptionName in there to allow individual NPCs to override their default 
- * "GroupName" dialog if for example we ever wanted an NPC to react specifically to having the restraint put on them. 
+ * The NPC dialog is for what the NPC says to you when you make a change to their restraints - the dialog lookup is on a
+ * per-NPC basis. You basically put the "AssetName" + OptionName in there to allow individual NPCs to override their default
+ * "GroupName" dialog if for example we ever wanted an NPC to react specifically to having the restraint put on them.
  * That could be done by adding an "AssetName" entry (or entries) to that NPC's dialog CSV
  * @param {Character} C - The NPC to whom the restraint is applied
  * @param {Option} Option - The chosen option for this extended item

--- a/BondageClub/Screens/Inventory/ItemEars/Headphones/Headphones.js
+++ b/BondageClub/Screens/Inventory/ItemEars/Headphones/Headphones.js
@@ -78,9 +78,9 @@ function InventoryItemEarsHeadphonesPublishAction(C, Option, PreviousOption) {
 }
 
 /**
- * The NPC dialog is for what the NPC says to you when you make a change to their restraints - the dialog lookup is on a 
- * per-NPC basis. You basically put the "AssetName" + OptionName in there to allow individual NPCs to override their default 
- * "GroupName" dialog if for example we ever wanted an NPC to react specifically to having the restraint put on them. 
+ * The NPC dialog is for what the NPC says to you when you make a change to their restraints - the dialog lookup is on a
+ * per-NPC basis. You basically put the "AssetName" + OptionName in there to allow individual NPCs to override their default
+ * "GroupName" dialog if for example we ever wanted an NPC to react specifically to having the restraint put on them.
  * That could be done by adding an "AssetName" entry (or entries) to that NPC's dialog CSV
  * @param {Character} C - The NPC to whom the restraint is applied
  * @param {Option} Option - The chosen option for this extended item

--- a/BondageClub/Screens/Inventory/ItemFeet/Chains/Chains.js
+++ b/BondageClub/Screens/Inventory/ItemFeet/Chains/Chains.js
@@ -62,9 +62,9 @@ function InventoryItemFeetChainsPublishAction(C, Option) {
 }
 
 /**
- * The NPC dialog is for what the NPC says to you when you make a change to their restraints - the dialog lookup is on a 
- * per-NPC basis. You basically put the "AssetName" + OptionName in there to allow individual NPCs to override their default 
- * "GroupName" dialog if for example we ever wanted an NPC to react specifically to having the restraint put on them. 
+ * The NPC dialog is for what the NPC says to you when you make a change to their restraints - the dialog lookup is on a
+ * per-NPC basis. You basically put the "AssetName" + OptionName in there to allow individual NPCs to override their default
+ * "GroupName" dialog if for example we ever wanted an NPC to react specifically to having the restraint put on them.
  * That could be done by adding an "AssetName" entry (or entries) to that NPC's dialog CSV
  * @param {Character} C - The NPC to whom the restraint is applied
  * @param {Option} Option - The chosen option for this extended item

--- a/BondageClub/Screens/Inventory/ItemFeet/FuturisticAnkleCuffs/FuturisticAnkleCuffs.js
+++ b/BondageClub/Screens/Inventory/ItemFeet/FuturisticAnkleCuffs/FuturisticAnkleCuffs.js
@@ -18,7 +18,7 @@ var InventoryItemFeetFuturisticAnkleCuffsOptions = [
 function InventoryItemFeetFuturisticAnkleCuffsLoad() {
 	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
 	if (InventoryItemMouthFuturisticPanelGagValidate(C) !== "") {
-		InventoryItemMouthFuturisticPanelGagLoadAccessDenied()
+		InventoryItemMouthFuturisticPanelGagLoadAccessDenied();
 	} else
 		ExtendedItemLoad(InventoryItemFeetFuturisticAnkleCuffsOptions, "SelectBondagePosition");
 }
@@ -27,7 +27,7 @@ function InventoryItemFeetFuturisticAnkleCuffsLoad() {
 function InventoryItemFeetFuturisticAnkleCuffsDraw() {
 	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
 	if (InventoryItemMouthFuturisticPanelGagValidate(C) !== "") {
-		InventoryItemMouthFuturisticPanelGagDrawAccessDenied()
+		InventoryItemMouthFuturisticPanelGagDrawAccessDenied();
 	} else
 		ExtendedItemDraw(InventoryItemFeetFuturisticAnkleCuffsOptions, "LeatherAnkleCuffsPose");
 }
@@ -36,18 +36,18 @@ function InventoryItemFeetFuturisticAnkleCuffsDraw() {
 function InventoryItemFeetFuturisticAnkleCuffsClick() {
 	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
 	if (InventoryItemMouthFuturisticPanelGagValidate(C) !== "") {
-		InventoryItemMouthFuturisticPanelGagClickAccessDenied()
+		InventoryItemMouthFuturisticPanelGagClickAccessDenied();
 	} else
 		ExtendedItemClick(InventoryItemFeetFuturisticAnkleCuffsOptions);
 }
 
 
 function InventoryItemFeetFuturisticAnkleCuffsExit() {
-	InventoryItemMouthFuturisticPanelGagExitAccessDenied()
+	InventoryItemMouthFuturisticPanelGagExitAccessDenied();
 }
 
 function InventoryItemFeetFuturisticAnkleCuffsValidate(C, Option) {
-	return InventoryItemMouthFuturisticPanelGagValidate(C, Option)
+	return InventoryItemMouthFuturisticPanelGagValidate(C, Option);
 }
 
 function InventoryItemFeetFuturisticAnkleCuffsPublishAction(C, Option) {

--- a/BondageClub/Screens/Inventory/ItemFeet/SturdyLeatherBelts/SturdyLeatherBelts.js
+++ b/BondageClub/Screens/Inventory/ItemFeet/SturdyLeatherBelts/SturdyLeatherBelts.js
@@ -80,9 +80,9 @@ function InventoryItemFeetSturdyLeatherBeltsPublishAction(C, Option) {
 }
 
 /**
- * The NPC dialog is for what the NPC says to you when you make a change to their restraints - the dialog lookup is on a 
- * per-NPC basis. You basically put the "AssetName" + OptionName in there to allow individual NPCs to override their default 
- * "GroupName" dialog if for example we ever wanted an NPC to react specifically to having the restraint put on them. 
+ * The NPC dialog is for what the NPC says to you when you make a change to their restraints - the dialog lookup is on a
+ * per-NPC basis. You basically put the "AssetName" + OptionName in there to allow individual NPCs to override their default
+ * "GroupName" dialog if for example we ever wanted an NPC to react specifically to having the restraint put on them.
  * That could be done by adding an "AssetName" entry (or entries) to that NPC's dialog CSV
  * @param {Character} C - The NPC to whom the restraint is applied
  * @param {Option} Option - The chosen option for this extended item

--- a/BondageClub/Screens/Inventory/ItemHead/InteractiveVRHeadset/InteractiveVRHeadset.js
+++ b/BondageClub/Screens/Inventory/ItemHead/InteractiveVRHeadset/InteractiveVRHeadset.js
@@ -41,7 +41,7 @@ var InventoryItemHeadInteractiveVRHeadsetOptions = [
 function InventoryItemHeadInteractiveVRHeadsetLoad() {
 	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
 	if (InventoryItemMouthFuturisticPanelGagValidate(C) !== "") {
-		InventoryItemMouthFuturisticPanelGagLoadAccessDenied()
+		InventoryItemMouthFuturisticPanelGagLoadAccessDenied();
 	} else
 		ExtendedItemLoad(InventoryItemHeadInteractiveVRHeadsetOptions, "SelectHeadsetType");
 }
@@ -49,7 +49,7 @@ function InventoryItemHeadInteractiveVRHeadsetLoad() {
 function InventoryItemHeadInteractiveVRHeadsetDraw() {
 	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
 	if (InventoryItemMouthFuturisticPanelGagValidate(C) !== "") {
-		InventoryItemMouthFuturisticPanelGagDrawAccessDenied()
+		InventoryItemMouthFuturisticPanelGagDrawAccessDenied();
 	} else
 		ExtendedItemDraw(InventoryItemHeadInteractiveVRHeadsetOptions, "InteractiveVRHeadsetHeadType");
 }
@@ -57,7 +57,7 @@ function InventoryItemHeadInteractiveVRHeadsetDraw() {
 function InventoryItemHeadInteractiveVRHeadsetClick() {
 	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
 	if (InventoryItemMouthFuturisticPanelGagValidate(C) !== "") {
-		InventoryItemMouthFuturisticPanelGagClickAccessDenied()
+		InventoryItemMouthFuturisticPanelGagClickAccessDenied();
 	} else
 		ExtendedItemClick(InventoryItemHeadInteractiveVRHeadsetOptions);
 }
@@ -74,7 +74,7 @@ function InventoryItemHeadInteractiveVRHeadsetPublishAction(C, Option) {
 
 
 function InventoryItemHeadInteractiveVRHeadsetExit() {
-	InventoryItemMouthFuturisticPanelGagExitAccessDenied()
+	InventoryItemMouthFuturisticPanelGagExitAccessDenied();
 }
 
 function InventoryItemHeadInteractiveVRHeadsetValidate(C, Option) {

--- a/BondageClub/Screens/Inventory/ItemHead/InteractiveVisor/InteractiveVisor.js
+++ b/BondageClub/Screens/Inventory/ItemHead/InteractiveVisor/InteractiveVisor.js
@@ -35,7 +35,7 @@ var InventoryItemHeadInteractiveVisorOptions = [
 function InventoryItemHeadInteractiveVisorLoad() {
 	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
 	if (InventoryItemMouthFuturisticPanelGagValidate(C) !== "") {
-		InventoryItemMouthFuturisticPanelGagLoadAccessDenied()
+		InventoryItemMouthFuturisticPanelGagLoadAccessDenied();
 	} else
 		ExtendedItemLoad(InventoryItemHeadInteractiveVisorOptions, "SelectVisorType");
 }
@@ -43,7 +43,7 @@ function InventoryItemHeadInteractiveVisorLoad() {
 function InventoryItemHeadInteractiveVisorDraw() {
 	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
 	if (InventoryItemMouthFuturisticPanelGagValidate(C) !== "") {
-		InventoryItemMouthFuturisticPanelGagDrawAccessDenied()
+		InventoryItemMouthFuturisticPanelGagDrawAccessDenied();
 	} else
 		ExtendedItemDraw(InventoryItemHeadInteractiveVisorOptions, "InteractiveVisorHeadType");
 }
@@ -51,7 +51,7 @@ function InventoryItemHeadInteractiveVisorDraw() {
 function InventoryItemHeadInteractiveVisorClick() {
 	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
 	if (InventoryItemMouthFuturisticPanelGagValidate(C) !== "") {
-		InventoryItemMouthFuturisticPanelGagClickAccessDenied()
+		InventoryItemMouthFuturisticPanelGagClickAccessDenied();
 	} else
 		ExtendedItemClick(InventoryItemHeadInteractiveVisorOptions);
 }
@@ -68,7 +68,7 @@ function InventoryItemHeadInteractiveVisorPublishAction(C, Option) {
 
 
 function InventoryItemHeadInteractiveVisorExit() {
-	InventoryItemMouthFuturisticPanelGagExitAccessDenied()
+	InventoryItemMouthFuturisticPanelGagExitAccessDenied();
 }
 
 function InventoryItemHeadInteractiveVisorValidate(C, Option) {

--- a/BondageClub/Screens/Inventory/ItemLegs/Chains/Chains.js
+++ b/BondageClub/Screens/Inventory/ItemLegs/Chains/Chains.js
@@ -52,9 +52,9 @@ function InventoryItemLegsChainsPublishAction(C, Option) {
 }
 
 /**
- * The NPC dialog is for what the NPC says to you when you make a change to their restraints - the dialog lookup is on a 
- * per-NPC basis. You basically put the "AssetName" + OptionName in there to allow individual NPCs to override their default 
- * "GroupName" dialog if for example we ever wanted an NPC to react specifically to having the restraint put on them. 
+ * The NPC dialog is for what the NPC says to you when you make a change to their restraints - the dialog lookup is on a
+ * per-NPC basis. You basically put the "AssetName" + OptionName in there to allow individual NPCs to override their default
+ * "GroupName" dialog if for example we ever wanted an NPC to react specifically to having the restraint put on them.
  * That could be done by adding an "AssetName" entry (or entries) to that NPC's dialog CSV
  * @param {Character} C - The NPC to whom the restraint is applied
  * @param {Option} Option - The chosen option for this extended item

--- a/BondageClub/Screens/Inventory/ItemLegs/DuctTape/DuctTape.js
+++ b/BondageClub/Screens/Inventory/ItemLegs/DuctTape/DuctTape.js
@@ -56,9 +56,9 @@ function InventoryItemLegsDuctTapePublishAction(C, Option) {
 }
 
 /**
- * The NPC dialog is for what the NPC says to you when you make a change to their restraints - the dialog lookup is on a 
- * per-NPC basis. You basically put the "AssetName" + OptionName in there to allow individual NPCs to override their default 
- * "GroupName" dialog if for example we ever wanted an NPC to react specifically to having the restraint put on them. 
+ * The NPC dialog is for what the NPC says to you when you make a change to their restraints - the dialog lookup is on a
+ * per-NPC basis. You basically put the "AssetName" + OptionName in there to allow individual NPCs to override their default
+ * "GroupName" dialog if for example we ever wanted an NPC to react specifically to having the restraint put on them.
  * That could be done by adding an "AssetName" entry (or entries) to that NPC's dialog CSV
  * @param {Character} C - The NPC to whom the restraint is applied
  * @param {Option} Option - The chosen option for this extended item

--- a/BondageClub/Screens/Inventory/ItemLegs/SturdyLeatherBelts/SturdyLeatherBelts.js
+++ b/BondageClub/Screens/Inventory/ItemLegs/SturdyLeatherBelts/SturdyLeatherBelts.js
@@ -75,9 +75,9 @@ function InventoryItemLegsSturdyLeatherBeltsPublishAction(C, Option) {
 }
 
 /**
- * The NPC dialog is for what the NPC says to you when you make a change to their restraints - the dialog lookup is on a 
- * per-NPC basis. You basically put the "AssetName" + OptionName in there to allow individual NPCs to override their default 
- * "GroupName" dialog if for example we ever wanted an NPC to react specifically to having the restraint put on them. 
+ * The NPC dialog is for what the NPC says to you when you make a change to their restraints - the dialog lookup is on a
+ * per-NPC basis. You basically put the "AssetName" + OptionName in there to allow individual NPCs to override their default
+ * "GroupName" dialog if for example we ever wanted an NPC to react specifically to having the restraint put on them.
  * That could be done by adding an "AssetName" entry (or entries) to that NPC's dialog CSV
  * @param {Character} C - The NPC to whom the restraint is applied
  * @param {Option} Option - The chosen option for this extended item

--- a/BondageClub/Screens/Inventory/ItemMisc/ExclusivePadlock/ExclusivePadlock.js
+++ b/BondageClub/Screens/Inventory/ItemMisc/ExclusivePadlock/ExclusivePadlock.js
@@ -9,7 +9,7 @@ function InventoryItemMiscExclusivePadlockDraw() {
 	DrawAssetPreview(1387, 225, DialogFocusItem.Asset);
 	DrawText(DialogFindPlayer(DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Intro"), 1500, 600, "white", "gray");
 	DrawText(DialogFindPlayer(DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Detail"), 1500, 700, "white", "gray");
-	if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property != null) && (DialogFocusSourceItem.Property.LockMemberNumber != null)) 
+	if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property != null) && (DialogFocusSourceItem.Property.LockMemberNumber != null))
 		DrawText(DialogFindPlayer("LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 800, "white", "gray");
 }
 

--- a/BondageClub/Screens/Inventory/ItemMisc/IntricatePadlock/IntricatePadlock.js
+++ b/BondageClub/Screens/Inventory/ItemMisc/IntricatePadlock/IntricatePadlock.js
@@ -8,7 +8,7 @@ function InventoryItemMiscIntricatePadlockLoad() {
 function InventoryItemMiscIntricatePadlockDraw() {
 	DrawAssetPreview(1387, 225, DialogFocusItem.Asset);
 	DrawText(DialogFindPlayer(DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Intro"), 1500, 600, "white", "gray");
-	if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property != null) && (DialogFocusSourceItem.Property.LockMemberNumber != null)) 
+	if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property != null) && (DialogFocusSourceItem.Property.LockMemberNumber != null))
 		DrawText(DialogFindPlayer("LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 700, "white", "gray");
 }
 

--- a/BondageClub/Screens/Inventory/ItemMisc/MetalPadlock/MetalPadlock.js
+++ b/BondageClub/Screens/Inventory/ItemMisc/MetalPadlock/MetalPadlock.js
@@ -8,7 +8,7 @@ function InventoryItemMiscMetalPadlockLoad() {
 function InventoryItemMiscMetalPadlockDraw() {
 	DrawAssetPreview(1387, 225, DialogFocusItem.Asset);
 	DrawText(DialogFindPlayer(DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Intro"), 1500, 600, "white", "gray");
-	if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property != null) && (DialogFocusSourceItem.Property.LockMemberNumber != null)) 
+	if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property != null) && (DialogFocusSourceItem.Property.LockMemberNumber != null))
 		DrawText(DialogFindPlayer("LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 700, "white", "gray");
 }
 

--- a/BondageClub/Screens/Inventory/ItemMisc/MistressPadlock/MistressPadlock.js
+++ b/BondageClub/Screens/Inventory/ItemMisc/MistressPadlock/MistressPadlock.js
@@ -8,7 +8,7 @@ function InventoryItemMiscMistressPadlockLoad() {
 function InventoryItemMiscMistressPadlockDraw() {
 	DrawAssetPreview(1387, 225, DialogFocusItem.Asset);
 	DrawText(DialogFindPlayer(DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Intro"), 1500, 600, "white", "gray");
-	if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property != null) && (DialogFocusSourceItem.Property.LockMemberNumber != null)) 
+	if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property != null) && (DialogFocusSourceItem.Property.LockMemberNumber != null))
 		DrawText(DialogFindPlayer("LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 700, "white", "gray");
 }
 

--- a/BondageClub/Screens/Inventory/ItemMisc/OwnerPadlock/OwnerPadlock.js
+++ b/BondageClub/Screens/Inventory/ItemMisc/OwnerPadlock/OwnerPadlock.js
@@ -8,7 +8,7 @@ function InventoryItemMiscOwnerPadlockLoad() {
 function InventoryItemMiscOwnerPadlockDraw() {
 	DrawAssetPreview(1387, 225, DialogFocusItem.Asset);
 	DrawText(DialogFindPlayer(DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Intro"), 1500, 600, "white", "gray");
-	if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property != null) && (DialogFocusSourceItem.Property.LockMemberNumber != null)) 
+	if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property != null) && (DialogFocusSourceItem.Property.LockMemberNumber != null))
 		DrawText(DialogFindPlayer("LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 700, "white", "gray");
 	DrawText(DialogFindPlayer(DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Detail"), 1500, 800, "white", "gray");
 }

--- a/BondageClub/Screens/Inventory/ItemMisc/TimerPadlock/TimerPadlock.js
+++ b/BondageClub/Screens/Inventory/ItemMisc/TimerPadlock/TimerPadlock.js
@@ -16,7 +16,7 @@ function InventoryItemMiscTimerPadlockDraw() {
 		DrawText(DialogFindPlayer("LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 700, "white", "gray");
 	if ((Player.MemberNumber == DialogFocusSourceItem.Property.LockMemberNumber) && Player.CanInteract()) {
 		MainCanvas.textAlign = "left";
-		DrawButton(1100, 836, 64, 64, "", "White", (DialogFocusSourceItem.Property.RemoveItem) ? "Icons/Checked.png" : "");	
+		DrawButton(1100, 836, 64, 64, "", "White", (DialogFocusSourceItem.Property.RemoveItem) ? "Icons/Checked.png" : "");
 		DrawText(DialogFindPlayer("RemoveItemWithTimer"), 1200, 868, "white", "gray");
 		MainCanvas.textAlign = "center";
 	} else DrawText(DialogFindPlayer((DialogFocusSourceItem.Property.RemoveItem) ? "WillRemoveItemWithTimer" : "WontRemoveItemWithTimer"), 1500, 868, "white", "gray");

--- a/BondageClub/Screens/Inventory/ItemMouth/FuturisticHarnessPanelGag/FuturisticHarnessPanelGag.js
+++ b/BondageClub/Screens/Inventory/ItemMouth/FuturisticHarnessPanelGag/FuturisticHarnessPanelGag.js
@@ -34,8 +34,8 @@ function InventoryItemMouthFuturisticHarnessPanelNpcDialog(C, Option) {
 
 
 function AssetsItemMouthFuturisticHarnessPanelGagScriptDraw(data) {
-	AssetsItemMouthFuturisticPanelGagScriptDraw(data)
+	AssetsItemMouthFuturisticPanelGagScriptDraw(data);
 }
 function AssetsItemMouthFuturisticHarnessPanelGagBeforeDraw(data) {
-	return AssetsItemMouthFuturisticPanelGagBeforeDraw(data)
+	return AssetsItemMouthFuturisticPanelGagBeforeDraw(data);
 }

--- a/BondageClub/Screens/Inventory/ItemMouth/MilkBottle/MilkBottle.js
+++ b/BondageClub/Screens/Inventory/ItemMouth/MilkBottle/MilkBottle.js
@@ -12,7 +12,7 @@ var InventoryItemMouthMilkBottleOptions = [
 	{
 		Name: "Chug",
 		Property: { Type: "Chug" },
-	},	
+	},
 ];
 
 // Loads the item extension properties

--- a/BondageClub/Screens/Inventory/ItemMouth2/ClothGag/ClothGag.js
+++ b/BondageClub/Screens/Inventory/ItemMouth2/ClothGag/ClothGag.js
@@ -1,6 +1,6 @@
 "use strict";
 function InventoryItemMouth2ClothGagLoad() { InventoryItemMouthClothGagLoad(); }
 function InventoryItemMouth2ClothGagDraw() { InventoryItemMouthClothGagDraw(); }
-function InventoryItemMouth2ClothGagClick() { InventoryItemMouthClothGagClick(); } 
+function InventoryItemMouth2ClothGagClick() { InventoryItemMouthClothGagClick(); }
 function InventoryItemMouth2ClothGagPublishAction(C, Option) { InventoryItemMouthClothGagPublishAction(C, Option); }
-function InventoryItemMouth2ClothGagNpcDialog(C, Option) { InventoryItemMouthClothGagNpcDialog(C, Option); } 
+function InventoryItemMouth2ClothGagNpcDialog(C, Option) { InventoryItemMouthClothGagNpcDialog(C, Option); }

--- a/BondageClub/Screens/Inventory/ItemMouth3/ClothGag/ClothGag.js
+++ b/BondageClub/Screens/Inventory/ItemMouth3/ClothGag/ClothGag.js
@@ -1,6 +1,6 @@
 "use strict";
 function InventoryItemMouth3ClothGagLoad() { InventoryItemMouthClothGagLoad(); }
 function InventoryItemMouth3ClothGagDraw() { InventoryItemMouthClothGagDraw(); }
-function InventoryItemMouth3ClothGagClick() { InventoryItemMouthClothGagClick(); } 
+function InventoryItemMouth3ClothGagClick() { InventoryItemMouthClothGagClick(); }
 function InventoryItemMouth3ClothGagPublishAction(C, Option) { InventoryItemMouthClothGagPublishAction(C, Option); }
-function InventoryItemMouth3ClothGagNpcDialog(C, Option) { InventoryItemMouthClothGagNpcDialog(C, Option); } 
+function InventoryItemMouth3ClothGagNpcDialog(C, Option) { InventoryItemMouthClothGagNpcDialog(C, Option); }

--- a/BondageClub/Screens/Inventory/ItemNeck/SlaveCollar/SlaveCollar.js
+++ b/BondageClub/Screens/Inventory/ItemNeck/SlaveCollar/SlaveCollar.js
@@ -1,4 +1,4 @@
-"use strict"
+"use strict";
 var InventoryItemNeckSlaveCollarColorMode = false;
 var InventoryItemNeckSlaveCollarColor = "Default";
 var InventoryItemNeckSlaveCollarOffset = 0;
@@ -114,7 +114,7 @@ function InventoryItemNeckSlaveCollarDraw() {
 
             // In color picking mode, we allow the user to change the collar color
             ElementPosition("InputColor", 1450, 65, 300);
-            ColorPickerDraw(1300, 145, 675, 830, document.getElementById("InputColor"), function (Color) { DialogChangeItemColor(C, Color) });
+            ColorPickerDraw(1300, 145, 675, 830, document.getElementById("InputColor"), function (Color) { DialogChangeItemColor(C, Color); });
             DrawButton(1665, 25, 90, 90, "", "White", "Icons/ColorSelect.png");
             DrawButton(1775, 25, 90, 90, "", "White", "Icons/ColorCancel.png");
 
@@ -180,7 +180,7 @@ function InventoryItemNeckSlaveCollarClick() {
             }
 
         } else {
-			
+
 			// In regular mode, the owner can select the collar model and change the offset to get the next 8 models
             if ((MouseX >= 1665) && (MouseX <= 1755) && (MouseY >= 25) && (MouseY <= 110)) {
 				InventoryItemNeckSlaveCollarOffset = InventoryItemNeckSlaveCollarOffset + 8;

--- a/BondageClub/Screens/Inventory/ItemNeckAccessories/CustomCollarTag.js/CustomCollarTag.js
+++ b/BondageClub/Screens/Inventory/ItemNeckAccessories/CustomCollarTag.js/CustomCollarTag.js
@@ -4,7 +4,7 @@ var InventoryItemNeckAccessoriesCustomCollarTagAllowedChars = /^[a-zA-Z0-9 ~!]*$
 function InventoryItemNeckAccessoriesCustomCollarTagLoad() {
     var C = CharacterGetCurrent();
 	var MustRefresh = false;
-	
+
 	if (DialogFocusItem.Property == null) DialogFocusItem.Property = {};
 	if (DialogFocusItem.Property.Text == null) {
 		DialogFocusItem.Property.Text = "Tag";
@@ -14,7 +14,7 @@ function InventoryItemNeckAccessoriesCustomCollarTagLoad() {
 		CharacterRefresh(C);
 		ChatRoomCharacterItemUpdate(C, DialogFocusItem.Asset.Group.Name);
 	}
-	
+
 	// Only create the inputs if the item isn't locked
 	if (!InventoryItemHasEffect(DialogFocusItem, "Lock", true)) {
 		ElementCreateInput("TagText", "text", DialogFocusItem.Property.Text, "9");
@@ -37,7 +37,7 @@ function InventoryItemNeckAccessoriesCustomCollarTagDraw() {
 
 // Catches the item extension clicks
 function InventoryItemNeckAccessoriesCustomCollarTagClick() {
-	
+
 	if (!InventoryItemHasEffect(DialogFocusItem, "Lock", true)) {
 		// Change values if they are different and the tag is not locked
 		if ((MouseX >= 1500) && (MouseX <= 1850)) {
@@ -63,7 +63,7 @@ function InventoryItemNeckAccessoriesCustomCollarTagExit() {
 }
 
 // When the tag is changed
-function InventoryItemNeckAccessoriesCustomCollarTagChange() { 
+function InventoryItemNeckAccessoriesCustomCollarTagChange() {
     var C = CharacterGetCurrent();
     CharacterRefresh(C);
     if (CurrentScreen == "ChatRoom") {

--- a/BondageClub/Screens/Inventory/ItemNeckAccessories/ElectronicTag/ElectronicTag.js
+++ b/BondageClub/Screens/Inventory/ItemNeckAccessories/ElectronicTag/ElectronicTag.js
@@ -3,7 +3,7 @@
 function InventoryItemNeckAccessoriesElectronicTagLoad() {
     var C = CharacterGetCurrent();
 	var MustRefresh = false;
-	
+
 	if (DialogFocusItem.Property == null) DialogFocusItem.Property = {};
 	if (DialogFocusItem.Property.Text == null) {
 		DialogFocusItem.Property.Text = "Tag";
@@ -13,7 +13,7 @@ function InventoryItemNeckAccessoriesElectronicTagLoad() {
 		CharacterRefresh(C);
 		ChatRoomCharacterItemUpdate(C, DialogFocusItem.Asset.Group.Name);
 	}
-	
+
 	// Only create the inputs if the item isn't locked
 	if (!InventoryItemHasEffect(DialogFocusItem, "Lock", true)) {
 		ElementCreateInput("TagText", "text", DialogFocusItem.Property.Text, "9");
@@ -37,7 +37,7 @@ function InventoryItemNeckAccessoriesElectronicTagDraw() {
 
 // Catches the item extension clicks
 function InventoryItemNeckAccessoriesElectronicTagClick() {
-	
+
 	if (!InventoryItemHasEffect(DialogFocusItem, "Lock", true)) {
 		// Change values if they are different and the tag is not locked
 		if ((MouseX >= 1500) && (MouseX <= 1850)) {
@@ -63,7 +63,7 @@ function InventoryItemNeckAccessoriesElectronicTagExit() {
 }
 
 // When the tag is changed
-function InventoryItemNeckAccessoriesElectronicTagChange() { 
+function InventoryItemNeckAccessoriesElectronicTagChange() {
     var C = CharacterGetCurrent();
     CharacterRefresh(C);
     if (CurrentScreen == "ChatRoom") {

--- a/BondageClub/Screens/Inventory/ItemNipples/PlateClamps/PlateClamps.js
+++ b/BondageClub/Screens/Inventory/ItemNipples/PlateClamps/PlateClamps.js
@@ -13,7 +13,7 @@ var InventoryItemNipplesPlateClampsOptions = [
 			Type: "Tight"
 		},
 	}
-]
+];
 
 /**
  * Loads the item extension properties

--- a/BondageClub/Screens/Inventory/ItemNipplesPiercings/RoundPiercing/RoundPiercing.js
+++ b/BondageClub/Screens/Inventory/ItemNipplesPiercings/RoundPiercing/RoundPiercing.js
@@ -44,7 +44,7 @@ var InventoryItemNipplesPiercingsRoundPiercingOptions = [
 			Block: ["ItemNeck"],
 		},
 	},
-]
+];
 
 /**
  * Loads the item extension properties
@@ -87,9 +87,9 @@ function InventoryItemNipplesPiercingsRoundPiercingPublishAction(C, Option, Prev
 }
 
 /**
- * The NPC dialog is for what the NPC says to you when you make a change to their restraints - the dialog lookup is on a 
- * per-NPC basis. You basically put the "AssetName" + OptionName in there to allow individual NPCs to override their default 
- * "GroupName" dialog if for example we ever wanted an NPC to react specifically to having the restraint put on them. 
+ * The NPC dialog is for what the NPC says to you when you make a change to their restraints - the dialog lookup is on a
+ * per-NPC basis. You basically put the "AssetName" + OptionName in there to allow individual NPCs to override their default
+ * "GroupName" dialog if for example we ever wanted an NPC to react specifically to having the restraint put on them.
  * That could be done by adding an "AssetName" entry (or entries) to that NPC's dialog CSV
  * @param {Character} C - The NPC to whom the restraint is applied
  * @param {Option} Option - The chosen option for this extended item

--- a/BondageClub/Screens/Inventory/ItemNose/NoseRing/NoseRing.js
+++ b/BondageClub/Screens/Inventory/ItemNose/NoseRing/NoseRing.js
@@ -31,9 +31,9 @@ var InventoryItemNoseNoseRingOptions = [
 			Type: "Leash",
 			Effect: ["Leash"],
 			SetPose: [],
-		}, 
+		},
 	},
-]
+];
 
 /**
  * Loads the item extension properties

--- a/BondageClub/Screens/Inventory/ItemPelvis/MetalChastityBelt/MetalChastityBelt.js
+++ b/BondageClub/Screens/Inventory/ItemPelvis/MetalChastityBelt/MetalChastityBelt.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var InventoryItemPelvisMetalChastityBeltOptions = [	
+var InventoryItemPelvisMetalChastityBeltOptions = [
 	{
 		Name: "OpenBack",
 		Property: {
@@ -72,9 +72,9 @@ function InventoryItemPelvisMetalChastityBeltValidate(C) {
 }
 
 /**
- * The NPC dialog is for what the NPC says to you when you make a change to their restraints - the dialog lookup is on a 
- * per-NPC basis. You basically put the "AssetName" + OptionName in there to allow individual NPCs to override their default 
- * "GroupName" dialog if for example we ever wanted an NPC to react specifically to having the restraint put on them. 
+ * The NPC dialog is for what the NPC says to you when you make a change to their restraints - the dialog lookup is on a
+ * per-NPC basis. You basically put the "AssetName" + OptionName in there to allow individual NPCs to override their default
+ * "GroupName" dialog if for example we ever wanted an NPC to react specifically to having the restraint put on them.
  * That could be done by adding an "AssetName" entry (or entries) to that NPC's dialog CSV
  * @param {Character} C - The NPC to whom the restraint is applied
  * @param {Option} Option - The chosen option for this extended item

--- a/BondageClub/Screens/Inventory/ItemVulva/ClitAndDildoVibratorbelt/ClitAndDildoVibratorbelt.js
+++ b/BondageClub/Screens/Inventory/ItemVulva/ClitAndDildoVibratorbelt/ClitAndDildoVibratorbelt.js
@@ -77,7 +77,7 @@ function InventoryItemVulvaClitAndDildoVibratorbeltSetIntensity(Modifier) {
 		if (DialogFocusItem.Property.Effect == null) DialogFocusItem.Property.Effect = [];
 		DialogFocusItem.Property.Effect.push("Lock");
 	}
-	
+
 	CharacterLoadEffect(C);
 	if (C.ID == 0) ServerPlayerAppearanceSync();
 

--- a/BondageClub/Screens/Inventory/ItemVulvaPiercings/ClitRing/ClitRing.js
+++ b/BondageClub/Screens/Inventory/ItemVulvaPiercings/ClitRing/ClitRing.js
@@ -15,9 +15,9 @@ var InventoryItemVulvaPiercingsClitRingOptions = [
 			Type: "Leash",
 			Effect: ["Leash"],
 			SetPose: [],
-		}, 
+		},
 	},
-]
+];
 
 /**
  * Loads the item extension properties


### PR DESCRIPTION
This PR has no functional effect, it only:
- Removes spaces and tabs on end of lines, where they have no effect (trailing whitespace)
- Add semicolons to where they should be

To keep this cleanup small, this part only focuses on files in `Screens/Inventory/` and only on files with at most 5 edits each