### PR TITLE
Cleanup: Scripts formatting (Part 9 - `Screens/Inventory/*` - rest)

### DIFF
--- a/BondageClub/Screens/Inventory/ItemHood/OldGasMask/OldGasMask.js
+++ b/BondageClub/Screens/Inventory/ItemHood/OldGasMask/OldGasMask.js
@@ -36,7 +36,7 @@ function InventoryItemHoodOldGasMaskDraw() {
 	DrawButton(1250, 760, 200, 55, DialogFindPlayer("OldGasMaskLensesRebreather"), itemBlocked || lensesRebreatherIsBlocked ? "#888" : "White");
 
 	// Draw the message if the player is wearing an addon
-	if (tube1IsBlocked || tube2IsBlocked || lensesIsBlocked || rebreatherIsBlocked || lensesTube1IsBlocked || lensesTube2IsBlocked || lensesRebreatherIsBlocked) { 
+	if (tube1IsBlocked || tube2IsBlocked || lensesIsBlocked || rebreatherIsBlocked || lensesTube1IsBlocked || lensesTube2IsBlocked || lensesRebreatherIsBlocked) {
 		DrawTextWrap(DialogFindPlayer("ItemAddonsSomeWrongPermissions"), 1100, 850, 800, 160, "White");
 	}
 }
@@ -45,10 +45,10 @@ function InventoryItemHoodOldGasMaskDraw() {
 function InventoryItemHoodOldGasMaskClick() {
 	var C = CharacterGetCurrent();
 	var itemBlocked = InventoryGet(C, "ItemHoodAddon") != null;
-	
+
 	if ((MouseX >= 1885) && (MouseX <= 1975) && (MouseY >= 25) && (MouseY <= 110)) DialogFocusItem = null;
 	if ((MouseX >= 1885) && (MouseX <= 1975) && (MouseY >= 25) && (MouseY <= 110)) DialogFocusItem = null;
-	
+
 	if (MouseIn(1250, 520, 200, 55) && !itemBlocked) InventoryItemHoodOldGasMaskSetItem("OldGasMaskLenses");
 	if (MouseIn(1550, 520, 200, 55) && !itemBlocked) InventoryItemHoodOldGasMaskSetItem("OldGasMaskTube1");
 	if (MouseIn(1250, 600, 200, 55) && !itemBlocked) InventoryItemHoodOldGasMaskSetItem("OldGasMaskRebreather");
@@ -56,7 +56,7 @@ function InventoryItemHoodOldGasMaskClick() {
 	if (MouseIn(1250, 680, 200, 55) && !itemBlocked) InventoryItemHoodOldGasMaskSetItem("OldGasMaskLensesTube1");
 	if (MouseIn(1550, 680, 200, 55) && !itemBlocked) InventoryItemHoodOldGasMaskSetItem("OldGasMaskLensesTube2");
 	if (MouseIn(1250, 760, 200, 55) && !itemBlocked) InventoryItemHoodOldGasMaskSetItem("OldGasMaskLensesRebreather");
-	
+
 }
 
 // Sets the lenses
@@ -72,11 +72,11 @@ function InventoryItemHoodOldGasMaskSetItem(itemName) {
 	var item = InventoryItemCreate(C, "ItemHoodAddon", itemName);
 	// Do not continue if the item is blocked by permissions
 	if (InventoryBlockedOrLimited(C, item)) return;
-	
+
 	// Wear the item
 	InventoryWear(C, itemName, "ItemHoodAddon", DialogColorSelect);
 	DialogFocusItem = InventoryGet(C, "ItemHoodAddon");
-	
+
 	// Refreshes the character and chatroom
 	CharacterRefresh(C);
 	CharacterLoadEffect(C);

--- a/BondageClub/Screens/Inventory/ItemMisc/HighSecurityPadlock/HighSecurityPadlock.js
+++ b/BondageClub/Screens/Inventory/ItemMisc/HighSecurityPadlock/HighSecurityPadlock.js
@@ -1,15 +1,15 @@
 "use strict";
 
-var InventoryItemMiscHighSecurityPadlockPlayerCanUnlock = true
-var HighSecurityPadlockConfigOwner = true
-var HighSecurityPadlockConfigLover = true
-var HighSecurityPadlockConfigWhitelist = false
+var InventoryItemMiscHighSecurityPadlockPlayerCanUnlock = true;
+var HighSecurityPadlockConfigOwner = true;
+var HighSecurityPadlockConfigLover = true;
+var HighSecurityPadlockConfigWhitelist = false;
 
 
 // Loads the item extension properties
 function InventoryItemMiscHighSecurityPadlockLoad() {
 	var C = CharacterGetCurrent();
-	InventoryItemMiscHighSecurityPadlockPlayerCanUnlock = true
+	InventoryItemMiscHighSecurityPadlockPlayerCanUnlock = true;
 	if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property == null)) DialogFocusSourceItem.Property = {};
 	if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property != null) && (DialogFocusSourceItem.Property.MemberNumberListKeys == null))
 		DialogFocusSourceItem.Property.MemberNumberListKeys = "" + (DialogFocusSourceItem.Property.LockMemberNumber) ? DialogFocusSourceItem.Property.LockMemberNumber : "";
@@ -23,9 +23,9 @@ function InventoryItemMiscHighSecurityPadlockLoad() {
 				document.getElementById("MemberNumberList").setAttribute("autocomplete", "off");
 				ElementValue("MemberNumberList", DialogFocusSourceItem.Property.MemberNumberListKeys);
 			}
-			
+
 			if (!InventoryItemMiscHighSecurityPadlockPlayerHasKeys(C, DialogFocusItem)) {
-				InventoryItemMiscHighSecurityPadlockPlayerCanUnlock = false
+				InventoryItemMiscHighSecurityPadlockPlayerCanUnlock = false;
 			}
 		}
 	}
@@ -44,7 +44,7 @@ function InventoryItemMiscHighSecurityPadlockPlayerHasKeys(C, Item) {
 				return true;
 			} else return true;
 		}
-	return true
+	return true;
 }
 
 // Draw the extension screen
