### PR TITLE
Cleanup: Scripts formatting (Part 8 - `Screens/Inventory/*` - Futuristic items)

### DIFF
--- a/BondageClub/Screens/Inventory/ItemArms/FuturisticCuffs/FuturisticCuffs.js
+++ b/BondageClub/Screens/Inventory/ItemArms/FuturisticCuffs/FuturisticCuffs.js
@@ -41,7 +41,7 @@ var InventoryItemArmsFuturisticCuffsOptions = [
 			SelfUnlock: false,
 		},
 	}
-]
+];
 
 /**
  * Loads the item extension properties
@@ -50,7 +50,7 @@ var InventoryItemArmsFuturisticCuffsOptions = [
 function InventoryItemArmsFuturisticCuffsLoad() {
 	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
 	if (InventoryItemMouthFuturisticPanelGagValidate(C) !== "") {
-		InventoryItemMouthFuturisticPanelGagLoadAccessDenied()
+		InventoryItemMouthFuturisticPanelGagLoadAccessDenied();
 	} else
 		ExtendedItemLoad(InventoryItemArmsFuturisticCuffsOptions, "SelectBondagePosition");
 }
@@ -62,11 +62,11 @@ function InventoryItemArmsFuturisticCuffsLoad() {
 function InventoryItemArmsFuturisticCuffsDraw() {
 	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
 	if (InventoryItemMouthFuturisticPanelGagValidate(C) !== "") {
-		InventoryItemMouthFuturisticPanelGagDrawAccessDenied()
+		InventoryItemMouthFuturisticPanelGagDrawAccessDenied();
 	} else
 		ExtendedItemDraw(InventoryItemArmsFuturisticCuffsOptions, "LeatherCuffsPose");
 }
-	
+
 /**
  * Catches the item extension clicks
  * @returns {void} - Nothing
@@ -74,7 +74,7 @@ function InventoryItemArmsFuturisticCuffsDraw() {
 function InventoryItemArmsFuturisticCuffsClick() {
 	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
 	if (InventoryItemMouthFuturisticPanelGagValidate(C) !== "") {
-		InventoryItemMouthFuturisticPanelGagClickAccessDenied()
+		InventoryItemMouthFuturisticPanelGagClickAccessDenied();
 	} else
 		ExtendedItemClick(InventoryItemArmsFuturisticCuffsOptions);
 }
@@ -82,11 +82,11 @@ function InventoryItemArmsFuturisticCuffsClick() {
 
 
 function InventoryItemArmsFuturisticCuffsExit() {
-	InventoryItemMouthFuturisticPanelGagExitAccessDenied()
+	InventoryItemMouthFuturisticPanelGagExitAccessDenied();
 }
 
 function InventoryItemArmsFuturisticCuffsValidate(C, Option) {
-	return InventoryItemMouthFuturisticPanelGagValidate(C, Option)
+	return InventoryItemMouthFuturisticPanelGagValidate(C, Option);
 }
 
 
@@ -107,9 +107,9 @@ function InventoryItemArmsFuturisticCuffsPublishAction(C, Option, PreviousOption
 }
 
 /**
- * The NPC dialog is for what the NPC says to you when you make a change to their restraints - the dialog lookup is on a 
- * per-NPC basis. You basically put the "AssetName" + OptionName in there to allow individual NPCs to override their default 
- * "GroupName" dialog if for example we ever wanted an NPC to react specifically to having the restraint put on them. 
+ * The NPC dialog is for what the NPC says to you when you make a change to their restraints - the dialog lookup is on a
+ * per-NPC basis. You basically put the "AssetName" + OptionName in there to allow individual NPCs to override their default
+ * "GroupName" dialog if for example we ever wanted an NPC to react specifically to having the restraint put on them.
  * That could be done by adding an "AssetName" entry (or entries) to that NPC's dialog CSV
  * @param {Character} C - The NPC to whom the restraint is applied
  * @param {Option} Option - The chosen option for this extended item

--- a/BondageClub/Screens/Inventory/ItemBoots/FuturisticHeels/FuturisticHeels.js
+++ b/BondageClub/Screens/Inventory/ItemBoots/FuturisticHeels/FuturisticHeels.js
@@ -9,12 +9,12 @@ var InventoryItemBootsFuturisticHeelsOptions = [
 		Name: "Heel",
 		Property: { Type: "Heel", HeightModifier: 16 },
 	},
-]
+];
 
 function InventoryItemBootsFuturisticHeelsLoad() {
 	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
 	if (InventoryItemMouthFuturisticPanelGagValidate(C) !== "") {
-		InventoryItemMouthFuturisticPanelGagLoadAccessDenied()
+		InventoryItemMouthFuturisticPanelGagLoadAccessDenied();
 	} else
 		ExtendedItemLoad(InventoryItemBootsFuturisticHeelsOptions, "FuturisticHeelsType");
 }
@@ -22,23 +22,23 @@ function InventoryItemBootsFuturisticHeelsLoad() {
 function InventoryItemBootsFuturisticHeelsDraw() {
 	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
 	if (InventoryItemMouthFuturisticPanelGagValidate(C) !== "") {
-		InventoryItemMouthFuturisticPanelGagDrawAccessDenied()
+		InventoryItemMouthFuturisticPanelGagDrawAccessDenied();
 	} else
 		ExtendedItemDraw(InventoryItemBootsFuturisticHeelsOptions, "FuturisticHeelsType");
-	
+
 }
 
 function InventoryItemBootsFuturisticHeelsClick() {
 	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
 	if (InventoryItemMouthFuturisticPanelGagValidate(C) !== "") {
-		InventoryItemMouthFuturisticPanelGagClickAccessDenied()
+		InventoryItemMouthFuturisticPanelGagClickAccessDenied();
 	} else {
 		ExtendedItemClick(InventoryItemBootsFuturisticHeelsOptions);
 	}
 }
 
 function InventoryItemBootsFuturisticHeelsExit() {
-	InventoryItemMouthFuturisticPanelGagExitAccessDenied()
+	InventoryItemMouthFuturisticPanelGagExitAccessDenied();
 }
 
 function InventoryItemBootsFuturisticHeelsPublishAction(C, Option) {
@@ -50,7 +50,7 @@ function InventoryItemBootsFuturisticHeelsPublishAction(C, Option) {
 	ChatRoomPublishCustomAction(msg, true, Dictionary);
 }
 
-function InventoryItemBootsFuturisticHeelsValidate(C) { 
+function InventoryItemBootsFuturisticHeelsValidate(C) {
 	return InventoryItemMouthFuturisticPanelGagValidate(C, Option); // All futuristic items refer to the gag
 }
 

--- a/BondageClub/Screens/Inventory/ItemBreast/FuturisticBra/FuturisticBra.js
+++ b/BondageClub/Screens/Inventory/ItemBreast/FuturisticBra/FuturisticBra.js
@@ -1,9 +1,9 @@
 "use strict";
 
-var small_yoffset = -5
-var normal_yoffset = 0
-var large_yoffset = 4
-var xlarge_yoffset = 7
+var small_yoffset = -5;
+var normal_yoffset = 0;
+var large_yoffset = 4;
+var xlarge_yoffset = 7;
 
 var InventoryItemBreastFuturisticBraOptions = [
 	{
@@ -26,38 +26,38 @@ function InventoryItemBreastFuturisticBraLoad() {
 	if (DialogFocusItem.Property == null) DialogFocusItem.Property = { HeartRate: 0, HeartIcon: false };
 	if (DialogFocusItem.Property.HeartRate == null) DialogFocusItem.Property.HeartRate = 0;
 	if (DialogFocusItem.Property.HeartIcon == null) DialogFocusItem.Property.HeartIcon = false;
-	
+
 }
 
 function InventoryItemBreastFuturisticBraUpdate(C) {
-	var current_bpm = 65
-	var current_breathing = "Low"
-	var current_temp = 37
-	
-	
-	
+	var current_bpm = 65;
+	var current_breathing = "Low";
+	var current_temp = 37;
+
+
+
 	if (C.MemberNumber) {
-		current_bpm += C.MemberNumber % 20 // 'Pseudo random baseline'
+		current_bpm += C.MemberNumber % 20; // 'Pseudo random baseline'
 	}
-	
+
 	if (C.ArousalSettings && C.ArousalSettings.Progress > 0) {
-		var Progress = C.ArousalSettings.Progress
-		current_bpm += Math.floor(Progress*0.60)
-		current_temp += Math.floor(Progress*0.1)/10
+		var Progress = C.ArousalSettings.Progress;
+		current_bpm += Math.floor(Progress*0.60);
+		current_temp += Math.floor(Progress*0.1)/10;
 		if ((C.ArousalSettings.OrgasmStage && C.ArousalSettings.OrgasmStage > 0) || (C.ArousalSettings.ProgressTimer && C.ArousalSettings.ProgressTimer > 1)) {
-			current_breathing = "Action"
-			current_bpm += 10
-			current_temp += 0.5
+			current_breathing = "Action";
+			current_bpm += 10;
+			current_temp += 0.5;
 		} else if (C.ArousalSettings.Progress > 10) {
 			if (C.ArousalSettings.Progress > 90) {
-				current_breathing = "High"
+				current_breathing = "High";
 			} else {
-				current_breathing = "Med"
+				current_breathing = "Med";
 			}
 		}
-		
+
 	}
-	return {bpm: current_bpm, breathing: current_breathing, temp: current_temp}
+	return {bpm: current_bpm, breathing: current_breathing, temp: current_temp};
 }
 
 // Draw the item extension screen
@@ -65,19 +65,19 @@ function InventoryItemBreastFuturisticBraDraw() {
 	DrawAssetPreview(1387, 225, DialogFocusItem.Asset);
 
 	var C = CharacterGetCurrent();
-	
-	var update = InventoryItemBreastFuturisticBraUpdate(C)
-	var current_bpm = update.bpm
-	var current_breathing = update.breathing
-	var current_temp = update.temp
+
+	var update = InventoryItemBreastFuturisticBraUpdate(C);
+	var current_bpm = update.bpm;
+	var current_breathing = update.breathing;
+	var current_temp = update.temp;
 
 	DrawText(DialogFindPlayer("FuturisticBraPlayerDesc") + " " + C.MemberNumber, 1500, 600, "White", "Gray");
 	DrawText(DialogFindPlayer("FuturisticBraPlayerHeartRate") + " " + current_bpm + " " + DialogFindPlayer("FuturisticBraPlayerHeartRateBPM"), 1500, 680, "White", "Gray");
 	DrawText(DialogFindPlayer("FuturisticBraPlayerTemp") + " " + current_temp + DialogFindPlayer("FuturisticBraPlayerTempC"), 1500, 730, "White", "Gray");
 	DrawText(DialogFindPlayer("FuturisticBraPlayerBreathing") + " " + DialogFindPlayer("FuturisticBraPlayerBreathing" + current_breathing), 1500, 780, "White", "Gray");
 	DrawText(DialogFindPlayer("FuturisticBraPlayerTracking"), 1500, 830, "White", "Gray");
-	
-	// If the player can modify 
+
+	// If the player can modify
 	if (InventoryItemMouthFuturisticPanelGagValidate(C) == "") {
 		if (DialogFocusItem.Property.Type == "Solid") {
 			DrawButton(1250, 900, 200, 64, DialogFindPlayer("FuturisticBraPlayerShow"), "White", "");
@@ -85,8 +85,8 @@ function InventoryItemBreastFuturisticBraDraw() {
 			DrawButton(1550, 900, 200, 64, DialogFindPlayer("FuturisticBraPlayerSolid"), "White", "");
 		}
 	}
-	
-	
+
+
 	/*
 	DrawText(DialogFindPlayer("Intensity" + DialogFocusItem.Property.Intensity.toString()).replace("Item", DialogFocusItem.Asset.Description), 1500, 600, "White", "Gray");
 	if (DialogFocusItem.Property.Intensity > 0) DrawButton(1200, 650, 200, 55, DialogFindPlayer("Low"), "White");
@@ -100,28 +100,28 @@ function InventoryItemBreastFuturisticBraDraw() {
 // Catches the item extension clicks
 function InventoryItemBreastFuturisticBraClick() {
 	if (MouseIn(1885, 25, 90, 90)) DialogFocusItem = null;
-	
+
 	if (MouseIn(1250, 900, 500, 64)) {
 		var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
-		
-		// If the player can modify 
+
+		// If the player can modify
 		if (InventoryItemMouthFuturisticPanelGagValidate(C) == "") {
-			
+
 			if (DialogFocusItem.Property.Type == "Solid" && MouseIn(1250, 900, 500, 64)) {
-				DialogFocusItem.Property.Type = ""
+				DialogFocusItem.Property.Type = "";
 				if (CurrentScreen == "ChatRoom")
-					InventoryItemBreastFuturisticBraPublishAction(C, InventoryItemBreastFuturisticBraOptions[0])
+					InventoryItemBreastFuturisticBraPublishAction(C, InventoryItemBreastFuturisticBraOptions[0]);
 			} else if (MouseIn(1550, 900, 500, 64)) {
-				DialogFocusItem.Property.Type = "Solid"
+				DialogFocusItem.Property.Type = "Solid";
 				if (CurrentScreen == "ChatRoom")
-					InventoryItemBreastFuturisticBraPublishAction(C, InventoryItemBreastFuturisticBraOptions[1])
+					InventoryItemBreastFuturisticBraPublishAction(C, InventoryItemBreastFuturisticBraOptions[1]);
 			}
-			
+
 			CharacterRefresh(C, true);
 			ChatRoomCharacterUpdate(C);
 		}
 	}
-	
+
 }
 
 function InventoryItemBreastFuturisticBraPublishAction(C, Option) {
@@ -140,7 +140,7 @@ function InventoryItemBreastFuturisticBraPublishAction(C, Option) {
 
 // Sets the shock collar intensity
 function InventoryItemBreastFuturisticBraSetIntensity(Modifier) {
-	
+
 	// Gets the current item and character
 	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
 	if ((CurrentScreen == "ChatRoom") || (DialogFocusItem == null)) {
@@ -158,11 +158,11 @@ function InventoryItemBreastFuturisticBraSetIntensity(Modifier) {
 	}
 	else
 		DialogLeave();
-		
+
 }
 
 // Trigger a shock from the dialog menu
-function InventoryItemBreastFuturisticBraTrigger() { 
+function InventoryItemBreastFuturisticBraTrigger() {
 	// Gets the current item and character
 	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
 	if ((CurrentScreen == "ChatRoom") || (DialogFocusItem == null)) {
@@ -179,14 +179,14 @@ function InventoryItemBreastFuturisticBraTrigger() {
 	Dictionary.push({ Tag: "ActivityGroup", Text: DialogFocusItem.Asset.Group.Name });
 	Dictionary.push({ AssetName: DialogFocusItem.Asset.Name });
 	Dictionary.push({ AssetGroupName: DialogFocusItem.Asset.Group.Name });
-		
+
 	ChatRoomPublishCustomAction("TriggerShock" + DialogFocusItem.Property.Intensity, true, Dictionary);
-		
+
 	if (C.ID == Player.ID) {
 		// The Player shocks herself
 		ActivityArousalItem(C, C, DialogFocusItem.Asset);
 	}
-	
+
     CharacterSetFacialExpression(C, "Eyebrows", "Soft", 10);
     CharacterSetFacialExpression(C, "Blush", "Soft", 15);
     CharacterSetFacialExpression(C, "Eyes", "Closed", 5);
@@ -194,7 +194,7 @@ function InventoryItemBreastFuturisticBraTrigger() {
 
 
 
-function InventoryItemBreastFuturisticBraDynamicAudio(data) { 
+function InventoryItemBreastFuturisticBraDynamicAudio(data) {
 	var Modifier = parseInt(data.Content.substr(data.Content.length - 1));
 	if (isNaN(Modifier)) Modifier = 0;
 	return ["Shocks", Modifier * 3];
@@ -204,14 +204,14 @@ function InventoryItemBreastFuturisticBraDynamicAudio(data) {
 // Drawing function for the text on the bra
 function AssetsItemBreastFuturisticBraAfterDraw({
     C, A, X, Y, Property, drawCanvas, drawCanvasBlink, AlphaMasks, L, G, Color
-}) { 
+}) {
 	if (L === "_Text" && Property && Property.Type != "Solid") {
-		
-		var offset = normal_yoffset
-		if (G == "_Large") offset = large_yoffset
-		if (G == "_XLarge") offset = xlarge_yoffset
-		if (G == "_Small") offset = small_yoffset
-		
+
+		var offset = normal_yoffset;
+		if (G == "_Large") offset = large_yoffset;
+		if (G == "_XLarge") offset = xlarge_yoffset;
+		if (G == "_Small") offset = small_yoffset;
+
 		// We set up a canvas
 		const Height = 50;
 		const Width = 55;
@@ -231,10 +231,10 @@ function AssetsItemBreastFuturisticBraAfterDraw({
 		context.fillStyle = Color;
 		context.textAlign = "center";
 		context.fillText((Property && Property.HeartRate) ? Property.HeartRate : "--", Width / 2, Width / 2, Width);
-    
+
 		// We print the canvas to the character based on the asset position
 		drawCanvas(TempCanvas, X + 47, Y + 103.5 + offset, AlphaMasks);
-		
+
 		drawCanvasBlink(TempCanvas, X + 47, Y + 103.5 + offset, AlphaMasks);
 	}
 }
@@ -246,11 +246,11 @@ function AssetsItemBreastFuturisticBraScriptDraw(data) {
 	if (typeof persistentData.UpdateTime !== "number") persistentData.UpdateTime = CommonTime() + 4000;
 
 	if (persistentData.UpdateTime < CommonTime()) {
-		var update = InventoryItemBreastFuturisticBraUpdate(data.C)
+		var update = InventoryItemBreastFuturisticBraUpdate(data.C);
 		property.HeartRate = update.bpm;
 		if (property.Type != "Solid")
 			property.Type = (update.breathing == "Action") ? "Heart" : null;
-		
+
 		var timeToNextRefresh = 1100;
 		persistentData.UpdateTime = CommonTime() + timeToNextRefresh;
 		AnimationRequestRefreshRate(data.C, 5000 - timeToNextRefresh);

--- a/BondageClub/Screens/Inventory/ItemBreast/FuturisticBra2/FuturisticBra2.js
+++ b/BondageClub/Screens/Inventory/ItemBreast/FuturisticBra2/FuturisticBra2.js
@@ -9,12 +9,12 @@ var InventoryItemBreastFuturisticBra2Options = [
 		Name: "NoDisplay",
 		Property: { Type: "NoDisplay" },
 	},
-]
+];
 
 function InventoryItemBreastFuturisticBra2Load() {
 	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
 	if (InventoryItemMouthFuturisticPanelGagValidate(C) !== "") {
-		InventoryItemMouthFuturisticPanelGagLoadAccessDenied()
+		InventoryItemMouthFuturisticPanelGagLoadAccessDenied();
 	} else
 		ExtendedItemLoad(InventoryItemBreastFuturisticBra2Options, "FuturisticBra2Type");
 }
@@ -22,23 +22,23 @@ function InventoryItemBreastFuturisticBra2Load() {
 function InventoryItemBreastFuturisticBra2Draw() {
 	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
 	if (InventoryItemMouthFuturisticPanelGagValidate(C) !== "") {
-		InventoryItemMouthFuturisticPanelGagDrawAccessDenied()
+		InventoryItemMouthFuturisticPanelGagDrawAccessDenied();
 	} else
 		ExtendedItemDraw(InventoryItemBreastFuturisticBra2Options, "FuturisticBra2Type");
-	
+
 }
 
 function InventoryItemBreastFuturisticBra2Click() {
 	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
 	if (InventoryItemMouthFuturisticPanelGagValidate(C) !== "") {
-		InventoryItemMouthFuturisticPanelGagClickAccessDenied()
+		InventoryItemMouthFuturisticPanelGagClickAccessDenied();
 	} else {
 		ExtendedItemClick(InventoryItemBreastFuturisticBra2Options);
 	}
 }
 
 function InventoryItemBreastFuturisticBra2Exit() {
-	InventoryItemMouthFuturisticPanelGagExitAccessDenied()
+	InventoryItemMouthFuturisticPanelGagExitAccessDenied();
 }
 
 function InventoryItemBreastFuturisticBra2PublishAction(C, Option) {

--- a/BondageClub/Screens/Inventory/ItemHands/FuturisticMittens/FuturisticMittens.js
+++ b/BondageClub/Screens/Inventory/ItemHands/FuturisticMittens/FuturisticMittens.js
@@ -15,7 +15,7 @@ var InventoryItemHandsFuturisticMittensOptions = [
 function InventoryItemHandsFuturisticMittensLoad() {
 	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
 	if (InventoryItemMouthFuturisticPanelGagValidate(C) !== "") {
-		InventoryItemMouthFuturisticPanelGagLoadAccessDenied()
+		InventoryItemMouthFuturisticPanelGagLoadAccessDenied();
 	} else
 	ExtendedItemLoad(InventoryItemHandsFuturisticMittensOptions, "SelectFuturisticMittensType");
 }
@@ -24,7 +24,7 @@ function InventoryItemHandsFuturisticMittensLoad() {
 function InventoryItemHandsFuturisticMittensDraw() {
 	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
 	if (InventoryItemMouthFuturisticPanelGagValidate(C) !== "") {
-		InventoryItemMouthFuturisticPanelGagDrawAccessDenied()
+		InventoryItemMouthFuturisticPanelGagDrawAccessDenied();
 	} else
 		ExtendedItemDraw(InventoryItemHandsFuturisticMittensOptions, "FuturisticMittensType");
 }
@@ -33,17 +33,17 @@ function InventoryItemHandsFuturisticMittensDraw() {
 function InventoryItemHandsFuturisticMittensClick() {
 	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
 	if (InventoryItemMouthFuturisticPanelGagValidate(C) !== "") {
-		InventoryItemMouthFuturisticPanelGagClickAccessDenied()
+		InventoryItemMouthFuturisticPanelGagClickAccessDenied();
 	} else
 		ExtendedItemClick(InventoryItemHandsFuturisticMittensOptions);
 }
 
 function InventoryItemHandsFuturisticMittensExit() {
-	InventoryItemMouthFuturisticPanelGagExitAccessDenied()
+	InventoryItemMouthFuturisticPanelGagExitAccessDenied();
 }
-	
+
 function InventoryItemHandsFuturisticMittensValidate(C, Option) {
-	return InventoryItemMouthFuturisticPanelGagValidate(C, Option)
+	return InventoryItemMouthFuturisticPanelGagValidate(C, Option);
 }
 
 function InventoryItemHandsFuturisticMittensPublishAction(C, Option) {

--- a/BondageClub/Screens/Inventory/ItemMouth/FuturisticHarnessBallGag/FuturisticHarnessBallGag.js
+++ b/BondageClub/Screens/Inventory/ItemMouth/FuturisticHarnessBallGag/FuturisticHarnessBallGag.js
@@ -31,7 +31,7 @@ var InventoryItemMouthFuturisticBallGagOptions = [
 function InventoryItemMouthFuturisticHarnessBallGagLoad() {
 	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
 	if (InventoryItemMouthFuturisticPanelGagValidate(C) !== "") {
-		InventoryItemMouthFuturisticPanelGagLoadAccessDenied()
+		InventoryItemMouthFuturisticPanelGagLoadAccessDenied();
 	} else {
 		ExtendedItemLoad(InventoryItemMouthFuturisticBallGagOptions, "SelectGagType");
 		if (DialogFocusItem.Property == null) DialogFocusItem.Property = { Type: null, Option: InventoryItemMouthFuturisticBallGagOptions[0],
@@ -46,7 +46,7 @@ function InventoryItemMouthFuturisticHarnessBallGagLoad() {
 }
 
 function InventoryItemMouthFuturisticHarnessBallGagExit() {
-	InventoryItemMouthFuturisticPanelGagExit()
+	InventoryItemMouthFuturisticPanelGagExit();
 }
 
 /**
@@ -56,29 +56,29 @@ function InventoryItemMouthFuturisticHarnessBallGagExit() {
 function InventoryItemMouthFuturisticHarnessBallGagDraw() {
 	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
 	if (InventoryItemMouthFuturisticPanelGagValidate(C) !== "") {
-		InventoryItemMouthFuturisticPanelGagDrawAccessDenied()
+		InventoryItemMouthFuturisticPanelGagDrawAccessDenied();
 	} else {
 		DrawAssetPreview(1387, 75, DialogFocusItem.Asset);
 
 		if (DialogFocusItem.Property.AutoPunishUndoTime - CurrentTime > 0)
-			DrawText(DialogFindPlayer("FuturisticPanelGagMouthDeflationTime") + " " + TimerToString(DialogFocusItem.Property.AutoPunishUndoTime - CurrentTime), 1500, 415, "White", "Gray");		
+			DrawText(DialogFindPlayer("FuturisticPanelGagMouthDeflationTime") + " " + TimerToString(DialogFocusItem.Property.AutoPunishUndoTime - CurrentTime), 1500, 415, "White", "Gray");
 
 		var type = "FuturisticPanelGagMouthType" + ((DialogFocusItem.Property.Type != null) ?
 			((DialogFocusItem.Property.Type != "Ball") ? DialogFocusItem.Property.Type : "BallLarge")
-			: "BallGag")
+			: "BallGag");
 		DrawText(DialogFindPlayer("FuturisticPanelGagMouthTypeDesc") + " " +
-			DialogFindPlayer(type), 1350, 475, "White", "Gray");	
+			DialogFindPlayer(type), 1350, 475, "White", "Gray");
 
 		MainCanvas.textAlign = "left";
 		DrawCheckbox(1100, 890, 64, 64, "", DialogFocusItem.Property.ChatMessage, "White");
-		DrawText(DialogFindPlayer("FuturisticPanelGagMouthButtonChatMessage"), 1200, 923, "White", "Gray");	
+		DrawText(DialogFindPlayer("FuturisticPanelGagMouthButtonChatMessage"), 1200, 923, "White", "Gray");
 		MainCanvas.textAlign = "center";
 
-		var autopunish = "Off" 
-		if (DialogFocusItem.Property.AutoPunish == 0) {autopunish = "Off"}
-		else if (DialogFocusItem.Property.AutoPunish == 1) {autopunish = "Low"}
-		else if (DialogFocusItem.Property.AutoPunish == 2) {autopunish = "Medium"}
-		else {autopunish = "Maximum"}
+		var autopunish = "Off";
+		if (DialogFocusItem.Property.AutoPunish == 0) {autopunish = "Off";}
+		else if (DialogFocusItem.Property.AutoPunish == 1) {autopunish = "Low";}
+		else if (DialogFocusItem.Property.AutoPunish == 2) {autopunish = "Medium";}
+		else {autopunish = "Maximum";}
 
 		DrawText(DialogFindPlayer("FuturisticPanelGagMouthButtonAutoPunish") + " " + autopunish, 1350, 683, "White", "Gray");
 		if (DialogFocusItem) {
@@ -91,7 +91,7 @@ function InventoryItemMouthFuturisticHarnessBallGagDraw() {
 			if (DialogFocusItem.Property.AutoPunish != 2) DrawButton(1100, 777, 200, 64, DialogFindPlayer("Medium"), "White", "");
 			if (DialogFocusItem.Property.AutoPunish != 3) DrawButton(1400, 777, 200, 64, DialogFindPlayer("Maximum"), "White", "");
 
-			DrawText(DialogFindPlayer("FuturisticPanelGagMouthDeflationTimeSetting" + DialogFocusItem.Property.AutoPunishUndoTimeSetting), 1775, 475, "White", "Gray");	
+			DrawText(DialogFindPlayer("FuturisticPanelGagMouthDeflationTimeSetting" + DialogFocusItem.Property.AutoPunishUndoTimeSetting), 1775, 475, "White", "Gray");
 			if (DialogFocusItem.Property.AutoPunishUndoTimeSetting != 120000) DrawButton(1675, 500, 200, 64, DialogFindPlayer("FuturisticPanelGagMouthDeflationTimeButton120000"), "White", "");
 			if (DialogFocusItem.Property.AutoPunishUndoTimeSetting != 300000) DrawButton(1675, 570, 200, 64, DialogFindPlayer("FuturisticPanelGagMouthDeflationTimeButton300000"), "White", "");
 			if (DialogFocusItem.Property.AutoPunishUndoTimeSetting != 900000) DrawButton(1675, 640, 200, 64, DialogFindPlayer("FuturisticPanelGagMouthDeflationTimeButton900000"), "White", "");
@@ -112,45 +112,45 @@ function InventoryItemMouthFuturisticHarnessBallGagDraw() {
 function InventoryItemMouthFuturisticHarnessBallGagClick() {
 	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
 	if (InventoryItemMouthFuturisticPanelGagValidate(C) !== "") {
-		InventoryItemMouthFuturisticPanelGagClickAccessDenied()
-	} else {		
-		if (MouseIn(1885, 25, 90, 90)) InventoryItemMouthFuturisticPanelGagExit()
-			
-		else if (MouseIn(1100, 890, 64, 64)) DialogFocusItem.Property.ChatMessage = !DialogFocusItem.Property.ChatMessage
-		
-		
+		InventoryItemMouthFuturisticPanelGagClickAccessDenied();
+	} else {
+		if (MouseIn(1885, 25, 90, 90)) InventoryItemMouthFuturisticPanelGagExit();
+
+		else if (MouseIn(1100, 890, 64, 64)) DialogFocusItem.Property.ChatMessage = !DialogFocusItem.Property.ChatMessage;
+
+
 		else if (DialogFocusItem.Property.Type != null && MouseIn(1250, 500, 200, 64)) {
 			DialogFocusItem.Property.AutoPunishUndoTime = 0;
 			DialogFocusItem.Property.OriginalSetting = "LightBall";
-			ExtendedItemSetType(C, InventoryItemMouthFuturisticBallGagOptions, InventoryItemMouthFuturisticBallGagOptions[0])}
+			ExtendedItemSetType(C, InventoryItemMouthFuturisticBallGagOptions, InventoryItemMouthFuturisticBallGagOptions[0]);}
 		else if (DialogFocusItem.Property.Type != "Ball" && MouseIn(1100, 570, 200, 64)) {
 			DialogFocusItem.Property.AutoPunishUndoTime = 0;
 			DialogFocusItem.Property.OriginalSetting = "Ball";
-			ExtendedItemSetType(C, InventoryItemMouthFuturisticBallGagOptions, InventoryItemMouthFuturisticBallGagOptions[1])}
+			ExtendedItemSetType(C, InventoryItemMouthFuturisticBallGagOptions, InventoryItemMouthFuturisticBallGagOptions[1]);}
 		else if (DialogFocusItem.Property.Type != "Plug" && MouseIn(1400, 570, 200, 64)) {
 			DialogFocusItem.Property.AutoPunishUndoTime = 0;
 			DialogFocusItem.Property.OriginalSetting = "Plug";
-		ExtendedItemSetType(C, InventoryItemMouthFuturisticBallGagOptions, InventoryItemMouthFuturisticBallGagOptions[2])}
-		
-		else if (DialogFocusItem.Property.AutoPunish != 0 && MouseIn(1100, 707, 200, 64)) InventoryItemMouthFuturisticPanelGagSetAutoPunish(C, DialogFocusItem, 0)
-		else if (DialogFocusItem.Property.AutoPunish != 1 && MouseIn(1400, 707, 200, 64)) InventoryItemMouthFuturisticPanelGagSetAutoPunish(C, DialogFocusItem, 1)
-		else if (DialogFocusItem.Property.AutoPunish != 2 && MouseIn(1100, 777, 200, 64)) InventoryItemMouthFuturisticPanelGagSetAutoPunish(C, DialogFocusItem, 2)
-		else if (DialogFocusItem.Property.AutoPunish != 3 && MouseIn(1400, 777, 200, 64)) InventoryItemMouthFuturisticPanelGagSetAutoPunish(C, DialogFocusItem, 3)
-			
-		
-		else if (DialogFocusItem.Property.AutoPunishUndoTimeSetting != 120000 && MouseIn(1675, 500, 200, 64)) InventoryItemMouthFuturisticPanelGagSetAutoPunishTime(C, DialogFocusItem, 120000)
-		else if (DialogFocusItem.Property.AutoPunishUndoTimeSetting != 300000 && MouseIn(1675, 570, 200, 64)) InventoryItemMouthFuturisticPanelGagSetAutoPunishTime(C, DialogFocusItem, 300000)
-		else if (DialogFocusItem.Property.AutoPunishUndoTimeSetting != 900000 && MouseIn(1675, 640, 200, 64)) InventoryItemMouthFuturisticPanelGagSetAutoPunishTime(C, DialogFocusItem, 900000)
-		else if (DialogFocusItem.Property.AutoPunishUndoTimeSetting != 3600000 && MouseIn(1675, 710, 200, 64)) InventoryItemMouthFuturisticPanelGagSetAutoPunishTime(C, DialogFocusItem, 3600000)
-		else if (DialogFocusItem.Property.AutoPunishUndoTimeSetting != 72000000 && MouseIn(1675, 780, 200, 64)) InventoryItemMouthFuturisticPanelGagSetAutoPunishTime(C, DialogFocusItem, 72000000)
-			
+		ExtendedItemSetType(C, InventoryItemMouthFuturisticBallGagOptions, InventoryItemMouthFuturisticBallGagOptions[2]);}
+
+		else if (DialogFocusItem.Property.AutoPunish != 0 && MouseIn(1100, 707, 200, 64)) InventoryItemMouthFuturisticPanelGagSetAutoPunish(C, DialogFocusItem, 0);
+		else if (DialogFocusItem.Property.AutoPunish != 1 && MouseIn(1400, 707, 200, 64)) InventoryItemMouthFuturisticPanelGagSetAutoPunish(C, DialogFocusItem, 1);
+		else if (DialogFocusItem.Property.AutoPunish != 2 && MouseIn(1100, 777, 200, 64)) InventoryItemMouthFuturisticPanelGagSetAutoPunish(C, DialogFocusItem, 2);
+		else if (DialogFocusItem.Property.AutoPunish != 3 && MouseIn(1400, 777, 200, 64)) InventoryItemMouthFuturisticPanelGagSetAutoPunish(C, DialogFocusItem, 3);
+
+
+		else if (DialogFocusItem.Property.AutoPunishUndoTimeSetting != 120000 && MouseIn(1675, 500, 200, 64)) InventoryItemMouthFuturisticPanelGagSetAutoPunishTime(C, DialogFocusItem, 120000);
+		else if (DialogFocusItem.Property.AutoPunishUndoTimeSetting != 300000 && MouseIn(1675, 570, 200, 64)) InventoryItemMouthFuturisticPanelGagSetAutoPunishTime(C, DialogFocusItem, 300000);
+		else if (DialogFocusItem.Property.AutoPunishUndoTimeSetting != 900000 && MouseIn(1675, 640, 200, 64)) InventoryItemMouthFuturisticPanelGagSetAutoPunishTime(C, DialogFocusItem, 900000);
+		else if (DialogFocusItem.Property.AutoPunishUndoTimeSetting != 3600000 && MouseIn(1675, 710, 200, 64)) InventoryItemMouthFuturisticPanelGagSetAutoPunishTime(C, DialogFocusItem, 3600000);
+		else if (DialogFocusItem.Property.AutoPunishUndoTimeSetting != 72000000 && MouseIn(1675, 780, 200, 64)) InventoryItemMouthFuturisticPanelGagSetAutoPunishTime(C, DialogFocusItem, 72000000);
+
 		else if (DialogFocusItem.Property.AutoPunishUndoTimeSetting && MouseIn(1675, 880, 200, 64)) {
-			InventoryItemMouthFuturisticPanelGagTrigger(C, DialogFocusItem, false, InventoryItemMouthFuturisticBallGagOptions)
-			DialogFocusItem.Property.AutoPunishUndoTime = CurrentTime + DialogFocusItem.Property.AutoPunishUndoTimeSetting // Reset the deflation time
+			InventoryItemMouthFuturisticPanelGagTrigger(C, DialogFocusItem, false, InventoryItemMouthFuturisticBallGagOptions);
+			DialogFocusItem.Property.AutoPunishUndoTime = CurrentTime + DialogFocusItem.Property.AutoPunishUndoTimeSetting; // Reset the deflation time
 			CharacterRefresh(C, true); // Does not sync appearance while in the wardrobe
 			ChatRoomCharacterUpdate(C);
 		}
-		
+
 	}
 }
 
@@ -165,16 +165,16 @@ function InventoryItemMouthFuturisticHarnessBallGagValidate(C, Option) {
 
 
 /**
- * The NPC dialog is for what the NPC says to you when you make a change to their restraints - the dialog lookup is on a 
- * per-NPC basis. You basically put the "AssetName" + OptionName in there to allow individual NPCs to override their default 
- * "GroupName" dialog if for example we ever wanted an NPC to react specifically to having the restraint put on them. 
+ * The NPC dialog is for what the NPC says to you when you make a change to their restraints - the dialog lookup is on a
+ * per-NPC basis. You basically put the "AssetName" + OptionName in there to allow individual NPCs to override their default
+ * "GroupName" dialog if for example we ever wanted an NPC to react specifically to having the restraint put on them.
  * That could be done by adding an "AssetName" entry (or entries) to that NPC's dialog CSV
  * @param {Character} C - The NPC to whom the restraint is applied
  * @param {Option} Option - The chosen option for this extended item
  * @returns {void} - Nothing
  */
 function InventoryItemMouthFuturisticHarnessBallGagNpcDialog(C, Option) {
-	InventoryItemMouthFuturisticPanelGagNpcDialog(C, Option)
+	InventoryItemMouthFuturisticPanelGagNpcDialog(C, Option);
 }
 
 // Update data
@@ -187,14 +187,14 @@ function AssetsItemMouthFuturisticHarnessBallGagScriptDraw(data) {
 
 	if (persistentData.UpdateTime < CommonTime() && data.C == Player) {
 		if (CurrentScreen == "ChatRoom") {
-		
-			AssetsItemMouthFuturisticPanelGagScriptUpdatePlayer(data, InventoryItemMouthFuturisticBallGagOptions)
-			
+
+			AssetsItemMouthFuturisticPanelGagScriptUpdatePlayer(data, InventoryItemMouthFuturisticBallGagOptions);
+
 			persistentData.LastMessageLen = (ChatRoomLastMessage) ? ChatRoomLastMessage.length : 0;
 		}
 
-		property.BlinkState = (property.BlinkState + 1) % 2
-		
+		property.BlinkState = (property.BlinkState + 1) % 2;
+
 		var timeToNextRefresh = 3025;
 		persistentData.UpdateTime = CommonTime() + timeToNextRefresh;
 		AnimationRequestRefreshRate(data.C, 5000 - timeToNextRefresh);
@@ -204,6 +204,6 @@ function AssetsItemMouthFuturisticHarnessBallGagScriptDraw(data) {
 
 
 // Drawing function for the blinking light
-function AssetsItemMouthFuturisticHarnessBallGagBeforeDraw(data) { 
-	return AssetsItemMouthFuturisticPanelGagBeforeDraw(data)
+function AssetsItemMouthFuturisticHarnessBallGagBeforeDraw(data) {
+	return AssetsItemMouthFuturisticPanelGagBeforeDraw(data);
 }

--- a/BondageClub/Screens/Inventory/ItemMouth/FuturisticPanelGag/FuturisticPanelGag.js
+++ b/BondageClub/Screens/Inventory/ItemMouth/FuturisticPanelGag/FuturisticPanelGag.js
@@ -40,13 +40,13 @@ var AutoPunishKeywords = [
 "growl",
 "laugh",
 "giggle",
-]
+];
 
 var AutoPunishGagActionFlag = false;
 
 // How to make your item futuristic!
 
-// In the load function, add this before your load function, without changing functions from the 
+// In the load function, add this before your load function, without changing functions from the
 // futuristic panel gag functions. Just make sure your item loads after the panel gag and not before in index.html:
 /*
  	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
@@ -82,8 +82,8 @@ var AutoPunishGagActionFlag = false;
 */
 
 
-var AutoPunishUndoCD = 300000 // Five minutes of being gagged, resetting each time the user does a violation
-var FuturisticAccessDeniedMessage = ""
+var AutoPunishUndoCD = 300000; // Five minutes of being gagged, resetting each time the user does a violation
+var FuturisticAccessDeniedMessage = "";
 
 /**
  * Loads the item extension properties
@@ -92,7 +92,7 @@ var FuturisticAccessDeniedMessage = ""
 function InventoryItemMouthFuturisticPanelGagLoad() {
 	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
 	if (InventoryItemMouthFuturisticPanelGagValidate(C) !== "") {
-		InventoryItemMouthFuturisticPanelGagLoadAccessDenied()
+		InventoryItemMouthFuturisticPanelGagLoadAccessDenied();
 	} else {
 		ExtendedItemLoad(InventoryItemMouthFuturisticPanelGagOptions, "SelectGagType");
 		if (DialogFocusItem.Property == null) DialogFocusItem.Property = { Type: null, Option: InventoryItemMouthFuturisticPanelGagOptions[0],
@@ -111,7 +111,7 @@ function InventoryItemMouthFuturisticPanelGagLoad() {
 function InventoryItemMouthFuturisticPanelGagLoadAccessDenied() {
 	ElementCreateInput("PasswordField", "text", "", "12");
 	if (!FuturisticAccessDeniedMessage)
-		FuturisticAccessDeniedMessage = ""
+		FuturisticAccessDeniedMessage = "";
 }
 
 // Draw the futuristic item ACCESS DENIED screen
@@ -119,44 +119,44 @@ function InventoryItemMouthFuturisticPanelGagDrawAccessDenied() {
 	DrawAssetPreview(1387, 225, DialogFocusItem.Asset);
 
 	DrawText(DialogFindPlayer("FuturisticItemLoginScreen"), 1500, 600, "White", "Gray");
-	
+
 	ElementPosition("PasswordField", 1505, 750, 350);
 	DrawText(DialogFindPlayer("FuturisticItemPassword"), 1500, 700, "White", "Gray");
 	DrawButton(1400, 800, 200, 64, DialogFindPlayer("FuturisticItemLogIn"), "White", "");
-	
+
 	if (FuturisticAccessDeniedMessage && FuturisticAccessDeniedMessage != "") DrawText(FuturisticAccessDeniedMessage, 1500, 963, "Red", "Black");
-	
+
 }
 
 // Click the futuristic item ACCESS DENIED screen
 function InventoryItemMouthFuturisticPanelGagClickAccessDenied() {
-	if (MouseIn(1885, 25, 90, 90)) InventoryItemMouthFuturisticPanelGagExit()
-		
+	if (MouseIn(1885, 25, 90, 90)) InventoryItemMouthFuturisticPanelGagExit();
+
 	if (MouseIn(1400, 800, 200, 64)) {
-		var pw = ElementValue("PasswordField").toUpperCase()
+		var pw = ElementValue("PasswordField").toUpperCase();
 		if (DialogFocusItem && DialogFocusItem.Property && DialogFocusItem.Property.LockedBy == "PasswordPadlock" && pw == DialogFocusItem.Property.Password) {
 			let C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
-			InventoryItemMiscPasswordPadlockUnlock(C, DialogFocusItem)
-			DialogFocusItem = null
-			Player.FocusGroup = null
+			InventoryItemMiscPasswordPadlockUnlock(C, DialogFocusItem);
+			DialogFocusItem = null;
+			Player.FocusGroup = null;
 			InventoryItemMouthFuturisticPanelGagExit();
 		} else if (DialogFocusItem && DialogFocusItem.Property && DialogFocusItem.Property.LockedBy == "TimerPasswordPadlock" && pw == DialogFocusItem.Property.Password) {
 			let C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
-			InventoryItemMiscTimerPasswordPadlockUnlock(C, DialogFocusItem)
-			DialogFocusItem = null
-			Player.FocusGroup = null
+			InventoryItemMiscTimerPasswordPadlockUnlock(C, DialogFocusItem);
+			DialogFocusItem = null;
+			Player.FocusGroup = null;
 			InventoryItemMouthFuturisticPanelGagExit();
 		} else if (DialogFocusItem && DialogFocusItem.Property && DialogFocusItem.Property.LockedBy == "CombinationPadlock" && pw == DialogFocusItem.Property.CombinationNumber) {
 			let C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
-			InventoryItemMiscCombinationPadlockUnlock(C, DialogFocusItem)
-			DialogFocusItem = null
-			Player.FocusGroup = null
+			InventoryItemMiscCombinationPadlockUnlock(C, DialogFocusItem);
+			DialogFocusItem = null;
+			Player.FocusGroup = null;
 			InventoryItemMouthFuturisticPanelGagExit();
 		} else {
 			FuturisticAccessDeniedMessage = DialogFindPlayer("CantChangeWhileLockedFuturistic");
 			AudioPlayInstantSound("Audio/AccessDenied.mp3");
 			if (CurrentScreen == "ChatRoom") {
-				InventoryItemMouthFuturisticPanelGagPublishAccessDenied((Player.FocusGroup != null) ? Player : CurrentCharacter)
+				InventoryItemMouthFuturisticPanelGagPublishAccessDenied((Player.FocusGroup != null) ? Player : CurrentCharacter);
 			}
 		}
 	}
@@ -164,12 +164,12 @@ function InventoryItemMouthFuturisticPanelGagClickAccessDenied() {
 
 function InventoryItemMouthFuturisticPanelGagExitAccessDenied() {
 	ElementRemove("PasswordField");
-	FuturisticAccessDeniedMessage = ""
+	FuturisticAccessDeniedMessage = "";
 	DialogFocusItem = null;
 }
 
 function InventoryItemMouthFuturisticPanelGagExit() {
-	InventoryItemMouthFuturisticPanelGagExitAccessDenied()
+	InventoryItemMouthFuturisticPanelGagExitAccessDenied();
 }
 
 /**
@@ -179,27 +179,27 @@ function InventoryItemMouthFuturisticPanelGagExit() {
 function InventoryItemMouthFuturisticPanelGagDraw() {
 	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
 	if (InventoryItemMouthFuturisticPanelGagValidate(C) !== "") {
-		InventoryItemMouthFuturisticPanelGagDrawAccessDenied()
+		InventoryItemMouthFuturisticPanelGagDrawAccessDenied();
 	} else {
 		DrawAssetPreview(1387, 75, DialogFocusItem.Asset);
 
 		if (DialogFocusItem.Property.AutoPunishUndoTime - CurrentTime > 0)
-			DrawText(DialogFindPlayer("FuturisticPanelGagMouthDeflationTime") + " " + TimerToString(DialogFocusItem.Property.AutoPunishUndoTime - CurrentTime), 1500, 415, "White", "Gray");		
+			DrawText(DialogFindPlayer("FuturisticPanelGagMouthDeflationTime") + " " + TimerToString(DialogFocusItem.Property.AutoPunishUndoTime - CurrentTime), 1500, 415, "White", "Gray");
 
-		var type = "FuturisticPanelGagMouthType" + ((DialogFocusItem.Property.Type != null) ? DialogFocusItem.Property.Type : "Padded")
+		var type = "FuturisticPanelGagMouthType" + ((DialogFocusItem.Property.Type != null) ? DialogFocusItem.Property.Type : "Padded");
 		DrawText(DialogFindPlayer("FuturisticPanelGagMouthTypeDesc") + " " +
-			DialogFindPlayer(type), 1350, 475, "White", "Gray");	
+			DialogFindPlayer(type), 1350, 475, "White", "Gray");
 
 		MainCanvas.textAlign = "left";
 		DrawCheckbox(1100, 890, 64, 64, "", DialogFocusItem.Property.ChatMessage, "White");
-		DrawText(DialogFindPlayer("FuturisticPanelGagMouthButtonChatMessage"), 1200, 923, "White", "Gray");	
+		DrawText(DialogFindPlayer("FuturisticPanelGagMouthButtonChatMessage"), 1200, 923, "White", "Gray");
 		MainCanvas.textAlign = "center";
 
-		var autopunish = "Off" 
-		if (DialogFocusItem.Property.AutoPunish == 0) {autopunish = "Off"}
-		else if (DialogFocusItem.Property.AutoPunish == 1) {autopunish = "Low"}
-		else if (DialogFocusItem.Property.AutoPunish == 2) {autopunish = "Medium"}
-		else {autopunish = "Maximum"}
+		var autopunish = "Off";
+		if (DialogFocusItem.Property.AutoPunish == 0) {autopunish = "Off";}
+		else if (DialogFocusItem.Property.AutoPunish == 1) {autopunish = "Low";}
+		else if (DialogFocusItem.Property.AutoPunish == 2) {autopunish = "Medium";}
+		else {autopunish = "Maximum";}
 
 		DrawText(DialogFindPlayer("FuturisticPanelGagMouthButtonAutoPunish") + " " + autopunish, 1350, 683, "White", "Gray");
 		if (DialogFocusItem) {
@@ -213,7 +213,7 @@ function InventoryItemMouthFuturisticPanelGagDraw() {
 			if (DialogFocusItem.Property.AutoPunish != 2) DrawButton(1100, 777, 200, 64, DialogFindPlayer("Medium"), "White", "");
 			if (DialogFocusItem.Property.AutoPunish != 3) DrawButton(1400, 777, 200, 64, DialogFindPlayer("Maximum"), "White", "");
 
-			DrawText(DialogFindPlayer("FuturisticPanelGagMouthDeflationTimeSetting" + DialogFocusItem.Property.AutoPunishUndoTimeSetting), 1775, 475, "White", "Gray");	
+			DrawText(DialogFindPlayer("FuturisticPanelGagMouthDeflationTimeSetting" + DialogFocusItem.Property.AutoPunishUndoTimeSetting), 1775, 475, "White", "Gray");
 			if (DialogFocusItem.Property.AutoPunishUndoTimeSetting != 120000) DrawButton(1675, 500, 200, 64, DialogFindPlayer("FuturisticPanelGagMouthDeflationTimeButton120000"), "White", "");
 			if (DialogFocusItem.Property.AutoPunishUndoTimeSetting != 300000) DrawButton(1675, 570, 200, 64, DialogFindPlayer("FuturisticPanelGagMouthDeflationTimeButton300000"), "White", "");
 			if (DialogFocusItem.Property.AutoPunishUndoTimeSetting != 900000) DrawButton(1675, 640, 200, 64, DialogFindPlayer("FuturisticPanelGagMouthDeflationTimeButton900000"), "White", "");
@@ -234,49 +234,49 @@ function InventoryItemMouthFuturisticPanelGagDraw() {
 function InventoryItemMouthFuturisticPanelGagClick() {
 	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
 	if (InventoryItemMouthFuturisticPanelGagValidate(C) !== "") {
-		InventoryItemMouthFuturisticPanelGagClickAccessDenied()
-	} else {		
-		if (MouseIn(1885, 25, 90, 90)) InventoryItemMouthFuturisticPanelGagExit()
-			
-		else if (MouseIn(1100, 890, 64, 64)) DialogFocusItem.Property.ChatMessage = !DialogFocusItem.Property.ChatMessage
-		
-		
+		InventoryItemMouthFuturisticPanelGagClickAccessDenied();
+	} else {
+		if (MouseIn(1885, 25, 90, 90)) InventoryItemMouthFuturisticPanelGagExit();
+
+		else if (MouseIn(1100, 890, 64, 64)) DialogFocusItem.Property.ChatMessage = !DialogFocusItem.Property.ChatMessage;
+
+
 		else if (DialogFocusItem.Property.Type != null && MouseIn(1100, 500, 200, 64)) {
-			DialogFocusItem.Property.AutoPunishUndoTime = 0; 
-			DialogFocusItem.Property.OriginalSetting = null; 
-			ExtendedItemSetType(C, InventoryItemMouthFuturisticPanelGagOptions, InventoryItemMouthFuturisticPanelGagOptions[0])}
+			DialogFocusItem.Property.AutoPunishUndoTime = 0;
+			DialogFocusItem.Property.OriginalSetting = null;
+			ExtendedItemSetType(C, InventoryItemMouthFuturisticPanelGagOptions, InventoryItemMouthFuturisticPanelGagOptions[0]);}
 		else if (DialogFocusItem.Property.Type != "LightBall" && MouseIn(1400, 500, 200, 64)) {
 			DialogFocusItem.Property.AutoPunishUndoTime = 0;
 			DialogFocusItem.Property.OriginalSetting = "LightBall";
-			ExtendedItemSetType(C, InventoryItemMouthFuturisticPanelGagOptions, InventoryItemMouthFuturisticPanelGagOptions[1])}
+			ExtendedItemSetType(C, InventoryItemMouthFuturisticPanelGagOptions, InventoryItemMouthFuturisticPanelGagOptions[1]);}
 		else if (DialogFocusItem.Property.Type != "Ball" && MouseIn(1100, 570, 200, 64)) {
 			DialogFocusItem.Property.AutoPunishUndoTime = 0;
 			DialogFocusItem.Property.OriginalSetting = "Ball";
-			ExtendedItemSetType(C, InventoryItemMouthFuturisticPanelGagOptions, InventoryItemMouthFuturisticPanelGagOptions[2])}
+			ExtendedItemSetType(C, InventoryItemMouthFuturisticPanelGagOptions, InventoryItemMouthFuturisticPanelGagOptions[2]);}
 		else if (DialogFocusItem.Property.Type != "Plug" && MouseIn(1400, 570, 200, 64)) {
 			DialogFocusItem.Property.AutoPunishUndoTime = 0;
 			DialogFocusItem.Property.OriginalSetting = "Plug";
-		ExtendedItemSetType(C, InventoryItemMouthFuturisticPanelGagOptions, InventoryItemMouthFuturisticPanelGagOptions[3])}
-		
-		else if (DialogFocusItem.Property.AutoPunish != 0 && MouseIn(1100, 707, 200, 64)) InventoryItemMouthFuturisticPanelGagSetAutoPunish(C, DialogFocusItem, 0)
-		else if (DialogFocusItem.Property.AutoPunish != 1 && MouseIn(1400, 707, 200, 64)) InventoryItemMouthFuturisticPanelGagSetAutoPunish(C, DialogFocusItem, 1)
-		else if (DialogFocusItem.Property.AutoPunish != 2 && MouseIn(1100, 777, 200, 64)) InventoryItemMouthFuturisticPanelGagSetAutoPunish(C, DialogFocusItem, 2)
-		else if (DialogFocusItem.Property.AutoPunish != 3 && MouseIn(1400, 777, 200, 64)) InventoryItemMouthFuturisticPanelGagSetAutoPunish(C, DialogFocusItem, 3)
-			
-		
-		else if (DialogFocusItem.Property.AutoPunishUndoTimeSetting != 120000 && MouseIn(1675, 500, 200, 64)) InventoryItemMouthFuturisticPanelGagSetAutoPunishTime(C, DialogFocusItem, 120000)
-		else if (DialogFocusItem.Property.AutoPunishUndoTimeSetting != 300000 && MouseIn(1675, 570, 200, 64)) InventoryItemMouthFuturisticPanelGagSetAutoPunishTime(C, DialogFocusItem, 300000)
-		else if (DialogFocusItem.Property.AutoPunishUndoTimeSetting != 900000 && MouseIn(1675, 640, 200, 64)) InventoryItemMouthFuturisticPanelGagSetAutoPunishTime(C, DialogFocusItem, 900000)
-		else if (DialogFocusItem.Property.AutoPunishUndoTimeSetting != 3600000 && MouseIn(1675, 710, 200, 64)) InventoryItemMouthFuturisticPanelGagSetAutoPunishTime(C, DialogFocusItem, 3600000)
-		else if (DialogFocusItem.Property.AutoPunishUndoTimeSetting != 72000000 && MouseIn(1675, 780, 200, 64)) InventoryItemMouthFuturisticPanelGagSetAutoPunishTime(C, DialogFocusItem, 72000000)
-			
+		ExtendedItemSetType(C, InventoryItemMouthFuturisticPanelGagOptions, InventoryItemMouthFuturisticPanelGagOptions[3]);}
+
+		else if (DialogFocusItem.Property.AutoPunish != 0 && MouseIn(1100, 707, 200, 64)) InventoryItemMouthFuturisticPanelGagSetAutoPunish(C, DialogFocusItem, 0);
+		else if (DialogFocusItem.Property.AutoPunish != 1 && MouseIn(1400, 707, 200, 64)) InventoryItemMouthFuturisticPanelGagSetAutoPunish(C, DialogFocusItem, 1);
+		else if (DialogFocusItem.Property.AutoPunish != 2 && MouseIn(1100, 777, 200, 64)) InventoryItemMouthFuturisticPanelGagSetAutoPunish(C, DialogFocusItem, 2);
+		else if (DialogFocusItem.Property.AutoPunish != 3 && MouseIn(1400, 777, 200, 64)) InventoryItemMouthFuturisticPanelGagSetAutoPunish(C, DialogFocusItem, 3);
+
+
+		else if (DialogFocusItem.Property.AutoPunishUndoTimeSetting != 120000 && MouseIn(1675, 500, 200, 64)) InventoryItemMouthFuturisticPanelGagSetAutoPunishTime(C, DialogFocusItem, 120000);
+		else if (DialogFocusItem.Property.AutoPunishUndoTimeSetting != 300000 && MouseIn(1675, 570, 200, 64)) InventoryItemMouthFuturisticPanelGagSetAutoPunishTime(C, DialogFocusItem, 300000);
+		else if (DialogFocusItem.Property.AutoPunishUndoTimeSetting != 900000 && MouseIn(1675, 640, 200, 64)) InventoryItemMouthFuturisticPanelGagSetAutoPunishTime(C, DialogFocusItem, 900000);
+		else if (DialogFocusItem.Property.AutoPunishUndoTimeSetting != 3600000 && MouseIn(1675, 710, 200, 64)) InventoryItemMouthFuturisticPanelGagSetAutoPunishTime(C, DialogFocusItem, 3600000);
+		else if (DialogFocusItem.Property.AutoPunishUndoTimeSetting != 72000000 && MouseIn(1675, 780, 200, 64)) InventoryItemMouthFuturisticPanelGagSetAutoPunishTime(C, DialogFocusItem, 72000000);
+
 		else if (DialogFocusItem.Property.AutoPunishUndoTimeSetting && MouseIn(1675, 880, 200, 64)) {
-			InventoryItemMouthFuturisticPanelGagTrigger(C, DialogFocusItem, false, InventoryItemMouthFuturisticPanelGagOptions)
-			DialogFocusItem.Property.AutoPunishUndoTime = CurrentTime + DialogFocusItem.Property.AutoPunishUndoTimeSetting // Reset the deflation time
+			InventoryItemMouthFuturisticPanelGagTrigger(C, DialogFocusItem, false, InventoryItemMouthFuturisticPanelGagOptions);
+			DialogFocusItem.Property.AutoPunishUndoTime = CurrentTime + DialogFocusItem.Property.AutoPunishUndoTimeSetting; // Reset the deflation time
 			CharacterRefresh(C, true); // Does not sync appearance while in the wardrobe
 			ChatRoomCharacterUpdate(C);
 		}
-		
+
 	}
 }
 
@@ -289,7 +289,7 @@ function InventoryItemMouthFuturisticPanelGagValidate(C, Option) {
 	var Allowed = "";
 
 	if (DialogFocusItem && DialogFocusItem.Property && DialogFocusItem.Property.LockedBy && !DialogCanUnlock(C, DialogFocusItem)) {
-		var collar = InventoryGet(C, "ItemNeck")
+		var collar = InventoryGet(C, "ItemNeck");
 		if (!collar || (!collar.Property || collar.Property.OpenPermission != true)) {
 			Allowed = DialogExtendedMessage = DialogFindPlayer("CantChangeWhileLockedFuturistic");
 		}
@@ -300,14 +300,14 @@ function InventoryItemMouthFuturisticPanelGagValidate(C, Option) {
 
 function InventoryItemMouthFuturisticPanelGagGetOption(Options, OptionType) {
 	for (let I = 0; I < Options.length; I++) {
-		if (Options[I].Property.Type == OptionType) return I
+		if (Options[I].Property.Type == OptionType) return I;
 	}
-	return 0
+	return 0;
 }
 
 function InventoryItemMouthFuturisticPanelGagPublishActionTrigger(C, Item, Option, Deflate) {
 	var msg = "FuturisticPanelGagMouthSetAuto" + ((Deflate) ? "Deflate" : "Inflate") + Option.Name;
-	
+
 	var Dictionary = [
 		{ Tag: "DestinationCharacterName", Text: C.Name, MemberNumber: C.MemberNumber },
 		{ Tag: "AssetName", AssetName: Item.Asset.Name },
@@ -320,7 +320,7 @@ function InventoryItemMouthFuturisticPanelGagPublishActionTrigger(C, Item, Optio
 }
 
 function InventoryItemMouthFuturisticPanelGagSetAutoPunish(C, Item, Level) {
-	Item.Property.AutoPunish = Level
+	Item.Property.AutoPunish = Level;
 	var msg = "FuturisticPanelGagMouthSetAutoPunish" + Level;
 	var Dictionary = [
 		{ Tag: "SourceCharacter", Text: Player.Name, MemberNumber: Player.MemberNumber },
@@ -330,7 +330,7 @@ function InventoryItemMouthFuturisticPanelGagSetAutoPunish(C, Item, Level) {
 }
 
 function InventoryItemMouthFuturisticPanelGagSetAutoPunishTime(C, Item, Time) {
-	Item.Property.AutoPunishUndoTimeSetting = Time
+	Item.Property.AutoPunishUndoTimeSetting = Time;
 	var msg = "FuturisticPanelGagMouthSetAutoPunishTime" + Time;
 	var Dictionary = [
 		{ Tag: "SourceCharacter", Text: Player.Name, MemberNumber: Player.MemberNumber },
@@ -355,20 +355,20 @@ function InventoryItemMouthFuturisticPanelGagPublishAction(C, Option) {
 }
 
 function InventoryItemMouthFuturisticPanelGagPublishAccessDenied(C) {
-	var msg = "FuturisticItemLoginLoginAttempt"
+	var msg = "FuturisticItemLoginLoginAttempt";
 	var Dictionary = [
 		{ Tag: "SourceCharacter", Text: Player.Name, MemberNumber: Player.MemberNumber },
 		{ Tag: "DestinationCharacter", Text: C.Name, MemberNumber: C.MemberNumber },
 		{ Tag: "FocusAssetGroup", AssetGroupName: C.FocusGroup.Name}
 	];
-	
+
 	ChatRoomPublishCustomAction(msg, true, Dictionary);
 }
 
 /**
- * The NPC dialog is for what the NPC says to you when you make a change to their restraints - the dialog lookup is on a 
- * per-NPC basis. You basically put the "AssetName" + OptionName in there to allow individual NPCs to override their default 
- * "GroupName" dialog if for example we ever wanted an NPC to react specifically to having the restraint put on them. 
+ * The NPC dialog is for what the NPC says to you when you make a change to their restraints - the dialog lookup is on a
+ * per-NPC basis. You basically put the "AssetName" + OptionName in there to allow individual NPCs to override their default
+ * "GroupName" dialog if for example we ever wanted an NPC to react specifically to having the restraint put on them.
  * That could be done by adding an "AssetName" entry (or entries) to that NPC's dialog CSV
  * @param {Character} C - The NPC to whom the restraint is applied
  * @param {Option} Option - The chosen option for this extended item
@@ -381,18 +381,18 @@ function InventoryItemMouthFuturisticPanelGagNpcDialog(C, Option) {
 function InventoryItemMouthFuturisticPanelGagTrigger(C, Item, Reset, Options) {
 	var OptionLevel = (Reset) ? Math.max(InventoryItemMouthFuturisticPanelGagGetOption(Options, Item.Property.OriginalSetting), InventoryItemMouthFuturisticPanelGagGetOption(Options, Item.Property.Type) - 1)
 		: Math.min(Options.length, InventoryItemMouthFuturisticPanelGagGetOption(Options, Item.Property.Type) + 1);
-	
+
 	if (Reset || Item.Property.Type != "Plug") {
-		var OriginalItemSetting = Item.Property.OriginalSetting
-		InventoryItemMouthFuturisticPanelGagSetOption(C, Options, Options[OptionLevel], Item)
+		var OriginalItemSetting = Item.Property.OriginalSetting;
+		InventoryItemMouthFuturisticPanelGagSetOption(C, Options, Options[OptionLevel], Item);
 		if (CurrentScreen == "ChatRoom" && Item.Property.ChatMessage)
-			InventoryItemMouthFuturisticPanelGagPublishActionTrigger(C, Item, Options[OptionLevel], Reset)
-		Item.Property.OriginalSetting = OriginalItemSetting // After automatically changing it, we put it back to original setting
-		
+			InventoryItemMouthFuturisticPanelGagPublishActionTrigger(C, Item, Options[OptionLevel], Reset);
+		Item.Property.OriginalSetting = OriginalItemSetting; // After automatically changing it, we put it back to original setting
+
 		CharacterSetFacialExpression(C, "Eyebrows", "Soft", 10);
 		CharacterSetFacialExpression(C, "Blush", "Extreme", 15);
 		CharacterSetFacialExpression(C, "Eyes", "Lewd", 5);
-		
+
 		/*var vol = 1
 		if (Player.AudioSettings && Player.AudioSettings.Volume) {
 			vol = Player.AudioSettings.Volume
@@ -404,7 +404,7 @@ function InventoryItemMouthFuturisticPanelGagTrigger(C, Item, Reset, Options) {
 		*/
 	}
 }
-	
+
 
 // Copied from extended item
 function InventoryItemMouthFuturisticPanelGagSetOption(C, Options, Option, Item, NoRefresh) {
@@ -428,31 +428,31 @@ function InventoryItemMouthFuturisticPanelGagSetOption(C, Options, Option, Item,
 	}
 
 	Item.Property = NewProperty;
-	
+
 	if (!NoRefresh) {
-		CharacterRefresh(C, true); 		
+		CharacterRefresh(C, true);
 		// For a restraint, we might publish an action or change the dialog of a NPC
-		ChatRoomCharacterUpdate(C);	
+		ChatRoomCharacterUpdate(C);
 	}
 }
 
 function AssetsItemMouthFuturisticPanelGagScriptUpdatePlayer(data, Options) {
-	var Item = data.Item
+	var Item = data.Item;
 	// Punish the player if they speak
 	if (Item.Property.AutoPunish < 3)
-		AutoPunishGagActionFlag = false
-	
+		AutoPunishGagActionFlag = false;
+
 	if (Item.Property.AutoPunish && Item.Property.AutoPunish > 0 && Item.Property.AutoPunishUndoTimeSetting) {
-		
-		var LastMessages = data.PersistentData().LastMessageLen
-		var GagTriggerPunish = false
+
+		var LastMessages = data.PersistentData().LastMessageLen;
+		var GagTriggerPunish = false;
 		var keywords = false;
 		var gagaction = false;
-		
+
 		if (Item.Property.AutoPunish == 3) {
 			if (AutoPunishGagActionFlag == true) {
-				gagaction = true
-				AutoPunishGagActionFlag = false
+				gagaction = true;
+				AutoPunishGagActionFlag = false;
 			} else for (let K = 0; K < AutoPunishKeywords.length; K++) {
 				if (ChatRoomLastMessage[ChatRoomLastMessage.length-1].includes(AutoPunishKeywords[K])) {
 					keywords = true;
@@ -460,48 +460,48 @@ function AssetsItemMouthFuturisticPanelGagScriptUpdatePlayer(data, Options) {
 				}
 			}
 		}
-		
+
 		if (Item.Property.AutoPunish == 3 && (gagaction || (ChatRoomLastMessage && ChatRoomLastMessage.length != LastMessages
 			&& !ChatRoomLastMessage[ChatRoomLastMessage.length-1].startsWith("(") && !ChatRoomLastMessage[ChatRoomLastMessage.length-1].startsWith("*") && ChatRoomLastMessage[ChatRoomLastMessage.length-1].replace(/[A-Za-zА-Яа-я]+/g, '') != ChatRoomLastMessage[ChatRoomLastMessage.length-1]
 			&& (!ChatRoomLastMessage[ChatRoomLastMessage.length-1].startsWith("/")
 			|| (keywords && (ChatRoomLastMessage[ChatRoomLastMessage.length-1].startsWith("/me") || ChatRoomLastMessage[ChatRoomLastMessage.length-1].startsWith("*")))))))
-			GagTriggerPunish = true
+			GagTriggerPunish = true;
 		if (Item.Property.AutoPunish == 2 && ChatRoomLastMessage && ChatRoomLastMessage.length != LastMessages
 			&& !ChatRoomLastMessage[ChatRoomLastMessage.length-1].startsWith("(") && !ChatRoomLastMessage[ChatRoomLastMessage.length-1].startsWith("*") && !ChatRoomLastMessage[ChatRoomLastMessage.length-1].startsWith("/")
 			&& (ChatRoomLastMessage[ChatRoomLastMessage.length-1].length > 25
 				|| (ChatRoomLastMessage[ChatRoomLastMessage.length-1].replace(/[A-Za-zА-Яа-я]+/g, '') != ChatRoomLastMessage[ChatRoomLastMessage.length-1] && (ChatRoomLastMessage[ChatRoomLastMessage.length-1] == ChatRoomLastMessage[ChatRoomLastMessage.length-1].toUpperCase()
 				|| (ChatRoomLastMessage[ChatRoomLastMessage.length-1].includes('!'))))))
-			GagTriggerPunish = true
+			GagTriggerPunish = true;
 		if (Item.Property.AutoPunish == 1 && ChatRoomLastMessage && ChatRoomLastMessage.length != LastMessages
 			&& !ChatRoomLastMessage[ChatRoomLastMessage.length-1].startsWith("(") && !ChatRoomLastMessage[ChatRoomLastMessage.length-1].startsWith("*") && !ChatRoomLastMessage[ChatRoomLastMessage.length-1].startsWith("/")
 			&& (ChatRoomLastMessage[ChatRoomLastMessage.length-1].replace(/[A-Za-zА-Яа-я]+/g, '') != ChatRoomLastMessage[ChatRoomLastMessage.length-1] && (ChatRoomLastMessage[ChatRoomLastMessage.length-1] == ChatRoomLastMessage[ChatRoomLastMessage.length-1].toUpperCase()
 				|| (ChatRoomLastMessage[ChatRoomLastMessage.length-1].includes('!')))))
-			GagTriggerPunish = true
-		
+			GagTriggerPunish = true;
+
 		if (ChatRoomTargetMemberNumber != null) {
-			GagTriggerPunish = false // No trigger on whispers
+			GagTriggerPunish = false; // No trigger on whispers
 		}
-		
+
 		if (GagTriggerPunish) {
-			InventoryItemMouthFuturisticPanelGagTrigger(Player, Item, false, Options)
-			Item.Property.AutoPunishUndoTime = CurrentTime + Item.Property.AutoPunishUndoTimeSetting // Reset the deflation time
+			InventoryItemMouthFuturisticPanelGagTrigger(Player, Item, false, Options);
+			Item.Property.AutoPunishUndoTime = CurrentTime + Item.Property.AutoPunishUndoTimeSetting; // Reset the deflation time
 			CharacterRefresh(Player, true); // Does not sync appearance while in the wardrobe
-			
+
 			// For a restraint, we might publish an action or change the dialog of a NPC
-			ChatRoomCharacterUpdate(Player);	
+			ChatRoomCharacterUpdate(Player);
 
 		} else if (Item.Property.AutoPunishUndoTime - CurrentTime <= 0 && Item.Property.Type && Item.Property.Type != Item.Property.OriginalSetting) {
 			// Deflate the gag back to the original setting after a while
-			InventoryItemMouthFuturisticPanelGagTrigger(Player, Item, true, Options)
+			InventoryItemMouthFuturisticPanelGagTrigger(Player, Item, true, Options);
 			if (Item.Property.OriginalSetting != Item.Property.Type)
-				Item.Property.AutoPunishUndoTime = CurrentTime + Item.Property.AutoPunishUndoTimeSetting // Reset the deflation time
+				Item.Property.AutoPunishUndoTime = CurrentTime + Item.Property.AutoPunishUndoTimeSetting; // Reset the deflation time
 			CharacterRefresh(Player, true); // Does not sync appearance while in the wardrobe
-			
+
 			// For a restraint, we might publish an action or change the dialog of a NPC
-			ChatRoomCharacterUpdate(Player);	
+			ChatRoomCharacterUpdate(Player);
 		}
 	}
-	
+
 }
 
 // Update data
@@ -514,14 +514,14 @@ function AssetsItemMouthFuturisticPanelGagScriptDraw(data) {
 
 	if (persistentData.UpdateTime < CommonTime() && data.C == Player) {
 		if (CurrentScreen == "ChatRoom") {
-		
-			AssetsItemMouthFuturisticPanelGagScriptUpdatePlayer(data, InventoryItemMouthFuturisticPanelGagOptions)
-			
+
+			AssetsItemMouthFuturisticPanelGagScriptUpdatePlayer(data, InventoryItemMouthFuturisticPanelGagOptions);
+
 			persistentData.LastMessageLen = (ChatRoomLastMessage) ? ChatRoomLastMessage.length : 0;
 		}
 
-		property.BlinkState = (property.BlinkState + 1) % 2
-		
+		property.BlinkState = (property.BlinkState + 1) % 2;
+
 		var timeToNextRefresh = 3025;
 		persistentData.UpdateTime = CommonTime() + timeToNextRefresh;
 		AnimationRequestRefreshRate(data.C, 5000 - timeToNextRefresh);
@@ -531,14 +531,14 @@ function AssetsItemMouthFuturisticPanelGagScriptDraw(data) {
 
 
 // Drawing function for the blinking light
-function AssetsItemMouthFuturisticPanelGagBeforeDraw(data) { 
+function AssetsItemMouthFuturisticPanelGagBeforeDraw(data) {
 	if (data.L === "_Light" && data.Property && data.Property.AutoPunish > 0 && data.Property.BlinkState == 1) {
-		
-		if (data.Color && data.Color != "" && data.Color != "Default") {return {LayerType : "Blink"}}
-		else if (data.Property.AutoPunish == 1) {return {LayerType : "Blink", Color : "#28ff28"}}
-		else if (data.Property.AutoPunish == 2) {return {LayerType : "Blink", Color : "#ffff28"}}
-		else if (data.Property.AutoPunish == 3) {return {LayerType : "Blink", Color : "#ff3838"}}
-		
+
+		if (data.Color && data.Color != "" && data.Color != "Default") {return {LayerType : "Blink"};}
+		else if (data.Property.AutoPunish == 1) {return {LayerType : "Blink", Color : "#28ff28"};}
+		else if (data.Property.AutoPunish == 2) {return {LayerType : "Blink", Color : "#ffff28"};}
+		else if (data.Property.AutoPunish == 3) {return {LayerType : "Blink", Color : "#ff3838"};}
+
 	}
-	return data
+	return data;
 }

--- a/BondageClub/Screens/Inventory/ItemNeck/FuturisticCollar/FuturisticCollar.js
+++ b/BondageClub/Screens/Inventory/ItemNeck/FuturisticCollar/FuturisticCollar.js
@@ -4,7 +4,7 @@
 function InventoryItemNeckFuturisticCollarLoad() {
 	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
 	if (InventoryItemMouthFuturisticPanelGagValidate(C) !== "") {
-		InventoryItemMouthFuturisticPanelGagLoadAccessDenied()
+		InventoryItemMouthFuturisticPanelGagLoadAccessDenied();
 	} else {
 		if (DialogFocusItem.Property == null) DialogFocusItem.Property = { OpenPermission: false };
 		if (DialogFocusItem.Property.OpenPermission == null) DialogFocusItem.Property.OpenPermission = false;
@@ -14,15 +14,15 @@ function InventoryItemNeckFuturisticCollarLoad() {
 
 
 
-		
+
 // Draw the item extension screen
 function InventoryItemNeckFuturisticCollarDraw() {
 	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
 	if (InventoryItemMouthFuturisticPanelGagValidate(C) !== "") {
-		InventoryItemMouthFuturisticPanelGagDrawAccessDenied()
+		InventoryItemMouthFuturisticPanelGagDrawAccessDenied();
 	} else {
 		DrawAssetPreview(1387, 65, DialogFocusItem.Asset);
-		
+
 		if ((DialogFocusItem && DialogFocusItem.Property && DialogFocusItem.Property.LockedBy && !DialogCanUnlock(C, DialogFocusItem))) {
 			DrawText(DialogFindPlayer("FuturisticCollarOptionsLockout"), 1500, 375, "White", "Gray");
 		}
@@ -32,19 +32,19 @@ function InventoryItemNeckFuturisticCollarDraw() {
 		DrawButton(1125, 465, 64, 64, "", "White", DialogFocusItem.Property.BlockRemotes ? "Icons/Checked.png" : "");
 		DrawText(DialogFindPlayer("FuturisticCollarBlockRemotes"), 1450, 495, "White", "Gray");
 
-		var FuturisticCollarStatus = "NoItems"
-		var FuturisticCollarItems = InventoryItemNeckFuturisticCollarGetItems(C)
-		var FuturisticCollarItemsUnlockable = InventoryItemNeckFuturisticCollarGetItems(C, true)
-		var lockedItems = 0
+		var FuturisticCollarStatus = "NoItems";
+		var FuturisticCollarItems = InventoryItemNeckFuturisticCollarGetItems(C);
+		var FuturisticCollarItemsUnlockable = InventoryItemNeckFuturisticCollarGetItems(C, true);
+		var lockedItems = 0;
 		for (let I = 0; I < FuturisticCollarItems.length; I++) {
 			if (InventoryGetLock(FuturisticCollarItems[I])) {
-				lockedItems += 1
+				lockedItems += 1;
 			}
 		}
 		if (FuturisticCollarItems.length > 0) {
-			if (lockedItems == 0) FuturisticCollarStatus = "NoLocks"
-			else if (lockedItems < FuturisticCollarItems.length) FuturisticCollarStatus = "PartialLocks"
-			else if (lockedItems == FuturisticCollarItems.length) FuturisticCollarStatus = "FullyLocked"
+			if (lockedItems == 0) FuturisticCollarStatus = "NoLocks";
+			else if (lockedItems < FuturisticCollarItems.length) FuturisticCollarStatus = "PartialLocks";
+			else if (lockedItems == FuturisticCollarItems.length) FuturisticCollarStatus = "FullyLocked";
 		}
 
 		DrawText(DialogFindPlayer("FuturisticCollarOptions" + FuturisticCollarStatus), 1500, 560, "White", "Gray");
@@ -72,61 +72,61 @@ function InventoryItemNeckFuturisticCollarDraw() {
 }
 
 function InventoryItemNeckFuturisticCollarExit() {
-	InventoryItemMouthFuturisticPanelGagExitAccessDenied()
+	InventoryItemMouthFuturisticPanelGagExitAccessDenied();
 }
 
 
 // Catches the item extension clicks
 function InventoryItemNeckFuturisticCollarClick() {
-	
+
 	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
 	if (InventoryItemMouthFuturisticPanelGagValidate(C) !== "") {
-		InventoryItemMouthFuturisticPanelGagClickAccessDenied()
+		InventoryItemMouthFuturisticPanelGagClickAccessDenied();
 	} else {
-		
+
 		if ((MouseX >= 1885) && (MouseX <= 1975) && (MouseY >= 25) && (MouseY <= 110)) InventoryItemNeckFuturisticCollarExit();
 		else if (MouseIn(1125, 395, 64, 64) && !(DialogFocusItem && DialogFocusItem.Property && DialogFocusItem.Property.LockedBy && !DialogCanUnlock(C, DialogFocusItem))) InventoryItemNeckFuturisticCollarTogglePermission(C, DialogFocusItem);
 		else if (MouseIn(1125, 465, 64, 64) && !(DialogFocusItem && DialogFocusItem.Property && DialogFocusItem.Property.LockedBy && !DialogCanUnlock(C, DialogFocusItem))) InventoryItemNeckFuturisticCollarToggleRemotes(C, DialogFocusItem);
 		else {
-		
-			var FuturisticCollarItems = InventoryItemNeckFuturisticCollarGetItems(C)
-			var FuturisticCollarItemsUnlockable = InventoryItemNeckFuturisticCollarGetItems(C, true)
-			var lockedItems = 0
+
+			var FuturisticCollarItems = InventoryItemNeckFuturisticCollarGetItems(C);
+			var FuturisticCollarItemsUnlockable = InventoryItemNeckFuturisticCollarGetItems(C, true);
+			var lockedItems = 0;
 			for (let I = 0; I < FuturisticCollarItems.length; I++) {
 				if (InventoryGetLock(FuturisticCollarItems[I])) {
-					lockedItems += 1
+					lockedItems += 1;
 				}
 			}
-			
-			var CollarAction = 0 // 0 - nothing, 1 - Lock, 2 - Unlock, 3 - Color
+
+			var CollarAction = 0; // 0 - nothing, 1 - Lock, 2 - Unlock, 3 - Color
 			if (FuturisticCollarItems.length > 0 ) {
-				
+
 				if (lockedItems < FuturisticCollarItems.length) {
-					if (MouseIn(1250, 590, 200, 55) && InventoryItemNeckFuturisticCollarCanLock(C, "MetalPadlock", "ItemMisc")) { InventoryItemNeckFuturisticCollarLockdown(C, "MetalPadlock"); CollarAction = 1}
-					else if (MouseIn(1550, 590, 200, 55) && InventoryItemNeckFuturisticCollarCanLock(C, "ExclusivePadlock", "ItemMisc")) { InventoryItemNeckFuturisticCollarLockdown(C, "ExclusivePadlock"); CollarAction = 1}
-					if (MouseIn(1250, 650, 200, 55) && InventoryItemNeckFuturisticCollarCanLock(C, "IntricatePadlock", "ItemMisc")) { InventoryItemNeckFuturisticCollarLockdown(C, "IntricatePadlock"); CollarAction = 1}
-					else if (MouseIn(1550, 650, 200, 55) && InventoryItemNeckFuturisticCollarCanLock(C, "HighSecurityPadlock", "ItemMisc")) { InventoryItemNeckFuturisticCollarLockdown(C, "HighSecurityPadlock"); CollarAction = 1}
-					else if (MouseIn(1250, 710, 200, 55) && InventoryItemNeckFuturisticCollarCanLock(C, "TimerPadlock", "ItemMisc")) { InventoryItemNeckFuturisticCollarLockdown(C, "TimerPadlock"); CollarAction = 1}
-					else if (MouseIn(1550, 710, 200, 55) && InventoryItemNeckFuturisticCollarCanLock(C, "MistressPadlock", "ItemMisc")) { InventoryItemNeckFuturisticCollarLockdown(C, "MistressPadlock"); CollarAction = 1}
-					else if (MouseIn(1250, 770, 200, 55) && InventoryItemNeckFuturisticCollarCanLock(C, "LoversPadlock", "ItemMisc")) { InventoryItemNeckFuturisticCollarLockdown(C, "LoversPadlock"); CollarAction = 1}
-					else if (MouseIn(1550, 770, 200, 55) && InventoryItemNeckFuturisticCollarCanLock(C, "OwnerPadlock", "ItemMisc")) { InventoryItemNeckFuturisticCollarLockdown(C, "OwnerPadlock"); CollarAction = 1}
+					if (MouseIn(1250, 590, 200, 55) && InventoryItemNeckFuturisticCollarCanLock(C, "MetalPadlock", "ItemMisc")) { InventoryItemNeckFuturisticCollarLockdown(C, "MetalPadlock"); CollarAction = 1;}
+					else if (MouseIn(1550, 590, 200, 55) && InventoryItemNeckFuturisticCollarCanLock(C, "ExclusivePadlock", "ItemMisc")) { InventoryItemNeckFuturisticCollarLockdown(C, "ExclusivePadlock"); CollarAction = 1;}
+					if (MouseIn(1250, 650, 200, 55) && InventoryItemNeckFuturisticCollarCanLock(C, "IntricatePadlock", "ItemMisc")) { InventoryItemNeckFuturisticCollarLockdown(C, "IntricatePadlock"); CollarAction = 1;}
+					else if (MouseIn(1550, 650, 200, 55) && InventoryItemNeckFuturisticCollarCanLock(C, "HighSecurityPadlock", "ItemMisc")) { InventoryItemNeckFuturisticCollarLockdown(C, "HighSecurityPadlock"); CollarAction = 1;}
+					else if (MouseIn(1250, 710, 200, 55) && InventoryItemNeckFuturisticCollarCanLock(C, "TimerPadlock", "ItemMisc")) { InventoryItemNeckFuturisticCollarLockdown(C, "TimerPadlock"); CollarAction = 1;}
+					else if (MouseIn(1550, 710, 200, 55) && InventoryItemNeckFuturisticCollarCanLock(C, "MistressPadlock", "ItemMisc")) { InventoryItemNeckFuturisticCollarLockdown(C, "MistressPadlock"); CollarAction = 1;}
+					else if (MouseIn(1250, 770, 200, 55) && InventoryItemNeckFuturisticCollarCanLock(C, "LoversPadlock", "ItemMisc")) { InventoryItemNeckFuturisticCollarLockdown(C, "LoversPadlock"); CollarAction = 1;}
+					else if (MouseIn(1550, 770, 200, 55) && InventoryItemNeckFuturisticCollarCanLock(C, "OwnerPadlock", "ItemMisc")) { InventoryItemNeckFuturisticCollarLockdown(C, "OwnerPadlock"); CollarAction = 1;}
 				}
 			}
-			if (MouseIn(1400, 850, 200, 55) && FuturisticCollarItemsUnlockable.length > 0) { InventoryItemNeckFuturisticCollarUnlock(C); CollarAction = 2}
-			if (MouseIn(1400, 910, 200, 55) && FuturisticCollarItems.length > 0 && DialogFocusItem) { InventoryItemNeckFuturisticCollarColor(C, DialogFocusItem); CollarAction = 3}
-			
+			if (MouseIn(1400, 850, 200, 55) && FuturisticCollarItemsUnlockable.length > 0) { InventoryItemNeckFuturisticCollarUnlock(C); CollarAction = 2;}
+			if (MouseIn(1400, 910, 200, 55) && FuturisticCollarItems.length > 0 && DialogFocusItem) { InventoryItemNeckFuturisticCollarColor(C, DialogFocusItem); CollarAction = 3;}
+
 			if (CollarAction > 0) {
 				InventoryItemNeckFuturisticCollarExit();
-				
+
 				/*var vol = 1
 				if (Player.AudioSettings && Player.AudioSettings.Volume) {
 					vol = Player.AudioSettings.Volume
 				}
-				if (CollarAction == 1) 
+				if (CollarAction == 1)
 					AudioPlayInstantSound("Audio/HydraulicLock.mp3", vol)
 				else
 					AudioPlayInstantSound("Audio/HydraulicUnlock.mp3", vol)*/
-				
+
 			}
 		}
 	}
@@ -136,26 +136,26 @@ function InventoryItemNeckFuturisticCollarClick() {
 
 
 function InventoryItemNeckFuturisticCollarCanLock(C, LockType) {
-	InventoryAvailable(Player, LockType, "ItemMisc")
-	var LockItem = null	
+	InventoryAvailable(Player, LockType, "ItemMisc");
+	var LockItem = null;
 	// First, we check if the inventory already exists, exit if it's the case
 	for (let I = 0; I < Player.Inventory.length; I++)
 		if ((Player.Inventory[I].Name == LockType) && (Player.Inventory[I].Group == "ItemMisc")) {
-			LockItem = Player.Inventory[I]
+			LockItem = Player.Inventory[I];
 			break;
 		}
 	// Next we check if the target player has it, but not for the mistress, owner, or lover locks
 	if (LockItem == null && LockType != "MistressPadlock" && LockType != "LoversPadlock" && LockType != "OwnerPadlock")
 	for (let I = 0; I < C.Inventory.length; I++)
 		if ((C.Inventory[I].Name == LockType) && (C.Inventory[I].Group == "ItemMisc")) {
-			LockItem = C.Inventory[I]
+			LockItem = C.Inventory[I];
 			break;
 		}
-		
 
-		
+
+
 	if (LockItem && !(InventoryBlockedOrLimited(C, LockItem))) {
-	
+
 
 
 		// Make sure we do not add owner/lover only items for invalid characters, owner/lover locks can be applied on the player by the player for self-bondage
@@ -165,26 +165,26 @@ function InventoryItemNeckFuturisticCollarCanLock(C, LockType) {
 		if (LockItem.Asset.LoverOnly && !C.IsLoverOfPlayer())
 			if ((C.ID != 0) || (C.Lovership.length == 0) || ((C.ID == 0) && C.GetLoversNumbers(true).length == 0))
 				return false;
-		return true
-	} 
-	return false
+		return true;
+	}
+	return false;
 }
 
 function InventoryItemNeckFuturisticCollarGetItems(C, OnlyUnlockable) {
-	var ItemList = []
-	
+	var ItemList = [];
+
 	for (let E = C.Appearance.length - 1; E >= 0; E--)
 		if (((C.Appearance[E].Asset.Name.indexOf("Futuristic") >= 0 || C.Appearance[E].Asset.Name.indexOf("Interactive") >= 0 || C.Appearance[E].Asset.Name.indexOf("Electronic") >= 0) && (!OnlyUnlockable || C.Appearance[E].Asset.Group.Name != "ItemNeck")) &&
 			(C.Appearance[E].Asset.AllowLock)
 			&& (!OnlyUnlockable || (InventoryGetLock(C.Appearance[E]) != null && InventoryItemHasEffect(C.Appearance[E], "Lock", true) && DialogCanUnlock(C, C.Appearance[E])))) {
-				ItemList.push(C.Appearance[E])
+				ItemList.push(C.Appearance[E]);
 		}
-	
-	return ItemList
+
+	return ItemList;
 }
 
 function InventoryItemNeckFuturisticCollarValidate(C, Option) {
-	return InventoryItemMouthFuturisticPanelGagValidate(C, Option)
+	return InventoryItemMouthFuturisticPanelGagValidate(C, Option);
 }
 
 
@@ -193,14 +193,14 @@ function InventoryItemNeckFuturisticCollarLockdown(C, LockType) {
 		if (((C.Appearance[E].Asset.Name.indexOf("Futuristic") >= 0 || C.Appearance[E].Asset.Name.indexOf("Interactive") >= 0 || C.Appearance[E].Asset.Name.indexOf("Electronic") >= 0) &&
 			(C.Appearance[E].Asset.AllowLock && InventoryGetLock(C.Appearance[E]) == null))) {
 				InventoryLock(C, C.Appearance[E], LockType, Player.MemberNumber);
-				var Lock = InventoryGetLock(C.Appearance[E])
+				var Lock = InventoryGetLock(C.Appearance[E]);
 		}
-		
+
 	ChatRoomCharacterUpdate(C);
 	CharacterRefresh(C, true);
-	
 
-	
+
+
 	if (CurrentScreen == "ChatRoom")	{
 		var Message;
 		var Dictionary = [
@@ -219,12 +219,12 @@ function InventoryItemNeckFuturisticCollarUnlock(C) {
 	for (let E = C.Appearance.length - 1; E >= 0; E--)
 		if (((C.Appearance[E].Asset.Name.indexOf("Futuristic") >= 0 || C.Appearance[E].Asset.Name.indexOf("Interactive") >= 0 || C.Appearance[E].Asset.Name.indexOf("Electronic") >= 0) && C.Appearance[E].Asset.Group.Name != "ItemNeck") &&
 			(InventoryGetLock(C.Appearance[E]) != null && InventoryItemHasEffect(C.Appearance[E], "Lock", true) && DialogCanUnlock(C, C.Appearance[E]))) {
-				InventoryUnlock(C, C.Appearance[E])
+				InventoryUnlock(C, C.Appearance[E]);
 		}
-	
+
 	ChatRoomCharacterUpdate(C);
 	CharacterRefresh(C, true);
-	
+
 	if (CurrentScreen == "ChatRoom")	{
 		var Message;
 		var Dictionary = [
@@ -233,45 +233,45 @@ function InventoryItemNeckFuturisticCollarUnlock(C) {
 		];
 
 		Message = "FuturisticCollarTriggerUnlock";
-		
+
 		ServerSend("ChatRoomChat", { Content: Message, Type: "Action", Dictionary });
 	}
-	
-	//if (CurrentScreen == "ChatRoom")	
+
+	//if (CurrentScreen == "ChatRoom")
 	// ServerSend("ChatRoomChat", { Content: " 's bindings unlock with a hiss.", Type: "Emote" });
 }
 
 function InventoryItemNeckFuturisticCollarColor(C, Item) {
 	for (let E = C.Appearance.length - 1; E >= 0; E--)
 		if (C.Appearance[E].Asset.Name.indexOf("Futuristic") >= 0 && C.Appearance[E].Asset.Group.Name != "ItemNeck" || C.Appearance[E].Asset.Name.indexOf("Electronic") >= 0) {
-			
+
 			for (let L = C.Appearance[E].Asset.Layer.length - 1; L >= 0; L--) {
-				
+
 				if (C.Appearance[E].Asset.Layer[L].Name != "Light") {
 					if (C.Appearance[E].Asset.Layer[L].Name == "Lock") {
 						if (Item.Color[3] != "Default")
-							C.Appearance[E].Color[L] = Item.Color[3]
+							C.Appearance[E].Color[L] = Item.Color[3];
 						//C.Appearance[E].Asset.Layer[L].ColorIndex = Item.Asset.Layer[2].ColorIndex
 					} else if (C.Appearance[E].Asset.Layer[L].Name == "Display" || C.Appearance[E].Asset.Layer[L].Name == "Screen" || C.Appearance[E].Asset.Layer[L].Name == "Ball") {
 						if (Item.Color[0] != "Default")
-							C.Appearance[E].Color[L] = Item.Color[0]
+							C.Appearance[E].Color[L] = Item.Color[0];
 						//C.Appearance[E].Asset.Layer[L].ColorIndex = Item.Asset.Layer[0].ColorIndex
 					} else if (C.Appearance[E].Asset.Layer[L].Name != "Mesh" && C.Appearance[E].Asset.Layer[L].Name != "Text") {
 						if (Item.Color[1] != "Default")
-							C.Appearance[E].Color[L] = Item.Color[1]
+							C.Appearance[E].Color[L] = Item.Color[1];
 						//C.Appearance[E].Asset.Layer[L].ColorIndex = Item.Asset.Layer[1].ColorIndex
 					} else if (C.Appearance[E].Asset.Layer[L].Name != "Text") {
 						if (Item.Color[2] != "Default")
-							C.Appearance[E].Color[L] = Item.Color[2]
+							C.Appearance[E].Color[L] = Item.Color[2];
 						//C.Appearance[E].Asset.Layer[L].ColorIndex = Item.Asset.Layer[2].ColorIndex
 					}
 				}
 			}
 		}
-	
+
 	ChatRoomCharacterUpdate(C);
 	CharacterRefresh(C, true);
-	
+
 	if (CurrentScreen == "ChatRoom")	{
 		var Message;
 		var Dictionary = [
@@ -280,21 +280,21 @@ function InventoryItemNeckFuturisticCollarColor(C, Item) {
 		];
 
 		Message = "FuturisticCollarTriggerColor";
-		
+
 		ServerSend("ChatRoomChat", { Content: Message, Type: "Action", Dictionary });
 	}
-	
-	//if (CurrentScreen == "ChatRoom")	
+
+	//if (CurrentScreen == "ChatRoom")
 	// ServerSend("ChatRoomChat", { Content: " 's bindings unlock with a hiss.", Type: "Emote" });
 }
 
 function InventoryItemNeckFuturisticCollarTogglePermission(C, Item) {
 	if (Item.Property && Item.Property.OpenPermission != null) {
-		Item.Property.OpenPermission = !Item.Property.OpenPermission
-		
+		Item.Property.OpenPermission = !Item.Property.OpenPermission;
+
 		ChatRoomCharacterUpdate(C);
 		CharacterRefresh(C, true);
-		
+
 		if (CurrentScreen == "ChatRoom")	{
 			var Message;
 			var Dictionary = [
@@ -305,7 +305,7 @@ function InventoryItemNeckFuturisticCollarTogglePermission(C, Item) {
 			Message = "FuturisticCollarSetOpenPermission";
 			if (Item.Property.OpenPermission) Message = Message + "On";
 			else Message = Message + "Off";
-			
+
 			ServerSend("ChatRoomChat", { Content: Message, Type: "Action", Dictionary });
 		}
 	}
@@ -314,15 +314,15 @@ function InventoryItemNeckFuturisticCollarTogglePermission(C, Item) {
 
 function InventoryItemNeckFuturisticCollarToggleRemotes(C, Item) {
 	if (Item.Property && Item.Property.BlockRemotes != null) {
-		Item.Property.BlockRemotes = !Item.Property.BlockRemotes
-		
+		Item.Property.BlockRemotes = !Item.Property.BlockRemotes;
+
 		// Default the previous Property and Type to the first option if not found on the current item
 		var PreviousProperty = DialogFocusItem.Property;
 
 		// Create a new Property object based on the previous one
 		var NewProperty = Object.assign({}, PreviousProperty);
-		
-		
+
+
 		NewProperty.Effect = [];
 
 		// If the item is locked, ensure it has the "Lock" effect
@@ -330,7 +330,7 @@ function InventoryItemNeckFuturisticCollarToggleRemotes(C, Item) {
 			NewProperty.Effect = (NewProperty.Effect || []);
 			NewProperty.Effect.push("Lock");
 		}
-		
+
 		// If the item is locked, ensure it has the "Lock" effect
 		if (Item.Property.BlockRemotes) {
 			NewProperty.Effect = (NewProperty.Effect || []);
@@ -338,11 +338,11 @@ function InventoryItemNeckFuturisticCollarToggleRemotes(C, Item) {
 		}
 
 		DialogFocusItem.Property = NewProperty;
-		
-		
+
+
 		ChatRoomCharacterUpdate(C);
 		CharacterRefresh(C, true);
-		
+
 		if (CurrentScreen == "ChatRoom")	{
 			var Message;
 			var Dictionary = [
@@ -353,7 +353,7 @@ function InventoryItemNeckFuturisticCollarToggleRemotes(C, Item) {
 			Message = "FuturisticCollarSetBlockRemotes";
 			if (Item.Property.BlockRemotes) Message = Message + "On";
 			else Message = Message + "Off";
-			
+
 			ServerSend("ChatRoomChat", { Content: Message, Type: "Action", Dictionary });
 		}
 	}

--- a/BondageClub/Screens/Inventory/ItemPelvis/FuturisticChastityBelt/FuturisticChastityBelt.js
+++ b/BondageClub/Screens/Inventory/ItemPelvis/FuturisticChastityBelt/FuturisticChastityBelt.js
@@ -1,12 +1,12 @@
 "use strict";
-var FuturisticChastityBeltShockCooldownOrgasm = 15000 // 15 sec
+var FuturisticChastityBeltShockCooldownOrgasm = 15000; // 15 sec
 
 var InventoryItemPelvisFuturisticChastityBeltTamperZones = [
 	"ItemPelvis",
 	"ItemButt",
 	"ItemVulva",
-]
-var InventoryItemPelvisFuturisticChastityBeltOptions = [	
+];
+var InventoryItemPelvisFuturisticChastityBeltOptions = [
 	{
 		Name: "OpenBack",
 		Property: {
@@ -34,7 +34,7 @@ var InventoryItemPelvisFuturisticChastityBeltOptions = [
 function InventoryItemPelvisFuturisticChastityBeltLoad() {
 	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
 	if (InventoryItemMouthFuturisticPanelGagValidate(C) !== "") {
-		InventoryItemMouthFuturisticPanelGagLoadAccessDenied()
+		InventoryItemMouthFuturisticPanelGagLoadAccessDenied();
 	} else{
 		if (DialogFocusItem.Property == null) DialogFocusItem.Property = { NextShockTime: 0, PunishStruggle: false , PunishStruggleOther: false , PunishOrgasm: false, ChatMessage: false,  CloseBack: false, };
 		if (DialogFocusItem.Property.NextShockTime == null) DialogFocusItem.Property.NextShockTime = 0;
@@ -48,7 +48,7 @@ function InventoryItemPelvisFuturisticChastityBeltLoad() {
 function InventoryItemPelvisFuturisticChastityBeltDraw() {
 	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
 	if (InventoryItemMouthFuturisticPanelGagValidate(C) !== "") {
-		InventoryItemMouthFuturisticPanelGagDrawAccessDenied()
+		InventoryItemMouthFuturisticPanelGagDrawAccessDenied();
 	} else if (DialogFocusItem && DialogFocusItem.Property) {
 		DrawAssetPreview(1387, 125, DialogFocusItem.Asset);
 
@@ -67,7 +67,7 @@ function InventoryItemPelvisFuturisticChastityBeltDraw() {
 
 		if (DialogFocusItem.Property.Type != null) {
 			DrawButton(1225, 910, 150, 64, DialogFindPlayer("FuturisticChastityBeltOpenBack"), "White", "");
-		} 
+		}
 		if (DialogFocusItem.Property.Type != "OpenFront") {
 			DrawButton(1425, 910, 150, 64, DialogFindPlayer("FuturisticChastityBeltOpenFront"), "White", "");
 		}
@@ -75,33 +75,33 @@ function InventoryItemPelvisFuturisticChastityBeltDraw() {
 			DrawButton(1625, 910, 150, 64, DialogFindPlayer("FuturisticChastityBeltClosedBack"), "White", "");
 		}
 
-		
+
 	}
-	
+
 }
 
 function InventoryItemPelvisFuturisticChastityBeltClick() {
 	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
 	if (InventoryItemMouthFuturisticPanelGagValidate(C) !== "") {
-		InventoryItemMouthFuturisticPanelGagClickAccessDenied()
+		InventoryItemMouthFuturisticPanelGagClickAccessDenied();
 	} else {
-		if (MouseIn(1885, 25, 90, 90)) InventoryItemPelvisFuturisticChastityBeltExit()
-		
+		if (MouseIn(1885, 25, 90, 90)) InventoryItemPelvisFuturisticChastityBeltExit();
+
 		if (MouseIn(1100, 550, 64, 64)) {
-			DialogFocusItem.Property.ChatMessage = !DialogFocusItem.Property.ChatMessage
+			DialogFocusItem.Property.ChatMessage = !DialogFocusItem.Property.ChatMessage;
 		} else if (MouseIn(1100, 620, 64, 64)) {
-			DialogFocusItem.Property.PunishStruggle = !DialogFocusItem.Property.PunishStruggle
-			InventoryItemPelvisFuturisticChastityBeltPublishMode(C, "PunishStruggle", DialogFocusItem.Property.PunishStruggle)
+			DialogFocusItem.Property.PunishStruggle = !DialogFocusItem.Property.PunishStruggle;
+			InventoryItemPelvisFuturisticChastityBeltPublishMode(C, "PunishStruggle", DialogFocusItem.Property.PunishStruggle);
 		} else if (MouseIn(1100, 690, 64, 64)) {
-			DialogFocusItem.Property.PunishStruggleOther = !DialogFocusItem.Property.PunishStruggleOther
-			InventoryItemPelvisFuturisticChastityBeltPublishMode(C, "PunishStruggleOther", DialogFocusItem.Property.PunishStruggleOther)
+			DialogFocusItem.Property.PunishStruggleOther = !DialogFocusItem.Property.PunishStruggleOther;
+			InventoryItemPelvisFuturisticChastityBeltPublishMode(C, "PunishStruggleOther", DialogFocusItem.Property.PunishStruggleOther);
 		} else if (MouseIn(1100, 760, 64, 64)) {
-			DialogFocusItem.Property.PunishOrgasm = !DialogFocusItem.Property.PunishOrgasm
-			InventoryItemPelvisFuturisticChastityBeltPublishMode(C, "PunishOrgasm", DialogFocusItem.Property.PunishOrgasm)
+			DialogFocusItem.Property.PunishOrgasm = !DialogFocusItem.Property.PunishOrgasm;
+			InventoryItemPelvisFuturisticChastityBeltPublishMode(C, "PunishOrgasm", DialogFocusItem.Property.PunishOrgasm);
 		} else if (MouseIn(1200, 910, 600, 64)) {
 			if (MouseIn(1225, 910, 150, 64) && DialogFocusItem.Property.Type != null) {
 				ExtendedItemSetType(C, InventoryItemPelvisFuturisticChastityBeltOptions, InventoryItemPelvisFuturisticChastityBeltOptions[0]);
-			} 
+			}
 			if (MouseIn(1425, 910, 150, 64) && DialogFocusItem.Property.Type != "OpenFront") {
 				ExtendedItemSetType(C, InventoryItemPelvisFuturisticChastityBeltOptions, InventoryItemPelvisFuturisticChastityBeltOptions[1]);
 			}
@@ -109,15 +109,15 @@ function InventoryItemPelvisFuturisticChastityBeltClick() {
 				ExtendedItemSetType(C, InventoryItemPelvisFuturisticChastityBeltOptions, InventoryItemPelvisFuturisticChastityBeltOptions[2]);
 			}
 
-		} 
-		
-		
-		
+		}
+
+
+
 	}
 }
 
 function InventoryItemPelvisFuturisticChastityBeltExit() {
-	InventoryItemMouthFuturisticPanelGagExitAccessDenied()
+	InventoryItemMouthFuturisticPanelGagExitAccessDenied();
 }
 
 function InventoryItemPelvisFuturisticChastityBeltPublishAction(C, Option) {
@@ -128,9 +128,9 @@ function InventoryItemPelvisFuturisticChastityBeltPublishAction(C, Option) {
 		{ Tag: "DestinationCharacter", Text: C.Name, MemberNumber: C.MemberNumber },
 	];
 	ChatRoomPublishCustomAction(msg, true, Dictionary);
-} 
+}
 
-function InventoryItemPelvisFuturisticChastityBeltPublishMode(C, Setting, Active) { 
+function InventoryItemPelvisFuturisticChastityBeltPublishMode(C, Setting, Active) {
 	var msg = "FuturisticChastityBeltSet" + Setting + ((Active) ? "On" : "Off");
 	var Dictionary = [
 		{ Tag: "SourceCharacter", Text: Player.Name, MemberNumber: Player.MemberNumber },
@@ -139,7 +139,7 @@ function InventoryItemPelvisFuturisticChastityBeltPublishMode(C, Setting, Active
 	ChatRoomPublishCustomAction(msg, true, Dictionary);
 }
 
-function InventoryItemPelvisFuturisticChastityBeltValidate(C) { 
+function InventoryItemPelvisFuturisticChastityBeltValidate(C) {
 	return InventoryItemMouthFuturisticPanelGagValidate(C, Option); // All futuristic items refer to the gag
 }
 
@@ -150,18 +150,18 @@ function InventoryItemPelvisFuturisticChastityBeltNpcDialog(C, Option) { Invento
 
 
 function AssetsItemPelvisFuturisticChastityBeltScriptUpdatePlayer(data) {
-	var Item = data.Item
+	var Item = data.Item;
 	// Punish the player if they try to mess with the groin area
 	if (Item.Property.PunishStruggle && Player.FocusGroup && (StruggleProgress >= 0 || StruggleLockPickProgressCurrentTries > 0) && StruggleProgressPrevItem != null && StruggleProgressStruggleCount > 0) {
-		var inFocus = false
+		var inFocus = false;
 		for (var Z = 0; Z < InventoryItemPelvisFuturisticChastityBeltTamperZones.length; Z++)
 			if (Player.FocusGroup.Name == InventoryItemPelvisFuturisticChastityBeltTamperZones[Z])
-				inFocus = true
-		
+				inFocus = true;
+
 		if (inFocus) {
-			AssetsItemPelvisFuturisticChastityBeltScriptTrigger(Player, Item, "Struggle")
-			StruggleProgressStruggleCount = 0
-			DialogLeaveDueToItem = true
+			AssetsItemPelvisFuturisticChastityBeltScriptTrigger(Player, Item, "Struggle");
+			StruggleProgressStruggleCount = 0;
+			DialogLeaveDueToItem = true;
 			/*var vol = 1
 			if (Player.AudioSettings && Player.AudioSettings.Volume) {
 				vol = Player.AudioSettings.Volume
@@ -171,18 +171,18 @@ function AssetsItemPelvisFuturisticChastityBeltScriptUpdatePlayer(data) {
 	}
 	// Punish the player if they struggle anywhere
 	if (Item.Property.PunishStruggleOther && Player.FocusGroup && StruggleProgressPrevItem != null && StruggleProgressStruggleCount > 0 && (StruggleProgress > 50 || StruggleLockPickProgressCurrentTries > 2)) {
-		AssetsItemPelvisFuturisticChastityBeltScriptTrigger(Player, Item, "StruggleOther")
-		StruggleProgressStruggleCount = 0
-		StruggleProgress = 0
-		DialogLeaveDueToItem = true
+		AssetsItemPelvisFuturisticChastityBeltScriptTrigger(Player, Item, "StruggleOther");
+		StruggleProgressStruggleCount = 0;
+		StruggleProgress = 0;
+		DialogLeaveDueToItem = true;
 
 	}
-		
+
 	if (Item.Property.NextShockTime - CurrentTime <= 0) {
 		// Punish the player if they orgasm
 		if (Item.Property.PunishOrgasm && Player.ArousalSettings && Player.ArousalSettings.OrgasmStage > 1) {
-			AssetsItemPelvisFuturisticChastityBeltScriptTrigger(Player, Item, "Orgasm")
-			Item.Property.NextShockTime = CurrentTime + FuturisticChastityBeltShockCooldownOrgasm // Difficult to have two orgasms in 10 seconds
+			AssetsItemPelvisFuturisticChastityBeltScriptTrigger(Player, Item, "Orgasm");
+			Item.Property.NextShockTime = CurrentTime + FuturisticChastityBeltShockCooldownOrgasm; // Difficult to have two orgasms in 10 seconds
 			/*var vol = 1
 			if (Player.AudioSettings && Player.AudioSettings.Volume) {
 				vol = Player.AudioSettings.Volume
@@ -191,9 +191,9 @@ function AssetsItemPelvisFuturisticChastityBeltScriptUpdatePlayer(data) {
 		}
 	}
 }
-		
+
 // Trigger a shock automatically
-function AssetsItemPelvisFuturisticChastityBeltScriptTrigger(C, Item, ShockType) { 
+function AssetsItemPelvisFuturisticChastityBeltScriptTrigger(C, Item, ShockType) {
 
 	if (!(CurrentScreen == "ChatRoom")) {
 		AudioPlayInstantSound("Audio/Shocks.mp3");
@@ -209,7 +209,7 @@ function AssetsItemPelvisFuturisticChastityBeltScriptTrigger(C, Item, ShockType)
 			Dictionary.push({ AssetName: Item.Asset.Name });
 			Dictionary.push({ AssetGroupName: Item.Asset.Group.Name });
 			Dictionary.push({ Automatic: true });
-				
+
 			ServerSend("ChatRoomChat", { Content: "FuturisticChastityBeltShock" + ShockType, Type: "Action", Dictionary });
 		}
 	}
@@ -227,12 +227,12 @@ function AssetsItemPelvisFuturisticChastityBeltScriptDraw(data) {
 	if (typeof persistentData.LastMessageLen !== "number") persistentData.LastMessageLen = (ChatRoomLastMessage) ? ChatRoomLastMessage.length : 0;
 
 	if (persistentData.UpdateTime < CommonTime() && data.C == Player) {
-		
+
 		if (CommonTime() > property.NextShockTime) {
-			AssetsItemPelvisFuturisticChastityBeltScriptUpdatePlayer(data)
+			AssetsItemPelvisFuturisticChastityBeltScriptUpdatePlayer(data);
 			persistentData.LastMessageLen = (ChatRoomLastMessage) ? ChatRoomLastMessage.length : 0;
 		}
-		
+
 		var timeToNextRefresh = 950;
 		persistentData.UpdateTime = CommonTime() + timeToNextRefresh;
 		AnimationRequestRefreshRate(data.C, 5000 - timeToNextRefresh);

--- a/BondageClub/Screens/Inventory/ItemPelvis/FuturisticChastityBelt2/FuturisticChastityBelt2.js
+++ b/BondageClub/Screens/Inventory/ItemPelvis/FuturisticChastityBelt2/FuturisticChastityBelt2.js
@@ -1,24 +1,24 @@
 "use strict";
 
 function InventoryItemPelvisFuturisticChastityBelt2Load() {
-	InventoryItemPelvisFuturisticChastityBeltLoad()
+	InventoryItemPelvisFuturisticChastityBeltLoad();
 }
 
 function InventoryItemPelvisFuturisticChastityBelt2Draw() {
-	InventoryItemPelvisFuturisticChastityBeltDraw()
-	
+	InventoryItemPelvisFuturisticChastityBeltDraw();
+
 }
 
 function InventoryItemPelvisFuturisticChastityBelt2Click() {
-	InventoryItemPelvisFuturisticChastityBeltClick()
+	InventoryItemPelvisFuturisticChastityBeltClick();
 }
 
 function InventoryItemPelvisFuturisticChastityBelt2Exit() {
-	InventoryItemPelvisFuturisticChastityBeltExit()
+	InventoryItemPelvisFuturisticChastityBeltExit();
 }
 
 
-function InventoryItemPelvisFuturisticChastityBelt2Validate(C) { 
+function InventoryItemPelvisFuturisticChastityBelt2Validate(C) {
 	return InventoryItemPelvisFuturisticChastityBeltValidate(C);
 }
 
@@ -26,12 +26,12 @@ function InventoryItemPelvisFuturisticChastityBelt2NpcDialog(C, Option) { Invent
 
 
 function AssetsItemPelvisFuturisticChastityBelt2ScriptUpdatePlayer(data) {
-	AssetsItemPelvisFuturisticChastityBeltScriptUpdatePlayer(data)
+	AssetsItemPelvisFuturisticChastityBeltScriptUpdatePlayer(data);
 }
-		
+
 // Update data
 function AssetsItemPelvisFuturisticChastityBelt2ScriptDraw(data) {
-	AssetsItemPelvisFuturisticChastityBeltScriptDraw(data) 
+	AssetsItemPelvisFuturisticChastityBeltScriptDraw(data);
 }
 
 function InventoryItemPelvisFuturisticChastityBelt2PublishAction(C, Option) {
@@ -42,4 +42,4 @@ function InventoryItemPelvisFuturisticChastityBelt2PublishAction(C, Option) {
 		{ Tag: "DestinationCharacter", Text: C.Name, MemberNumber: C.MemberNumber },
 	];
 	ChatRoomPublishCustomAction(msg, true, Dictionary);
-} 
+}

--- a/BondageClub/Screens/Inventory/ItemTorso/FuturisticHarness/FuturisticHarness.js
+++ b/BondageClub/Screens/Inventory/ItemTorso/FuturisticHarness/FuturisticHarness.js
@@ -13,13 +13,13 @@ var InventoryItemTorsoFuturisticHarnessOptions = [
 		Name: "Lower",
 		Property: { Type: "Lower", Difficulty: 0},
 	},
-]
+];
 
 // Loads the item extension properties
 function InventoryItemTorsoFuturisticHarnessLoad() {
 	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
 	if (InventoryItemMouthFuturisticPanelGagValidate(C) !== "") {
-		InventoryItemMouthFuturisticPanelGagLoadAccessDenied()
+		InventoryItemMouthFuturisticPanelGagLoadAccessDenied();
 	}  else
 		ExtendedItemLoad(InventoryItemTorsoFuturisticHarnessOptions, "FuturisticHarnessType");
 }
@@ -28,14 +28,14 @@ function InventoryItemTorsoFuturisticHarnessLoad() {
 function InventoryItemTorsoFuturisticHarnessDraw() {
 	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
 	if (InventoryItemMouthFuturisticPanelGagValidate(C) !== "") {
-		InventoryItemMouthFuturisticPanelGagDrawAccessDenied()
+		InventoryItemMouthFuturisticPanelGagDrawAccessDenied();
 	} else {
 		ExtendedItemDraw(InventoryItemTorsoFuturisticHarnessOptions, "FuturisticHarnessType");
-		
+
 		DrawAssetPreview(1387, 75, DialogFocusItem.Asset);
-		
-		var FuturisticCollarItems = InventoryItemNeckFuturisticCollarGetItems(C)
-		
+
+		var FuturisticCollarItems = InventoryItemNeckFuturisticCollarGetItems(C);
+
 		if (FuturisticCollarItems.length > 0) {
 			DrawButton(1400, 910, 200, 55, DialogFindPlayer("FuturisticCollarColor"), "White");
 		}
@@ -56,16 +56,16 @@ function InventoryItemTorsoFuturisticHarnessPublishAction(C, Option) {
 function InventoryItemTorsoFuturisticHarnessClick() {
 	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
 	if (InventoryItemMouthFuturisticPanelGagValidate(C) !== "") {
-		InventoryItemMouthFuturisticPanelGagClickAccessDenied()
+		InventoryItemMouthFuturisticPanelGagClickAccessDenied();
 	} else {
-		
+
 		ExtendedItemClick(InventoryItemTorsoFuturisticHarnessOptions);
-		
-		var FuturisticCollarItems = InventoryItemNeckFuturisticCollarGetItems(C)
+
+		var FuturisticCollarItems = InventoryItemNeckFuturisticCollarGetItems(C);
 		if (MouseIn(1400, 910, 200, 55) && FuturisticCollarItems.length > 0 && DialogFocusItem) { InventoryItemNeckFuturisticCollarColor(C, DialogFocusItem); InventoryItemTorsoFuturisticHarnessExit();}
 	}
 }
 
 function InventoryItemTorsoFuturisticHarnessExit() {
-	InventoryItemMouthFuturisticPanelGagExitAccessDenied()
+	InventoryItemMouthFuturisticPanelGagExitAccessDenied();
 }

--- a/BondageClub/Screens/Inventory/ItemVulva/FuturisticVibrator/FuturisticVibrator.js
+++ b/BondageClub/Screens/Inventory/ItemVulva/FuturisticVibrator/FuturisticVibrator.js
@@ -1,18 +1,18 @@
 "use strict";
 
-var ItemVulvaFuturisticVibratorTriggers = ["Increase", "Decrease", "Disable", "Edge", "Random", "Deny", "Tease", "Shock"]
-var ItemVulvaFuturisticVibratorTriggerValues = []
+var ItemVulvaFuturisticVibratorTriggers = ["Increase", "Decrease", "Disable", "Edge", "Random", "Deny", "Tease", "Shock"];
+var ItemVulvaFuturisticVibratorTriggerValues = [];
 var FuturisticVibratorCheckChatTime = 1000; // Checks chat every 1 sec
 
 function InventoryItemVulvaFuturisticVibratorLoad() {
 	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
 	if (InventoryItemMouthFuturisticPanelGagValidate(C) !== "") {
-		InventoryItemMouthFuturisticPanelGagLoadAccessDenied()
+		InventoryItemMouthFuturisticPanelGagLoadAccessDenied();
 	} else {
 		VibratorModeLoad([VibratorModeSet.ADVANCED, VibratorModeSet.STANDARD]);
 		if ((DialogFocusItem != null) && (DialogFocusItem.Property != null) && (DialogFocusItem.Property.TriggerValues == null)) DialogFocusItem.Property.TriggerValues = CommonConvertArrayToString(ItemVulvaFuturisticVibratorTriggers);
 
-		ItemVulvaFuturisticVibratorTriggerValues = DialogFocusItem.Property.TriggerValues.split(',')
+		ItemVulvaFuturisticVibratorTriggerValues = DialogFocusItem.Property.TriggerValues.split(',');
 
 		// Only create the inputs if the zone isn't blocked
 		ItemVulvaFuturisticVibratorTriggers.forEach((trigger, i) => {
@@ -25,7 +25,7 @@ function InventoryItemVulvaFuturisticVibratorLoad() {
 function InventoryItemVulvaFuturisticVibratorDraw() {
 	var C = CharacterGetCurrent();
 	if (InventoryItemMouthFuturisticPanelGagValidate(C) !== "") {
-		InventoryItemMouthFuturisticPanelGagDrawAccessDenied()
+		InventoryItemMouthFuturisticPanelGagDrawAccessDenied();
 	} else {
 		// Draw the preview & current mode
 		DrawAssetPreview(1387, 50, DialogFocusItem.Asset);
@@ -45,7 +45,7 @@ function InventoryItemVulvaFuturisticVibratorDraw() {
 
 function InventoryItemVulvaFuturisticVibratorClick() {
 	var C = CharacterGetCurrent();
-	if (InventoryItemMouthFuturisticPanelGagValidate(C) !== "") InventoryItemMouthFuturisticPanelGagClickAccessDenied()
+	if (InventoryItemMouthFuturisticPanelGagValidate(C) !== "") InventoryItemMouthFuturisticPanelGagClickAccessDenied();
 	else if (MouseIn(1885, 25, 90, 90)) InventoryItemVulvaFuturisticVibratorExit();
 	else if (MouseIn(1325, 450 + 60 * ItemVulvaFuturisticVibratorTriggers.length, 350, 64)) InventoryItemVulvaFuturisticVibratorClickSet();
 }
@@ -53,16 +53,16 @@ function InventoryItemVulvaFuturisticVibratorClick() {
 
 function InventoryItemVulvaFuturisticVibratorClickSet() {
 	if ((DialogFocusItem != null) && (DialogFocusItem.Property != null)) {
-		var ItemVulvaFuturisticVibratorTriggerValuesTemp = []
+		var ItemVulvaFuturisticVibratorTriggerValuesTemp = [];
 		for (let I = 0; I < ItemVulvaFuturisticVibratorTriggers.length; I++) {
 			ItemVulvaFuturisticVibratorTriggerValuesTemp.push((ElementValue("FuturisticVibe" + ItemVulvaFuturisticVibratorTriggers[I]) != "") ? ElementValue("FuturisticVibe" + ItemVulvaFuturisticVibratorTriggers[I])
-				: ItemVulvaFuturisticVibratorTriggerValues[I])
+				: ItemVulvaFuturisticVibratorTriggerValues[I]);
 		}
-		
-		ItemVulvaFuturisticVibratorTriggerValues = ItemVulvaFuturisticVibratorTriggerValuesTemp
-		
-		var temp = CommonConvertArrayToString(ItemVulvaFuturisticVibratorTriggerValues)
-		
+
+		ItemVulvaFuturisticVibratorTriggerValues = ItemVulvaFuturisticVibratorTriggerValuesTemp;
+
+		var temp = CommonConvertArrayToString(ItemVulvaFuturisticVibratorTriggerValues);
+
 		if (temp != "" && typeof temp === "string") {
 			DialogFocusItem.Property.TriggerValues = temp;
 			if (CurrentScreen == "ChatRoom") {
@@ -74,22 +74,22 @@ function InventoryItemVulvaFuturisticVibratorClickSet() {
 			}
 			InventoryItemVulvaFuturisticVibratorExit();
 		}
-		
-		
+
+
 	}
 }
 
 function InventoryItemVulvaFuturisticVibratorExit() {
-	InventoryItemMouthFuturisticPanelGagExitAccessDenied()
+	InventoryItemMouthFuturisticPanelGagExitAccessDenied();
 	for (let I = 0; I <= ItemVulvaFuturisticVibratorTriggers.length; I++)
 		ElementRemove("FuturisticVibe" + ItemVulvaFuturisticVibratorTriggers[I]);
 }
 
 function InventoryItemVulvaFuturisticVibratorDetectMsg(msg, TriggerValues) {
 	for (let I = 0; I < TriggerValues.length; I++) {
-		if (msg.indexOf('(') != 0 && msg.includes(TriggerValues[I].toUpperCase())) return ItemVulvaFuturisticVibratorTriggers[I]
+		if (msg.indexOf('(') != 0 && msg.includes(TriggerValues[I].toUpperCase())) return ItemVulvaFuturisticVibratorTriggers[I];
 	}
-	return ""
+	return "";
 }
 
 function InventoryItemVulvaFuturisticVibratorGetMode(Item, Increase) {
@@ -97,7 +97,7 @@ function InventoryItemVulvaFuturisticVibratorGetMode(Item, Increase) {
 	if (Item.Property.Mode == VibratorMode.HIGH) return (Increase ? VibratorMode.MAXIMUM : VibratorMode.MEDIUM);
 	if (Item.Property.Mode == VibratorMode.MEDIUM) return (Increase ? VibratorMode.HIGH : VibratorMode.LOW);
 	if (Item.Property.Mode == VibratorMode.LOW) return (Increase ? VibratorMode.MEDIUM : VibratorMode.OFF);
-	
+
 	return (Increase ? ((Item.Property.Mode == VibratorMode.OFF) ? VibratorMode.LOW : VibratorMode.MAXIMUM ): VibratorMode.LOW);
 }
 
@@ -129,21 +129,21 @@ function InventoryItemVulvaFuturisticVibratorSetMode(C, Item, Option) {
 }
 
 // Trigger a shock automatically
-function InventoryItemVulvaFuturisticVibratorTriggerShock(C, Item) { 
-	
+function InventoryItemVulvaFuturisticVibratorTriggerShock(C, Item) {
+
 	if (CurrentScreen == "ChatRoom") {
 			var Dictionary = [];
 			Dictionary.push({ Tag: "DestinationCharacterName", Text: C.Name, MemberNumber: C.MemberNumber });
 			Dictionary.push({ Tag: "AssetName", AssetName: Item.Asset.Name});
-	
+
 			ServerSend("ChatRoomChat", { Content: "FuturisticVibratorShockTrigger", Type: "Action", Dictionary });
 	}
-	
+
 	CharacterSetFacialExpression(C, "Eyebrows", "Soft", 10);
 	CharacterSetFacialExpression(C, "Blush", "Soft", 15);
 	CharacterSetFacialExpression(C, "Eyes", "Closed", 5);
 }
-	
+
 
 function InventoryItemVulvaFuturisticVibratorHandleChat(C, Item, LastTime) {
 	if (!Item) return;
@@ -152,22 +152,22 @@ function InventoryItemVulvaFuturisticVibratorHandleChat(C, Item, LastTime) {
 	if (!TriggerValues) TriggerValues = ItemVulvaFuturisticVibratorTriggers;
 	for (let CH = 0; CH < ChatRoomChatLog.length; CH++) {
 		if (ChatRoomChatLog[CH].Time > LastTime) {
-			var msg = InventoryItemVulvaFuturisticVibratorDetectMsg(ChatRoomChatLog[CH].Chat.toUpperCase(), TriggerValues)
-			
+			var msg = InventoryItemVulvaFuturisticVibratorDetectMsg(ChatRoomChatLog[CH].Chat.toUpperCase(), TriggerValues);
+
 			if (msg != "") {
-				if (msg == "Edge") InventoryItemVulvaFuturisticVibratorSetMode(C, Item, VibratorModeGetOption(VibratorMode.EDGE))
-				if (msg == "Deny") InventoryItemVulvaFuturisticVibratorSetMode(C, Item, VibratorModeGetOption(VibratorMode.DENY))
-				if (msg == "Tease") InventoryItemVulvaFuturisticVibratorSetMode(C, Item, VibratorModeGetOption(VibratorMode.TEASE))
-				if (msg == "Random") InventoryItemVulvaFuturisticVibratorSetMode(C, Item, VibratorModeGetOption(VibratorMode.RANDOM))
-				if (msg == "Disable") InventoryItemVulvaFuturisticVibratorSetMode(C, Item, VibratorModeGetOption(VibratorMode.OFF))
-				if (msg == "Shock") InventoryItemVulvaFuturisticVibratorTriggerShock(C, Item)
-				if (msg == "Increase") InventoryItemVulvaFuturisticVibratorSetMode(C, Item, VibratorModeGetOption(InventoryItemVulvaFuturisticVibratorGetMode(Item, true)))
-				if (msg == "Decrease") InventoryItemVulvaFuturisticVibratorSetMode(C, Item, VibratorModeGetOption(InventoryItemVulvaFuturisticVibratorGetMode(Item, false)))
+				if (msg == "Edge") InventoryItemVulvaFuturisticVibratorSetMode(C, Item, VibratorModeGetOption(VibratorMode.EDGE));
+				if (msg == "Deny") InventoryItemVulvaFuturisticVibratorSetMode(C, Item, VibratorModeGetOption(VibratorMode.DENY));
+				if (msg == "Tease") InventoryItemVulvaFuturisticVibratorSetMode(C, Item, VibratorModeGetOption(VibratorMode.TEASE));
+				if (msg == "Random") InventoryItemVulvaFuturisticVibratorSetMode(C, Item, VibratorModeGetOption(VibratorMode.RANDOM));
+				if (msg == "Disable") InventoryItemVulvaFuturisticVibratorSetMode(C, Item, VibratorModeGetOption(VibratorMode.OFF));
+				if (msg == "Shock") InventoryItemVulvaFuturisticVibratorTriggerShock(C, Item);
+				if (msg == "Increase") InventoryItemVulvaFuturisticVibratorSetMode(C, Item, VibratorModeGetOption(InventoryItemVulvaFuturisticVibratorGetMode(Item, true)));
+				if (msg == "Decrease") InventoryItemVulvaFuturisticVibratorSetMode(C, Item, VibratorModeGetOption(InventoryItemVulvaFuturisticVibratorGetMode(Item, false)));
 			}
-			
+
 		}
 	}
-	
+
 }
 
 function AssetsItemVulvaFuturisticVibratorScriptDraw(data) {
@@ -176,14 +176,14 @@ function AssetsItemVulvaFuturisticVibratorScriptDraw(data) {
 	var Item = data.Item;
 	// Only run updates on the player and NPCs
 	if (C.ID !== 0 && C.MemberNumber !== null) return;
-	
+
 	if (typeof PersistentData.CheckTime !== "number") PersistentData.CheckTime = CommonTime() + FuturisticVibratorCheckChatTime;
 
 	if (CommonTime() > PersistentData.CheckTime) {
-		InventoryItemVulvaFuturisticVibratorHandleChat(C, Item, PersistentData.CheckTime - FuturisticVibratorCheckChatTime)
-		
+		InventoryItemVulvaFuturisticVibratorHandleChat(C, Item, PersistentData.CheckTime - FuturisticVibratorCheckChatTime);
+
 		PersistentData.CheckTime = CommonTime() + FuturisticVibratorCheckChatTime;
 	}
-	
+
 	VibratorModeScriptDraw(data);
 }


### PR DESCRIPTION
This PR has no functional effect, it only:
- Removes spaces and tabs on end of lines, where they have no effect (trailing whitespace)
- Add semicolons to where they should be

To keep this cleanup small, this part only focuses on files in `Screens/Inventory/` and only on futuristic items.