@@ -54,19 +54,19 @@ function InventoryItemMiscHighSecurityPadlockDraw() {
 	DrawAssetPreview(1387, 225, DialogFocusItem.Asset);
 	if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property != null) && (DialogFocusSourceItem.Property.LockMemberNumber != null))
 		DrawText(DialogFindPlayer("LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 650, "white", "gray");
-	
+
 	if (!InventoryGroupIsBlocked(C, C.FocusGroup.Name)&& (DialogFocusSourceItem != null && ((DialogFocusSourceItem.Property.MemberNumberListKeys && CommonConvertStringToArray("" + DialogFocusSourceItem.Property.MemberNumberListKeys).indexOf(Player.MemberNumber) >= 0)))) {
 		DrawText(DialogFindPlayer("HighSecuritySaveIntro"), 1500, 600, "white", "gray");
 		ElementPosition("MemberNumberList", 1260, 780, 300, 170);
 		DrawButton(1135, 920, 230, 64, DialogFindPlayer("HighSecuritySave"), "White", "");
-		
+
 		MainCanvas.textAlign = "left";
 		DrawCheckboxColor(1450, 700, 64, 64, DialogFindPlayer("HighSecurityAppendOwner"), HighSecurityPadlockConfigOwner, "White");
 		DrawCheckboxColor(1450, 780, 64, 64, DialogFindPlayer("HighSecurityAppendLover"), HighSecurityPadlockConfigLover, "White");
 		DrawCheckboxColor(1450, 860, 64, 64, DialogFindPlayer("HighSecurityAppendWhitelist"), HighSecurityPadlockConfigWhitelist, "White");
 		MainCanvas.textAlign = "center";
 
-		
+
 		if (!InventoryItemMiscHighSecurityPadlockPlayerCanUnlock) {
 			DrawText(DialogFindPlayer("HighSecurityWarning"), 1500, 550, "red", "gray");
 		}
@@ -81,16 +81,16 @@ function InventoryItemMiscHighSecurityPadlockClick() {
 	if (!InventoryGroupIsBlocked(C, C.FocusGroup.Name)&& (DialogFocusSourceItem != null && ((DialogFocusSourceItem.Property.MemberNumberListKeys && CommonConvertStringToArray("" + DialogFocusSourceItem.Property.MemberNumberListKeys).indexOf(Player.MemberNumber) >= 0)))) {
 		if (MouseIn(1135, 920, 230, 64)) {
 			if (DialogFocusSourceItem != null && DialogFocusSourceItem.Property != null) {
-				var list = CommonConvertStringToArray("" + ElementValue("MemberNumberList").trim())
+				var list = CommonConvertStringToArray("" + ElementValue("MemberNumberList").trim());
 				if (!InventoryItemMiscHighSecurityPadlockPlayerCanUnlock && list.length > 1 && list.indexOf(Player.MemberNumber) >= 0 ) {
 					list = list.filter(x => x !== Player.MemberNumber);
 				}
-				
+
 				for (let A = 0; A < C.Appearance.length; A++) {
 					if (C.Appearance[A].Asset.Group.Name == C.FocusGroup.Name)
 						C.Appearance[A] = DialogFocusSourceItem;
 				}
-				
+
 				if (HighSecurityPadlockConfigOwner && Player.Ownership && Player.Ownership.MemberNumber != null && list.indexOf(Player.Ownership.MemberNumber) < 0) {
 					list.push(Player.Ownership.MemberNumber);
 				}
@@ -104,14 +104,14 @@ function InventoryItemMiscHighSecurityPadlockClick() {
 				if (HighSecurityPadlockConfigWhitelist && Player.WhiteList) {
 					for (let L = 0; L < Player.WhiteList.length; L++) {
 						if (list.indexOf(Player.WhiteList[L]) < 0)
-							list.push(Player.WhiteList[L])
+							list.push(Player.WhiteList[L]);
 					}
 				}
-				
-				DialogFocusSourceItem.Property.MemberNumberListKeys = "" + 
-					CommonConvertArrayToString(list) // Convert to array and back; can only save strings on server
+
+				DialogFocusSourceItem.Property.MemberNumberListKeys = "" +
+					CommonConvertArrayToString(list); // Convert to array and back; can only save strings on server
 				ElementValue("MemberNumberList", DialogFocusSourceItem.Property.MemberNumberListKeys);
-				
+
 				if (CurrentScreen == "ChatRoom") {
 					var Dictionary = [];
 					Dictionary.push({Tag: "SourceCharacter", Text: Player.Name, MemberNumber: Player.MemberNumber});
@@ -125,19 +125,19 @@ function InventoryItemMiscHighSecurityPadlockClick() {
 					InventoryItemMiscHighSecurityPadlockExit();
 				}
 			}
-			
-			
+
+
 			return;
 		}
 		if (MouseIn(1450, 700, 64, 64)) {HighSecurityPadlockConfigOwner = !HighSecurityPadlockConfigOwner; return;}
 		if (MouseIn(1450, 780, 64, 64)) {HighSecurityPadlockConfigLover = !HighSecurityPadlockConfigLover; return;}
 		if (MouseIn(1450, 860, 64, 64)) {HighSecurityPadlockConfigWhitelist = !HighSecurityPadlockConfigWhitelist; return;}
 	}
-	if ((MouseX >= 1885) && (MouseX <= 1975) && (MouseY >= 25) && (MouseY <= 110)) InventoryItemMiscHighSecurityPadlockExit()
-	
+	if ((MouseX >= 1885) && (MouseX <= 1975) && (MouseY >= 25) && (MouseY <= 110)) InventoryItemMiscHighSecurityPadlockExit();
 
-	
-	
+
+
+
 }
 
 

--- a/BondageClub/Screens/Inventory/ItemMisc/PasswordPadlock/PasswordPadlock.js
+++ b/BondageClub/Screens/Inventory/ItemMisc/PasswordPadlock/PasswordPadlock.js
@@ -10,7 +10,7 @@ function InventoryItemMiscPasswordPadlockLoad() {
 
 	// Only create the inputs if the zone isn't blocked
 	if (!InventoryGroupIsBlocked(C, C.FocusGroup.Name)) {
-		if (DialogFocusSourceItem.Property && (DialogFocusSourceItem.Property.LockSet || 
+		if (DialogFocusSourceItem.Property && (DialogFocusSourceItem.Property.LockSet ||
 		(DialogFocusSourceItem.Property.LockMemberNumber && DialogFocusSourceItem.Property.LockMemberNumber != Player.MemberNumber))) {
 			// Normal lock interface
 			ElementCreateInput("Password", "text", "", "8");
@@ -25,8 +25,8 @@ function InventoryItemMiscPasswordPadlockLoad() {
 			document.getElementById("SetPassword").placeholder = DialogFocusSourceItem.Property.Password;
 			document.getElementById("SetHint").placeholder = DialogFocusSourceItem.Property.Hint;
 		}
-		
-		
+
+
 	}
 }
 
@@ -41,7 +41,7 @@ function InventoryItemMiscPasswordPadlockDraw() {
 		// If the zone is blocked, just display some text informing the player that they can't access the lock
 		DrawText(DialogFindPlayer("LockZoneBlocked"), 1500, 800, "white", "gray");
 	} else {
-		if (DialogFocusSourceItem.Property && (DialogFocusSourceItem.Property.LockSet || 
+		if (DialogFocusSourceItem.Property && (DialogFocusSourceItem.Property.LockSet ||
 		(DialogFocusSourceItem.Property.LockMemberNumber && DialogFocusSourceItem.Property.LockMemberNumber != Player.MemberNumber))) {
 			// Normal lock interface
 			if (DialogFocusSourceItem && DialogFocusSourceItem.Property && DialogFocusSourceItem.Property.Hint)
@@ -83,15 +83,15 @@ function InventoryItemMiscPasswordPadlockClick() {
 	var Item = InventoryGet(C, C.FocusGroup.Name);
 
 	if ((MouseX >= 1360) && (MouseX <= 1950) && !InventoryGroupIsBlocked(C, C.FocusGroup.Name)) {
-		
-		
-		if (DialogFocusSourceItem.Property && (DialogFocusSourceItem.Property.LockSet || 
+
+
+		if (DialogFocusSourceItem.Property && (DialogFocusSourceItem.Property.LockSet ||
 		(DialogFocusSourceItem.Property.LockMemberNumber && DialogFocusSourceItem.Property.LockMemberNumber != Player.MemberNumber))) {
-				
+
 				// Opens the padlock
 				if (MouseIn(1360, 871, 250, 64)) {
 					if (ElementValue("Password").toUpperCase() == DialogFocusSourceItem.Property.Password) {
-						InventoryItemMiscPasswordPadlockUnlock(C, DialogFocusSourceItem)
+						InventoryItemMiscPasswordPadlockUnlock(C, DialogFocusSourceItem);
 						InventoryItemMiscPasswordPadlockExit();
 					}
 
@@ -107,11 +107,11 @@ function InventoryItemMiscPasswordPadlockClick() {
 					}
 					else { PreferenceMessage = "PasswordPadlockError"; }
 				}
-			
+
 		} else {
 				if (MouseIn(1360, 871, 250, 64)) {
-					var pw = ElementValue("SetPassword").toUpperCase()
-					var hint =  ElementValue("SetHint")
+					var pw = ElementValue("SetPassword").toUpperCase();
+					var hint =  ElementValue("SetHint");
 					var E = /^[A-Z]+$/;
 					// We only accept code made of letters
 					if (pw == "" || pw.match(E)) {
@@ -140,7 +140,7 @@ function InventoryItemMiscPasswordPadlockClick() {
 						}
 					}
 					else { PreferenceMessage = "PasswordPadlockErrorInput"; }
-					
+
 				}
 		}
 	}

--- a/BondageClub/Screens/Inventory/ItemMisc/SafewordPadlock/SafewordPadlock.js
+++ b/BondageClub/Screens/Inventory/ItemMisc/SafewordPadlock/SafewordPadlock.js
@@ -8,7 +8,7 @@ function InventoryItemMiscSafewordPadlockLoad() {
 	if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property != null) && (DialogFocusSourceItem.Property.Hint == null)) DialogFocusSourceItem.Property.Hint = "Say the magic word...";
 	if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property != null) && (DialogFocusSourceItem.Property.LockSet == null)) DialogFocusSourceItem.Property.LockSet = false;
 
-	if (DialogFocusSourceItem.Property && (DialogFocusSourceItem.Property.LockSet || 
+	if (DialogFocusSourceItem.Property && (DialogFocusSourceItem.Property.LockSet ||
 	(DialogFocusSourceItem.Property.LockMemberNumber && DialogFocusSourceItem.Property.LockMemberNumber != Player.MemberNumber))) {
 		// Normal lock interface
 		ElementCreateInput("Password", "text", "", "8");
@@ -24,19 +24,19 @@ function InventoryItemMiscSafewordPadlockLoad() {
 		document.getElementById("SetPassword").placeholder = DialogFocusSourceItem.Property.Password;
 		document.getElementById("SetHint").placeholder = DialogFocusSourceItem.Property.Hint;
 	}
-		
+
 }
 
 // Draw the extension screen
 function InventoryItemMiscSafewordPadlockDraw() {
 	var C = CharacterGetCurrent();
 	DrawAssetPreview(1387, 225, DialogFocusItem.Asset);
-	
+
 	if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property != null) && (DialogFocusSourceItem.Property.LockMemberNumber != null))
 		DrawText(DialogFindPlayer("LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 600, "white", "gray");
 
 
-	if (DialogFocusSourceItem.Property && (DialogFocusSourceItem.Property.LockSet || 
+	if (DialogFocusSourceItem.Property && (DialogFocusSourceItem.Property.LockSet ||
 	(DialogFocusSourceItem.Property.LockMemberNumber && DialogFocusSourceItem.Property.LockMemberNumber != Player.MemberNumber))) {
 		// Normal lock interface
 		if (DialogFocusSourceItem && DialogFocusSourceItem.Property && DialogFocusSourceItem.Property.Hint)
@@ -77,15 +77,15 @@ function InventoryItemMiscSafewordPadlockClick() {
 	var Item = InventoryGet(C, C.FocusGroup.Name);
 
 	if ((MouseX >= 1360) && (MouseX <= 1950)) {
-		
-		
-		if (DialogFocusSourceItem.Property && (DialogFocusSourceItem.Property.LockSet || 
+
+
+		if (DialogFocusSourceItem.Property && (DialogFocusSourceItem.Property.LockSet ||
 		(DialogFocusSourceItem.Property.LockMemberNumber && DialogFocusSourceItem.Property.LockMemberNumber != Player.MemberNumber))) {
-				
+
 				// Opens the padlock
 				if (MouseIn(1360, 871, 250, 64)) {
 					if (ElementValue("Password").toUpperCase() == DialogFocusSourceItem.Property.Password) {
-						InventoryItemMiscSafewordPadlockUnlock(C, DialogFocusSourceItem)
+						InventoryItemMiscSafewordPadlockUnlock(C, DialogFocusSourceItem);
 						InventoryItemMiscSafewordPadlockExit();
 					}
 
@@ -101,11 +101,11 @@ function InventoryItemMiscSafewordPadlockClick() {
 					}
 					else { PreferenceMessage = "SafewordPadlockError"; }
 				}
-			
+
 		} else {
 				if (MouseIn(1360, 871, 250, 64)) {
-					var pw = ElementValue("SetPassword").toUpperCase()
-					var hint =  ElementValue("SetHint")
+					var pw = ElementValue("SetPassword").toUpperCase();
+					var hint =  ElementValue("SetHint");
 					var E = /^[A-Z]+$/;
 					// We only accept code made of letters
 					if (pw == "" || pw.match(E)) {
@@ -134,7 +134,7 @@ function InventoryItemMiscSafewordPadlockClick() {
 						}
 					}
 					else { PreferenceMessage = "SafewordPadlockErrorInput"; }
-					
+
 				}
 		}
 	}

--- a/BondageClub/Screens/Inventory/ItemMisc/TimerPasswordPadlock/TimerPasswordPadlock.js
+++ b/BondageClub/Screens/Inventory/ItemMisc/TimerPasswordPadlock/TimerPasswordPadlock.js
@@ -19,7 +19,7 @@ function InventoryItemMiscTimerPasswordPadlockLoad() {
 
 	// Only create the inputs if the zone isn't blocked
 	if (!InventoryGroupIsBlocked(C, C.FocusGroup.Name)) {
-		if (DialogFocusSourceItem.Property && (DialogFocusSourceItem.Property.LockSet || 
+		if (DialogFocusSourceItem.Property && (DialogFocusSourceItem.Property.LockSet ||
 		(DialogFocusSourceItem.Property.LockMemberNumber && DialogFocusSourceItem.Property.LockMemberNumber != Player.MemberNumber))) {
 			// Normal lock interface
 			ElementCreateInput("Password", "text", "", "8");
@@ -34,8 +34,8 @@ function InventoryItemMiscTimerPasswordPadlockLoad() {
 			document.getElementById("SetPassword").placeholder = DialogFocusSourceItem.Property.Password;
 			document.getElementById("SetHint").placeholder = DialogFocusSourceItem.Property.Hint;
 		}
-		
-		
+
+
 	}
 }
 
@@ -54,7 +54,7 @@ function InventoryItemMiscTimerPasswordPadlockDraw() {
 		// If the zone is blocked, just display some text informing the player that they can't access the lock
 		DrawText(DialogFindPlayer("LockZoneBlocked"), 1500, 550, "white", "gray");
 	} else {
-		if (DialogFocusSourceItem.Property && (DialogFocusSourceItem.Property.LockSet || 
+		if (DialogFocusSourceItem.Property && (DialogFocusSourceItem.Property.LockSet ||
 		(DialogFocusSourceItem.Property.LockMemberNumber && DialogFocusSourceItem.Property.LockMemberNumber != Player.MemberNumber))) {
 			// Normal lock interface
 			if (DialogFocusSourceItem && DialogFocusSourceItem.Property && DialogFocusSourceItem.Property.Hint)
@@ -76,9 +76,9 @@ function InventoryItemMiscTimerPasswordPadlockDraw() {
 			if (PreferenceMessage != "") DrawText(DialogFindPlayer(PreferenceMessage), 1500, 200, "Red", "Black");
 		}
 	}
-	
+
 	// Copied from mistress timer padlock and modified
-	
+
 	// Draw the settings
     if (Player.CanInteract() && (Player.MemberNumber == DialogFocusSourceItem.Property.LockMemberNumber)) {
         MainCanvas.textAlign = "left";
@@ -128,22 +128,22 @@ function InventoryItemMiscTimerPasswordPadlockUnlock(C, Item) {
 function InventoryItemMiscTimerPasswordPadlockClick() {
 	var C = CharacterGetCurrent();
 	var Item = InventoryGet(C, C.FocusGroup.Name);
-	
+
 	// Exits the screen
 	if ((MouseX >= 1885) && (MouseX <= 1975) && (MouseY >= 25) && (MouseY <= 110)) {
 		InventoryItemMiscTimerPasswordPadlockExit();
 	}
 
 	if ((MouseX >= 1360) && (MouseX <= 1950) && !InventoryGroupIsBlocked(C, C.FocusGroup.Name)) {
-		
-		
-		if (DialogFocusSourceItem.Property && (DialogFocusSourceItem.Property.LockSet || 
+
+
+		if (DialogFocusSourceItem.Property && (DialogFocusSourceItem.Property.LockSet ||
 		(DialogFocusSourceItem.Property.LockMemberNumber && DialogFocusSourceItem.Property.LockMemberNumber != Player.MemberNumber))) {
-				
+
 				// Opens the padlock
 				if (MouseIn(1670, 580, 250, 64)) {
 					if (ElementValue("Password").toUpperCase() == DialogFocusSourceItem.Property.Password) {
-						InventoryItemMiscTimerPasswordPadlockUnlock(C, DialogFocusSourceItem)
+						InventoryItemMiscTimerPasswordPadlockUnlock(C, DialogFocusSourceItem);
 						InventoryItemMiscTimerPasswordPadlockExit();
 					}
 
@@ -159,11 +159,11 @@ function InventoryItemMiscTimerPasswordPadlockClick() {
 					}
 					else { PreferenceMessage = "PasswordPadlockError"; }
 				}
-			
+
 		} else {
 				if (MouseIn(1653, 593, 250, 64)) {
-					var pw = ElementValue("SetPassword").toUpperCase()
-					var hint =  ElementValue("SetHint")
+					var pw = ElementValue("SetPassword").toUpperCase();
+					var hint =  ElementValue("SetHint");
 					var E = /^[A-Z]+$/;
 					// We only accept code made of letters
 					if (pw == "" || pw.match(E)) {
@@ -192,15 +192,15 @@ function InventoryItemMiscTimerPasswordPadlockClick() {
 						}
 					}
 					else { PreferenceMessage = "PasswordPadlockErrorInput"; }
-					
+
 				}
 		}
 	}
-	
+
 	// Copied from mistress timer padlock
-		
+
 		if (!Player.CanInteract()) return;
-		
+
 		if (Player.MemberNumber == DialogFocusSourceItem.Property.LockMemberNumber) {
 			if ((MouseX >= 1100) && (MouseX <= 1164)) {
 				if ((MouseY >= 666) && (MouseY <= 730)) { DialogFocusSourceItem.Property.RemoveItem = !(DialogFocusSourceItem.Property.RemoveItem); }

--- a/BondageClub/Screens/Inventory/ItemNeckAccessories/CollarAutoShockUnit/CollarAutoShockUnit.js
+++ b/BondageClub/Screens/Inventory/ItemNeckAccessories/CollarAutoShockUnit/CollarAutoShockUnit.js
@@ -40,19 +40,19 @@ function InventoryItemNeckAccessoriesCollarAutoShockUnitClick() {
 	if ((MouseX >= 1100) && (MouseX <= 1300) && (MouseY >= 550) && (MouseY <= 605) && (DialogFocusItem.Property.Intensity > 0)) InventoryItemNeckAccessoriesCollarAutoShockUnitSetIntensity(0 - DialogFocusItem.Property.Intensity);
 	if ((MouseX >= 1375) && (MouseX <= 1575) && (MouseY >= 550) && (MouseY <= 605) && (DialogFocusItem.Property.Intensity < 1 || DialogFocusItem.Property.Intensity > 1)) InventoryItemNeckAccessoriesCollarAutoShockUnitSetIntensity(1 - DialogFocusItem.Property.Intensity);
 	if ((MouseX >= 1650) && (MouseX <= 1850) && (MouseY >= 550) && (MouseY <= 605) && (DialogFocusItem.Property.Intensity < 2)) InventoryItemNeckAccessoriesCollarAutoShockUnitSetIntensity(2 - DialogFocusItem.Property.Intensity);
-	
-	
+
+
 	if ((MouseIn(1100, 700, 150, 55)) && (DialogFocusItem.Property.Sensitivity != 0)) InventoryItemNeckAccessoriesCollarAutoShockUnitSetSensitivity(0 - DialogFocusItem.Property.Sensitivity);
 	if ((MouseIn(1300, 700, 150, 55)) && (DialogFocusItem.Property.Sensitivity != 1)) InventoryItemNeckAccessoriesCollarAutoShockUnitSetSensitivity(1 - DialogFocusItem.Property.Sensitivity);
 	if ((MouseIn(1500, 700, 150, 55)) && (DialogFocusItem.Property.Sensitivity != 2)) InventoryItemNeckAccessoriesCollarAutoShockUnitSetSensitivity(2 - DialogFocusItem.Property.Sensitivity);
 	if ((MouseIn(1700, 700, 150, 55)) && (DialogFocusItem.Property.Sensitivity != 3)) InventoryItemNeckAccessoriesCollarAutoShockUnitSetSensitivity(3 - DialogFocusItem.Property.Sensitivity);
-	
+
 	if (Player.CanInteract() && (MouseX >= 1600) && (MouseX <= 1800) && (MouseY >= 790) && (MouseY <= 845)) InventoryItemNeckAccessoriesCollarAutoShockUnitTrigger();
 }
 
 // Sets the shock collar intensity
 function InventoryItemNeckAccessoriesCollarAutoShockUnitSetIntensity(Modifier) {
-	
+
 	// Gets the current item and character
 	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
 	if ((CurrentScreen == "ChatRoom") || (DialogFocusItem == null)) {
@@ -70,12 +70,12 @@ function InventoryItemNeckAccessoriesCollarAutoShockUnitSetIntensity(Modifier) {
 	}
 	else
 		DialogLeave();
-		
+
 }
 
 // Sets the shock collar sensitivity
 function InventoryItemNeckAccessoriesCollarAutoShockUnitSetSensitivity(Modifier) {
-	
+
 	// Gets the current item and character
 	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
 	if ((CurrentScreen == "ChatRoom") || (DialogFocusItem == null)) {
@@ -93,27 +93,27 @@ function InventoryItemNeckAccessoriesCollarAutoShockUnitSetSensitivity(Modifier)
 	}
 	else
 		DialogLeave();
-		
+
 }
 
 
 function InventoryItemNeckAccessoriesCollarAutoShockUnitUpdate(data) {
-	var Item = data.Item
+	var Item = data.Item;
 	if (Item.Property.Sensitivity < 3)
-		AutoShockGagActionFlag = false
-	
+		AutoShockGagActionFlag = false;
+
 	// Punish the player if they speak
 	if (Item.Property.Sensitivity && Item.Property.Sensitivity > 0) {
-		
-		var LastMessages = data.PersistentData().LastMessageLen
-		var ShockTriggerPunish = false
+
+		var LastMessages = data.PersistentData().LastMessageLen;
+		var ShockTriggerPunish = false;
 		var keywords = false;
 		var gagaction = false;
-		
+
 		if (Item.Property.Sensitivity == 3) {
 			if (AutoShockGagActionFlag == true) {
-				gagaction = true
-				AutoShockGagActionFlag = false
+				gagaction = true;
+				AutoShockGagActionFlag = false;
 			} else for (let K = 0; K < AutoPunishKeywords.length; K++) {
 				if (ChatRoomLastMessage[ChatRoomLastMessage.length-1].includes(AutoPunishKeywords[K])) {
 					keywords = true;
@@ -121,7 +121,7 @@ function InventoryItemNeckAccessoriesCollarAutoShockUnitUpdate(data) {
 				}
 			}
 		}
-		
+
 		if (Item.Property.Sensitivity == 3 && (gagaction || (ChatRoomLastMessage && ChatRoomLastMessage.length != LastMessages
 			&& !ChatRoomLastMessage[ChatRoomLastMessage.length-1].startsWith("(") && !ChatRoomLastMessage[ChatRoomLastMessage.length-1].startsWith("*") && ChatRoomLastMessage[ChatRoomLastMessage.length-1].replace(/[A-Za-z]+/g, '') != ChatRoomLastMessage[ChatRoomLastMessage.length-1]
 			&& (!ChatRoomLastMessage[ChatRoomLastMessage.length-1].startsWith("/")
@@ -132,33 +132,33 @@ function InventoryItemNeckAccessoriesCollarAutoShockUnitUpdate(data) {
 			&& (ChatRoomLastMessage[ChatRoomLastMessage.length-1].length > 25
 				|| (ChatRoomLastMessage[ChatRoomLastMessage.length-1].replace(/[A-Za-z]+/g, '') != ChatRoomLastMessage[ChatRoomLastMessage.length-1] && (ChatRoomLastMessage[ChatRoomLastMessage.length-1] == ChatRoomLastMessage[ChatRoomLastMessage.length-1].toUpperCase()
 				|| (ChatRoomLastMessage[ChatRoomLastMessage.length-1].includes('!'))))))
-			ShockTriggerPunish = true
+			ShockTriggerPunish = true;
 		if (Item.Property.Sensitivity == 1 && ChatRoomLastMessage && ChatRoomLastMessage.length != LastMessages
 			&& !ChatRoomLastMessage[ChatRoomLastMessage.length-1].startsWith("(") && !ChatRoomLastMessage[ChatRoomLastMessage.length-1].startsWith("*") && !ChatRoomLastMessage[ChatRoomLastMessage.length-1].startsWith("/")
 			&& (ChatRoomLastMessage[ChatRoomLastMessage.length-1].replace(/[A-Za-z]+/g, '') != ChatRoomLastMessage[ChatRoomLastMessage.length-1] && (ChatRoomLastMessage[ChatRoomLastMessage.length-1] == ChatRoomLastMessage[ChatRoomLastMessage.length-1].toUpperCase()
 				|| (ChatRoomLastMessage[ChatRoomLastMessage.length-1].includes('!')))))
-			ShockTriggerPunish = true
-		
-		
+			ShockTriggerPunish = true;
+
+
 		if (ChatRoomTargetMemberNumber != null) {
-			ShockTriggerPunish = false // No trigger on whispers
+			ShockTriggerPunish = false; // No trigger on whispers
 		}
-		
+
 		if (ShockTriggerPunish) {
-			InventoryItemNeckAccessoriesCollarAutoShockUnitTriggerAutomatic(data)
+			InventoryItemNeckAccessoriesCollarAutoShockUnitTriggerAutomatic(data);
 			ChatRoomCharacterUpdate(Player);
-		} 
+		}
 	}
-	
-	
+
+
 }
 
 // Trigger a shock outside of the dialog menu
-function InventoryItemNeckAccessoriesCollarAutoShockUnitTriggerAutomatic(data) { 
+function InventoryItemNeckAccessoriesCollarAutoShockUnitTriggerAutomatic(data) {
 	var msg = "TriggerShock" + data.Item.Property.Intensity;
-	var C = data.C
-	
-	
+	var C = data.C;
+
+
 	if (CurrentScreen == "ChatRoom" && data.Item.Property.ShowText) {
 		var Dictionary = [
 			{ Tag: "DestinationCharacterName", Text: C.Name, MemberNumber: C.MemberNumber },
@@ -167,14 +167,14 @@ function InventoryItemNeckAccessoriesCollarAutoShockUnitTriggerAutomatic(data) {
 		ServerSend("ChatRoomChat", { Content: msg, Type: "Action", Dictionary });
 		ChatRoomCharacterItemUpdate(C, data.Item.Asset.Group.Name);
 	}
-		
+
     CharacterSetFacialExpression(C, "Eyebrows", "Soft", 10);
     CharacterSetFacialExpression(C, "Blush", "Soft", 15);
     CharacterSetFacialExpression(C, "Eyes", "Closed", 5);
 }
 
 // Trigger a shock from the dialog menu
-function InventoryItemNeckAccessoriesCollarAutoShockUnitTrigger(data) { 
+function InventoryItemNeckAccessoriesCollarAutoShockUnitTrigger(data) {
 	// Gets the current item and character
 	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
 	if ((CurrentScreen == "ChatRoom") || (DialogFocusItem == null)) {
@@ -191,14 +191,14 @@ function InventoryItemNeckAccessoriesCollarAutoShockUnitTrigger(data) {
 	Dictionary.push({ Tag: "ActivityGroup", Text: DialogFocusItem.Asset.Group.Name });
 	Dictionary.push({ AssetName: DialogFocusItem.Asset.Name });
 	Dictionary.push({ AssetGroupName: DialogFocusItem.Asset.Group.Name });
-	
+
 	if (C.ID == Player.ID) {
 		// The Player shocks herself
 		ActivityArousalItem(C, C, DialogFocusItem.Asset);
 	}
-		
+
 	ChatRoomPublishCustomAction("TriggerShock" + DialogFocusItem.Property.Intensity, true, Dictionary);
-			
+
     CharacterSetFacialExpression(C, "Eyebrows", "Soft", 10);
     CharacterSetFacialExpression(C, "Blush", "Soft", 15);
     CharacterSetFacialExpression(C, "Eyes", "Closed", 5);
@@ -218,23 +218,23 @@ function AssetsItemNeckAccessoriesCollarAutoShockUnitScriptDraw(data) {
 		var wasBlinking = property.Type === "Blink";
 		property.Type = wasBlinking ? null : "Blink";
 		var timeToNextRefresh = wasBlinking ? 4000 : 1000;
-		
+
 		if (CurrentScreen == "ChatRoom" && data.C == Player) {
-		
-			InventoryItemNeckAccessoriesCollarAutoShockUnitUpdate(data)
-			
+
+			InventoryItemNeckAccessoriesCollarAutoShockUnitUpdate(data);
+
 			persistentData.LastMessageLen = (ChatRoomLastMessage) ? ChatRoomLastMessage.length : 0;
 		}
 
-		
-		
+
+
 		persistentData.ChangeTime = CommonTime() + timeToNextRefresh;
 		AnimationRequestRefreshRate(data.C, 5000 - timeToNextRefresh);
 		AnimationRequestDraw(data.C);
 	}
 }
 
-function InventoryItemNeckAccessoriesCollarAutoShockUnitDynamicAudio(data) { 
+function InventoryItemNeckAccessoriesCollarAutoShockUnitDynamicAudio(data) {
 	var Modifier = parseInt(data.Content.substr(data.Content.length - 1));
 	if (isNaN(Modifier)) Modifier = 0;
 	return ["Shocks", Modifier * 3];

--- a/BondageClub/Screens/Inventory/ItemNeckAccessories/CollarNameTag/CollarNameTag.js
+++ b/BondageClub/Screens/Inventory/ItemNeckAccessories/CollarNameTag/CollarNameTag.js
@@ -19,10 +19,10 @@ function InventoryItemNeckAccessoriesCollarNameTagDraw() {
 		for (let T = 0; T < List.length; T++) {
 			if ((DialogFocusItem.Property.Type != List[T])) DrawButton(X, Y, 200, 55, DialogFindPlayer("CollarNameTagType" + List[T]), "White");
 			X = X + 210;
-			if (T % 5 == 4) { 
-				X = 955; 
+			if (T % 5 == 4) {
+				X = 955;
 				Y = Y + 60;
-			}		
+			}
 		}
 	}
 	else {
@@ -41,10 +41,10 @@ function InventoryItemNeckAccessoriesCollarNameTagClick() {
 			if ((MouseX >= X) && (MouseX <= X + 200) && (MouseY >= Y) && (MouseY <= Y + 55) && (DialogFocusItem.Property.Type != List[T]))
 				InventoryItemNeckAccessoriesCollarNameTagSetType(List[T]);
 			X = X + 210;
-			if (T % 5 == 4) { 
-				X = 955; 
+			if (T % 5 == 4) {
+				X = 955;
 				Y = Y + 60;
-			}		
+			}
 		}
 	}
 }

--- a/BondageClub/Screens/Inventory/ItemNeckAccessories/CollarNameTagLivestock/CollarNameTagLivestock.js
+++ b/BondageClub/Screens/Inventory/ItemNeckAccessories/CollarNameTagLivestock/CollarNameTagLivestock.js
@@ -19,10 +19,10 @@ function InventoryItemNeckAccessoriesCollarNameTagLivestockDraw() {
 		for (let T = 0; T < List.length; T++) {
 			if ((DialogFocusItem.Property.Type != List[T])) DrawButton(X, Y, 200, 55, DialogFindPlayer("CollarNameTagLivestockType" + List[T]), "White");
 			X = X + 210;
-			if (T % 5 == 4) { 
-				X = 955; 
+			if (T % 5 == 4) {
+				X = 955;
 				Y = Y + 60;
-			}		
+			}
 		}
 	}
 	else {
@@ -41,10 +41,10 @@ function InventoryItemNeckAccessoriesCollarNameTagLivestockClick() {
 			if ((MouseX >= X) && (MouseX <= X + 200) && (MouseY >= Y) && (MouseY <= Y + 55) && (DialogFocusItem.Property.Type != List[T]))
 				InventoryItemNeckAccessoriesCollarNameTagLivestockSetType(List[T]);
 			X = X + 210;
-			if (T % 5 == 4) { 
-				X = 955; 
+			if (T % 5 == 4) {
+				X = 955;
 				Y = Y + 60;
-			}		
+			}
 		}
 	}
 }

--- a/BondageClub/Screens/Inventory/ItemNeckAccessories/CollarNameTagLover/CollarNameTagLover.js
+++ b/BondageClub/Screens/Inventory/ItemNeckAccessories/CollarNameTagLover/CollarNameTagLover.js
@@ -19,10 +19,10 @@ function InventoryItemNeckAccessoriesCollarNameTagLoverDraw() {
 		for (let T = 0; T < List.length; T++) {
 			if ((DialogFocusItem.Property.Type != List[T])) DrawButton(X, Y, 200, 55, DialogFindPlayer("CollarNameTagLoverType" + List[T]), "White");
 			X = X + 210;
-			if (T % 5 == 4) { 
-				X = 955; 
+			if (T % 5 == 4) {
+				X = 955;
 				Y = Y + 60;
-			}		
+			}
 		}
 	}
 	else {
@@ -41,10 +41,10 @@ function InventoryItemNeckAccessoriesCollarNameTagLoverClick() {
 			if ((MouseX >= X) && (MouseX <= X + 200) && (MouseY >= Y) && (MouseY <= Y + 55) && (DialogFocusItem.Property.Type != List[T]))
 				InventoryItemNeckAccessoriesCollarNameTagLoverSetType(List[T]);
 			X = X + 210;
-			if (T % 5 == 4) { 
-				X = 955; 
+			if (T % 5 == 4) {
+				X = 955;
 				Y = Y + 60;
-			}		
+			}
 		}
 	}
 }
@@ -59,7 +59,7 @@ function InventoryItemNeckAccessoriesCollarNameTagLoverSetType(NewType) {
 	DialogFocusItem.Property.Type = NewType;
 	DialogFocusItem.Property.Effect = [];
 
-	// Refreshes the character and chatroom	
+	// Refreshes the character and chatroom
 	CharacterRefresh(C);
 	var Dictionary = [];
 	Dictionary.push({Tag: "DestinationCharacter", Text: C.Name, MemberNumber: C.MemberNumber});

--- a/BondageClub/Screens/Inventory/ItemNeckAccessories/CollarNameTagOval/CollarNameTagOval.js
+++ b/BondageClub/Screens/Inventory/ItemNeckAccessories/CollarNameTagOval/CollarNameTagOval.js
@@ -19,10 +19,10 @@ function InventoryItemNeckAccessoriesCollarNameTagOvalDraw() {
 		for (let T = 0; T < List.length; T++) {
 			if ((DialogFocusItem.Property.Type != List[T])) DrawButton(X, Y, 200, 55, DialogFindPlayer("CollarNameTagOvalType" + List[T]), "White");
 			X = X + 210;
-			if (T % 5 == 4) { 
-				X = 955; 
+			if (T % 5 == 4) {
+				X = 955;
 				Y = Y + 60;
-			}		
+			}
 		}
 	}
 	else {
@@ -41,10 +41,10 @@ function InventoryItemNeckAccessoriesCollarNameTagOvalClick() {
 			if ((MouseX >= X) && (MouseX <= X + 200) && (MouseY >= Y) && (MouseY <= Y + 55) && (DialogFocusItem.Property.Type != List[T]))
 				InventoryItemNeckAccessoriesCollarNameTagOvalSetType(List[T]);
 			X = X + 210;
-			if (T % 5 == 4) { 
-				X = 955; 
+			if (T % 5 == 4) {
+				X = 955;
 				Y = Y + 60;
-			}		
+			}
 		}
 	}
 }

--- a/BondageClub/Screens/Inventory/ItemNeckAccessories/CollarNameTagPet/CollarNameTagPet.js
+++ b/BondageClub/Screens/Inventory/ItemNeckAccessories/CollarNameTagPet/CollarNameTagPet.js
@@ -19,10 +19,10 @@ function InventoryItemNeckAccessoriesCollarNameTagPetDraw() {
 		for (let T = 0; T < List.length; T++) {
 			if ((DialogFocusItem.Property.Type != List[T])) DrawButton(X, Y, 200, 55, DialogFindPlayer("CollarNameTagPetType" + List[T]), "White");
 			X = X + 210;
-			if (T % 5 == 4) { 
-				X = 955; 
+			if (T % 5 == 4) {
+				X = 955;
 				Y = Y + 60;
-			}		
+			}
 		}
 	}
 	else {
@@ -41,10 +41,10 @@ function InventoryItemNeckAccessoriesCollarNameTagPetClick() {
 			if ((MouseX >= X) && (MouseX <= X + 200) && (MouseY >= Y) && (MouseY <= Y + 55) && (DialogFocusItem.Property.Type != List[T]))
 				InventoryItemNeckAccessoriesCollarNameTagPetSetType(List[T]);
 			X = X + 210;
-			if (T % 5 == 4) { 
-				X = 955; 
+			if (T % 5 == 4) {
+				X = 955;
 				Y = Y + 60;
-			}		
+			}
 		}
 	}
 }

--- a/BondageClub/Screens/Inventory/ItemNeckAccessories/CollarShockUnit/CollarShockUnit.js
+++ b/BondageClub/Screens/Inventory/ItemNeckAccessories/CollarShockUnit/CollarShockUnit.js
@@ -33,7 +33,7 @@ function InventoryItemNeckAccessoriesCollarShockUnitClick() {
 
 // Sets the shock collar intensity
 function InventoryItemNeckAccessoriesCollarShockUnitSetIntensity(Modifier) {
-	
+
 	// Gets the current item and character
 	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
 	if ((CurrentScreen == "ChatRoom") || (DialogFocusItem == null)) {
@@ -51,11 +51,11 @@ function InventoryItemNeckAccessoriesCollarShockUnitSetIntensity(Modifier) {
 	}
 	else
 		DialogLeave();
-		
+
 }
 
 // Trigger a shock from the dialog menu
-function InventoryItemNeckAccessoriesCollarShockUnitTrigger() { 
+function InventoryItemNeckAccessoriesCollarShockUnitTrigger() {
 	// Gets the current item and character
 	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
 	if ((CurrentScreen == "ChatRoom") || (DialogFocusItem == null)) {
@@ -72,15 +72,15 @@ function InventoryItemNeckAccessoriesCollarShockUnitTrigger() {
 	Dictionary.push({ Tag: "ActivityGroup", Text: DialogFocusItem.Asset.Group.Name });
 	Dictionary.push({ AssetName: DialogFocusItem.Asset.Name });
 	Dictionary.push({ AssetGroupName: DialogFocusItem.Asset.Group.Name });
-		
+
 	ChatRoomPublishCustomAction("TriggerShock" + DialogFocusItem.Property.Intensity, false, Dictionary);
-		
+
 	if (C.ID == Player.ID) {
 		// The Player shocks herself
 		ActivityArousalItem(C, C, DialogFocusItem.Asset);
 	}
 	if (CurrentScreen == "ChatRoom") DialogLeave();
-	
+
     CharacterSetFacialExpression(C, "Eyebrows", "Soft", 10);
     CharacterSetFacialExpression(C, "Blush", "Soft", 15);
     CharacterSetFacialExpression(C, "Eyes", "Closed", 5);
@@ -105,7 +105,7 @@ function AssetsItemNeckAccessoriesCollarShockUnitScriptDraw(data) {
 	}
 }
 
-function InventoryItemNeckAccessoriesCollarShockUnitDynamicAudio(data) { 
+function InventoryItemNeckAccessoriesCollarShockUnitDynamicAudio(data) {
 	var Modifier = parseInt(data.Content.substr(data.Content.length - 1));
 	if (isNaN(Modifier)) Modifier = 0;
 	return ["Shocks", Modifier * 3];

--- a/BondageClub/Screens/Inventory/ItemPelvis/SciFiPleasurePanties/SciFiPleasurePanties.js
+++ b/BondageClub/Screens/Inventory/ItemPelvis/SciFiPleasurePanties/SciFiPleasurePanties.js
@@ -2,7 +2,7 @@
 function InventoryItemPelvisSciFiPleasurePantiesLoad() {
 	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
 	if (InventoryItemMouthFuturisticPanelGagValidate(C) !== "") {
-		InventoryItemMouthFuturisticPanelGagLoadAccessDenied()
+		InventoryItemMouthFuturisticPanelGagLoadAccessDenied();
 	}
     else{
         if (DialogFocusItem.Property == null) DialogFocusItem.Property = { Intensity: -1, ShockLevel: 0, ShowText: true, Effect: ["Egged"], LockButt: false, LockCrotch: false, Block: [], OrgasmLock: false };
@@ -21,13 +21,13 @@ function InventoryItemPelvisSciFiPleasurePantiesDraw() {
 
 	const Vibrating = DialogFocusItem.Property.Intensity >= 0;
 	DrawAssetPreview(1387, 175, DialogFocusItem.Asset, {Vibrating});
-	
+
     var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
 	if (InventoryItemMouthFuturisticPanelGagValidate(C) !== "") {
-		InventoryItemMouthFuturisticPanelGagDrawAccessDenied()
+		InventoryItemMouthFuturisticPanelGagDrawAccessDenied();
 	}
     else if (DialogFocusItem && DialogFocusItem.Property) {
-        
+
         DrawButton(1175, 580, 200, 55, DialogFind(Player, "TurnOff"), (DialogFocusItem.Property.Intensity == -1) ? "#888888" : "White");
         DrawButton(1400, 580, 200, 55, DialogFind(Player, "Low"), (DialogFocusItem.Property.Intensity == 0) ? "#888888" : "White");
         DrawButton(1625, 580, 200, 55, DialogFind(Player, "Medium"), (DialogFocusItem.Property.Intensity == 1) ? "#888888" : "White");
@@ -35,7 +35,7 @@ function InventoryItemPelvisSciFiPleasurePantiesDraw() {
 		DrawButton(1400, 650, 200, 55, DialogFind(Player, "Maximum"), (DialogFocusItem.Property.Intensity == 3) ? "#888888" : "White");
         DrawButton(1200, 930, 200, 55, DialogFind(Player, "LockOrgasm"), (DialogFocusItem.Property.OrgasmLock == true) ? "#888888" : "White");
         DrawButton(1550, 930, 200, 55, DialogFind(Player, "UnlockOrgasm"), (DialogFocusItem.Property.OrgasmLock == false) ? "#888888" : "White");
-		
+
 		DrawText(DialogFind(Player, "Intensity" + DialogFocusItem.Property.ShockLevel.toString()).replace("Item", DialogFocusItem.Asset.Description).replace("intensity", "Shock Intensity").replace("Vibe", "Shock Vibe"), 1500, 750, "White", "Gray");
         DrawButton(1175, 780, 200, 55, DialogFind(Player, "Low"), (DialogFocusItem.Property.ShockLevel == 0) ? "#888888" : "White");
         DrawButton(1400, 780, 200, 55, DialogFind(Player, "Medium"), (DialogFocusItem.Property.ShockLevel == 1) ? "#888888" : "White");
@@ -51,10 +51,10 @@ function InventoryItemPelvisSciFiPleasurePantiesDraw() {
 }
 
 function InventoryItemPelvisSciFiPleasurePantiesClick() {
-	
+
 	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
 	if (InventoryItemMouthFuturisticPanelGagValidate(C) !== "") {
-		InventoryItemMouthFuturisticPanelGagClickAccessDenied()
+		InventoryItemMouthFuturisticPanelGagClickAccessDenied();
 	}
     else {
 
@@ -66,7 +66,7 @@ function InventoryItemPelvisSciFiPleasurePantiesClick() {
 		if (MouseIn(1400, 650, 200, 55) && (DialogFocusItem.Property.Intensity != 3)) InventoryItemPelvisSciFiPleasurePantiesSetIntensity(3 - DialogFocusItem.Property.Intensity);
 		if (MouseIn(1200, 930, 200, 45) && (DialogFocusItem.Property.OrgasmLock == false)) InventoryItemPelvisSciFiPleasurePantiesLockOrgasm(true);
 		if (MouseIn(1550, 930, 200, 45) && (DialogFocusItem.Property.OrgasmLock == true)) InventoryItemPelvisSciFiPleasurePantiesLockOrgasm(false);
-		
+
 		if (MouseIn(1175, 850, 64, 64) && (CurrentScreen == "ChatRoom")) {
 			DialogFocusItem.Property.ShowText = !DialogFocusItem.Property.ShowText;
 		}
@@ -88,7 +88,7 @@ function InventoryItemPelvisSciFiPleasurePantiesClick() {
 
 		if (MouseIn(1200, 480, 250, 65)) {
 			DialogFocusItem.Property.LockCrotch = !DialogFocusItem.Property.LockCrotch;
-			InventoryItemPelvisSciFiPleasurePantiesLockCrotch()
+			InventoryItemPelvisSciFiPleasurePantiesLockCrotch();
 			CharacterRefresh(C);
 			if (CharacterGetCurrent().ID == 0) ServerPlayerAppearanceSync();
 			if (CurrentScreen == "ChatRoom") ChatRoomCharacterItemUpdate(C, "ItemPelvis");
@@ -101,7 +101,7 @@ function InventoryItemPelvisSciFiPleasurePantiesClick() {
 
 function InventoryItemPelvisSciFiPleasurePantiesLockOrgasm(OrgasmLock) {
 	var C = CharacterGetCurrent() || CharacterAppearanceSelection;
-	
+
     if (OrgasmLock == true && !DialogFocusItem.Property.Effect.includes("DenialMode")) {
 		DialogFocusItem.Property.Effect.push("DenialMode");
 		DialogFocusItem.Property.OrgasmLock = true;
@@ -167,14 +167,14 @@ function InventoryItemPelvisSciFiPleasurePantiesSetIntensity(Modifier) {
 
 	CharacterLoadEffect(C);
 	if (C.ID == 0) ServerPlayerAppearanceSync();
-	
+
 	var Dictionary = [];
 	Dictionary.push({Tag: "DestinationCharacterName", Text: C.Name, MemberNumber: C.MemberNumber});
 	ChatRoomPublishCustomAction("SciFiPleasurePantiesVibe" + ((Modifier > 0) ? "Increase" : "Decrease") + "To" + DialogFocusItem.Property.Intensity, true, Dictionary);
 }
 
 function InventoryItemPelvisSciFiPleasurePantiesSetShockLevel(Modifier) {
-	
+
 	// Gets the current item and character
 	var C = CharacterGetCurrent() || CharacterAppearanceSelection;
 	if ((CurrentScreen == "ChatRoom") || (DialogFocusItem == null)) {
@@ -190,7 +190,7 @@ function InventoryItemPelvisSciFiPleasurePantiesSetShockLevel(Modifier) {
 	}
 	else if (CurrentScreen == "ChatRoom")
         DialogFocusItem = null;
-		
+
 }
 
 function InventoryItemPelvisSciFiPleasurePantiesShockTrigger() {
@@ -199,23 +199,23 @@ function InventoryItemPelvisSciFiPleasurePantiesShockTrigger() {
 	if ((CurrentScreen == "ChatRoom") || (DialogFocusItem == null)) {
 		DialogFocusItem = InventoryGet(C, C.FocusGroup.Name);
 		InventoryItemPelvisSciFiPleasurePantiesLoad();
-	}	
-	
+	}
+
 	if (C.ID == Player.ID) {
 		// The Player shocks herself
 		ActivityArousalItem(C, C, DialogFocusItem.Asset);
 	}
 
 	var Dictionary = [];
-	Dictionary.push({ Tag: "AssetName", Text: DialogFocusItem.Asset.Description.toLowerCase() });		
+	Dictionary.push({ Tag: "AssetName", Text: DialogFocusItem.Asset.Description.toLowerCase() });
 	Dictionary.push({ Tag: "DestinationCharacterName", Text: C.Name, MemberNumber: C.MemberNumber });
     ChatRoomPublishCustomAction("SciFiPleasurePantiesShockTrigger" + DialogFocusItem.Property.ShockLevel, true, Dictionary);
-    
+
     CharacterSetFacialExpression(C, "Eyebrows", "Soft", 10);
     CharacterSetFacialExpression(C, "Blush", "ShockLow", 15);
     CharacterSetFacialExpression(C, "Eyes", "Closed", 5);
 }
 
 function InventoryItemPelvisSciFiPleasurePantiesExit() {
-	InventoryItemMouthFuturisticPanelGagExitAccessDenied()
+	InventoryItemMouthFuturisticPanelGagExitAccessDenied();
 }


### PR DESCRIPTION
This PR has no functional effect, it only:
- Removes spaces and tabs on end of lines, where they have no effect (trailing whitespace)
- Add semicolons to where they should be

To keep this cleanup small, this part only focuses on files in `Screens/Inventory/` and only on files not handled before