### PR TITLE
Cleanup: Scripts formatting (Part 11 - `Screens/Room/*`)

### DIFF
--- a/BondageClub/Screens/Room/Arcade/Arcade.js
+++ b/BondageClub/Screens/Room/Arcade/Arcade.js
@@ -14,7 +14,7 @@ var ArcadeCannotDoDeviousChallenge = false;
  */
 function ArcadeCanAskForHeadsetHelpBound() {
 	if (ArcadeCanPlayGames()) return false;
-	return !Player.CanInteract() && DialogInventoryAvailable("InteractiveVRHeadset", "ItemHead")
+	return !Player.CanInteract() && DialogInventoryAvailable("InteractiveVRHeadset", "ItemHead");
 }
 
 /**
@@ -81,11 +81,11 @@ function ArcadeBuyHeadset() {
  * @returns {void} - Nothing
  */
 function ArcadeToggleDeviousChallenge() {
-	ArcadeDeviousChallenge = !ArcadeDeviousChallenge
+	ArcadeDeviousChallenge = !ArcadeDeviousChallenge;
 	if (ArcadeDeviousChallenge)
-		LogAdd("DeviousChallenge", "Arcade", 1, true)
+		LogAdd("DeviousChallenge", "Arcade", 1, true);
 	else
-		LogDelete("DeviousChallenge", "Arcade", true)
+		LogDelete("DeviousChallenge", "Arcade", true);
 }
 
 /**
@@ -93,7 +93,7 @@ function ArcadeToggleDeviousChallenge() {
  * @returns {bool} - ArcadeDeviousChallenge
  */
 function ArcadeDeviousChallengeAllowed() {
-	return !ArcadeDeviousChallenge && !ArcadeCannotDoDeviousChallenge
+	return !ArcadeDeviousChallenge && !ArcadeCannotDoDeviousChallenge;
 }
 
 /**
@@ -101,7 +101,7 @@ function ArcadeDeviousChallengeAllowed() {
  * @returns {bool} - ArcadeDeviousChallenge
  */
 function ArcadeDeviousChallengeEnabled() {
-	return ArcadeDeviousChallenge
+	return ArcadeDeviousChallenge;
 }
 
 
@@ -113,18 +113,18 @@ function ArcadeLoad() {
 	ArcadeEmployee = CharacterLoadNPC("NPC_Arcade_Employee");
 	ArcadePlayer = CharacterLoadNPC("NPC_Arcade_Player");
 	InventoryWear(ArcadePlayer, "InteractiveVRHeadset","ItemHead");
-	
+
 	//if (!InventoryCharacterHasOwnerOnlyRestraint(Player) && !InventoryCharacterHasLoverOnlyRestraint(Player)) {
-		ArcadeDeviousChallenge = LogValue("DeviousChallenge", "Arcade") == 1
+		ArcadeDeviousChallenge = LogValue("DeviousChallenge", "Arcade") == 1;
 	//	ArcadeCannotDoDeviousChallenge = false
 	//}
 	//else
 	//	ArcadeCannotDoDeviousChallenge = true
-	
+
 }
 
 /**
- * Run the Arcade room and draw characters. This function is called dynamically at short intervals. 
+ * Run the Arcade room and draw characters. This function is called dynamically at short intervals.
  * Don't use expensive loops or functions from here
  * @returns {void} - Nothing
  */
@@ -152,11 +152,11 @@ function ArcadeClick() {
 		ArcadePlayer.Stage = "0";
 		CharacterSetCurrent(ArcadePlayer);
 	}
-	
+
 	if (ArcadeCanPlayGames()) {
-		if (MouseIn(1885, 265, 90, 90)) ArcadeKinkyDungeonStart(ReputationGet("Gaming"))
-	} 
-	
+		if (MouseIn(1885, 265, 90, 90)) ArcadeKinkyDungeonStart(ReputationGet("Gaming"));
+	}
+
 	if (MouseIn(1885, 25, 90, 90) && Player.CanWalk()) CommonSetScreen("Room", "MainHall");
 	if (MouseIn(1885, 145, 90, 90)) InformationSheetLoadCharacter(Player);
 }
@@ -167,7 +167,7 @@ function ArcadeClick() {
  * @returns {void} - Nothing
  */
 function ArcadeKinkyDungeonStart(PlayerLevel) {
-	
+
 	MiniGameStart("KinkyDungeon", PlayerLevel, "ArcadeKinkyDungeonEnd");
 }
 
@@ -179,6 +179,6 @@ function ArcadeKinkyDungeonEnd() {
 	CommonSetScreen("Room", "Arcade");
 
 	if (MiniGameVictory) {
-		ReputationChange("Gaming", Math.max(ReputationGet("Gaming"), MiniGameKinkyDungeonCheckpoint))
+		ReputationChange("Gaming", Math.max(ReputationGet("Gaming"), MiniGameKinkyDungeonCheckpoint));
 	}
 }

--- a/BondageClub/Screens/Room/AsylumBedroom/AsylumBedroom.js
+++ b/BondageClub/Screens/Room/AsylumBedroom/AsylumBedroom.js
@@ -7,11 +7,11 @@ var AsylumBedroomBackground = "AsylumBedroom";
  */
 function AsylumBedroomLoad() {
 	if (Player.ImmersionSettings && Player.LastChatRoom && Player.LastChatRoom != "") {
-		// We return to the chat room that the player was last in		
+		// We return to the chat room that the player was last in
 		if (Player.ImmersionSettings.ReturnToChatRoom) {
 			ChatRoomStart("Asylum", "", "AsylumEntrance", "AsylumEntrance", [BackgroundsTagAsylum]);
 		} else {
-			ChatRoomSetLastChatRoom("")
+			ChatRoomSetLastChatRoom("");
 		}
 	}
 }

--- a/BondageClub/Screens/Room/AsylumEntrance/AsylumEntrance.js
+++ b/BondageClub/Screens/Room/AsylumEntrance/AsylumEntrance.js
@@ -10,22 +10,22 @@ var AsylumEntranceEscapedPatientWillJoin = false;
  * Checks, if the player is able to leave the Asylum
  * @returns {boolean} - Returns true, if the player is able to leave, false otherwise
  */
-function AsylumEntranceCanWander() { return (Player.CanWalk() && ((LogValue("Committed", "Asylum") >= CurrentTime) || ((ReputationGet("Asylum") >= 1) && AsylumEntranceIsWearingNurseClothes(Player)))) }
+function AsylumEntranceCanWander() { return (Player.CanWalk() && ((LogValue("Committed", "Asylum") >= CurrentTime) || ((ReputationGet("Asylum") >= 1) && AsylumEntranceIsWearingNurseClothes(Player)))); }
 /**
  * Checks, if the player can bring the nurse to her private room
  * @returns {boolean} - Returns true, if the player can drag the nurse to her private roo, false otherwise
  */
-function AsylumEntranceCanTransferToRoom() { return (LogQuery("RentRoom", "PrivateRoom") && (PrivateCharacter.length < PrivateCharacterMax) && !LogQuery("LockOutOfPrivateRoom", "Rule")) }
+function AsylumEntranceCanTransferToRoom() { return (LogQuery("RentRoom", "PrivateRoom") && (PrivateCharacter.length < PrivateCharacterMax) && !LogQuery("LockOutOfPrivateRoom", "Rule")); }
 /**
  * CHecks if the player can kiss the nurse
  * @returns {boolean} - Returns true, if the player can kiss the nurse, false otherwise
  */
-function AsylumEntranceCanKiss() { return (Player.CanTalk() && CurrentCharacter.CanTalk()) }
+function AsylumEntranceCanKiss() { return (Player.CanTalk() && CurrentCharacter.CanTalk()); }
 /**
  * Checks if the player can have a nurse uniform of her own
  * @returns {boolean} - Returns true, if the player can have her own nurse uniform, false otherwise
  */
-function AsylumEntranceCanGetNurseUniform() { return ((ReputationGet("Asylum") >= 50) && (!DialogInventoryAvailable("NurseUniform", "Cloth") || !DialogInventoryAvailable("NurseCap", "Hat"))) }
+function AsylumEntranceCanGetNurseUniform() { return ((ReputationGet("Asylum") >= 50) && (!DialogInventoryAvailable("NurseUniform", "Cloth") || !DialogInventoryAvailable("NurseCap", "Hat"))); }
 
 /**
  * Loads the room and generates the nurse. Is called dynamically
@@ -41,7 +41,7 @@ function AsylumEntranceLoad() {
 }
 
 /**
- * // Runs the room (shows the nurse, player, icons and committed time). 
+ * // Runs the room (shows the nurse, player, icons and committed time).
  * Is called over and over again, so don't call expensive functions or loops from here.
  * @returns {void} - Nothing
  */
@@ -263,7 +263,7 @@ function AsylumEntranceNurseStrap(RepChange) {
 	InventoryWear(AsylumEntranceNurse, "MuzzleGag", "ItemMouth");
 }
 
-// 
+//
 /**
  * When the player gets committed again after escaping, she is restraint tightly and has to stay for a full day
  * @returns {void} - Nothing
@@ -286,8 +286,8 @@ function AsylumEntranceNurseCatchEscapedPlayer() {
 	CommonSetScreen("Room", "AsylumEntrance");
 	AsylumEntranceBackground = "MainHall";
 	AsylumEntranceKidnapNurse = null;
-	CharacterDelete("NPC_AsylumEntrance_KidnapNurse");	
-	AsylumEntranceKidnapNurse = CharacterLoadNPC("NPC_AsylumEntrance_KidnapNurse");	
+	CharacterDelete("NPC_AsylumEntrance_KidnapNurse");
+	AsylumEntranceKidnapNurse = CharacterLoadNPC("NPC_AsylumEntrance_KidnapNurse");
 	AsylumEntranceWearNurseClothes(AsylumEntranceKidnapNurse);
 	AsylumEntranceKidnapNurse.Stage = "0";
 	AsylumEntranceKidnapNurse.CurrentDialog = DialogFind(AsylumEntranceKidnapNurse, (Player.CanInteract() ? "Intro" : "Automatic") + (Math.floor(Math.random() * 3)).toString());
@@ -313,7 +313,7 @@ function AsylumEntranceKidnapNurseFightOutro(Surrender) {
 	CommonSetScreen("Room", "AsylumEntrance");
 	SkillProgress("Willpower", ((Player.KidnapMaxWillpower - Player.KidnapWillpower) + (AsylumEntranceKidnapNurse.KidnapMaxWillpower - AsylumEntranceKidnapNurse.KidnapWillpower)) * 2);
 	if ((Surrender != null) && Surrender) DialogChangeReputation("Dominant", -3);
-	AsylumEntranceKidnapNurse.Stage = (KidnapVictory) ? "100" : "200";	
+	AsylumEntranceKidnapNurse.Stage = (KidnapVictory) ? "100" : "200";
 	if (!KidnapVictory) CharacterRelease(AsylumEntranceKidnapNurse);
 	CharacterSetCurrent(AsylumEntranceKidnapNurse);
 	AsylumEntranceKidnapNurse.CurrentDialog = DialogFind(AsylumEntranceKidnapNurse, ((KidnapVictory) ? "Victory" : "Defeat"));
@@ -387,8 +387,8 @@ function AsylumEntranceEscapedPatientMeet() {
 	CommonSetScreen("Room", "AsylumEntrance");
 	AsylumEntranceBackground = "MainHall";
 	AsylumEntranceEscapedPatient = null;
-	CharacterDelete("NPC_AsylumEntrance_EscapedPatient");	
-	AsylumEntranceEscapedPatient = CharacterLoadNPC("NPC_AsylumEntrance_EscapedPatient");	
+	CharacterDelete("NPC_AsylumEntrance_EscapedPatient");
+	AsylumEntranceEscapedPatient = CharacterLoadNPC("NPC_AsylumEntrance_EscapedPatient");
 	AsylumEntranceWearPatientClothes(AsylumEntranceEscapedPatient);
 	AsylumEntranceEscapedPatient.Stage = "0";
 	AsylumEntranceEscapedPatient.CurrentDialog = DialogFind(AsylumEntranceEscapedPatient, "Intro" + (Math.floor(Math.random() * 3)).toString());

--- a/BondageClub/Screens/Room/AsylumMeeting/AsylumMeeting.js
+++ b/BondageClub/Screens/Room/AsylumMeeting/AsylumMeeting.js
@@ -8,18 +8,18 @@ var AsylumMeetingPatientRight = null;
  * Checks if the player can be released
  * @returns {boolean} - Returns true, if the player can be released, false otherwise
  */
-function AsylumMeetingCanReleasePlayer() { return (Player.IsRestrained() && !AsylumMeetingPatientLeft.IsRestrained() && (LogValue("Committed", "Asylum") >= CurrentTime)) }
+function AsylumMeetingCanReleasePlayer() { return (Player.IsRestrained() && !AsylumMeetingPatientLeft.IsRestrained() && (LogValue("Committed", "Asylum") >= CurrentTime)); }
 /**
  * Checks if the player cannot be released
  * @returns {boolean} - Returns true, if the player cannot be released, false otherwise
  */
-function AsylumMeetingCannotReleasePlayer() { return (Player.IsRestrained() && (AsylumMeetingPatientLeft.IsRestrained() || (LogValue("Committed", "Asylum") < CurrentTime))) }
+function AsylumMeetingCannotReleasePlayer() { return (Player.IsRestrained() && (AsylumMeetingPatientLeft.IsRestrained() || (LogValue("Committed", "Asylum") < CurrentTime))); }
 /**
  * Checks wether the player can be restrained or not
  * @returns {boolean} - Returns true, if the player can be restrained, flase otherwise
  */
-function AsylumMeetingCanRestrainPlayer() { return (!Player.IsRestrained() && !AsylumMeetingPatientLeft.IsRestrained() && (LogValue("Committed", "Asylum") >= CurrentTime)) }
-function AsylumMeetingCanKiss() { return (Player.CanTalk() && CurrentCharacter.CanTalk()) }
+function AsylumMeetingCanRestrainPlayer() { return (!Player.IsRestrained() && !AsylumMeetingPatientLeft.IsRestrained() && (LogValue("Committed", "Asylum") >= CurrentTime)); }
+function AsylumMeetingCanKiss() { return (Player.CanTalk() && CurrentCharacter.CanTalk()); }
 
 /**
  * Loads the room and it's patients

--- a/BondageClub/Screens/Room/AsylumTherapy/AsylumTherapy.js
+++ b/BondageClub/Screens/Room/AsylumTherapy/AsylumTherapy.js
@@ -7,7 +7,7 @@ var AsylumTherapyPatient = null;
  * Checks if the therapy for the player can start
  * @returns {boolean} - Returns true, if the player is ready for therapy, false otherwise
  */
-function AsylumTherapyPatientReadyForTherapy() { return (!Player.IsRestrained() && Player.IsNaked()) }
+function AsylumTherapyPatientReadyForTherapy() { return (!Player.IsRestrained() && Player.IsNaked()); }
 
 /**
  * Loads the room and initializes the nurse and the patient
@@ -122,7 +122,7 @@ function AsylumTherapyTherapySuccess() {
 }
 
 /**
- * Apply restraints on the player for pain therapy. 
+ * Apply restraints on the player for pain therapy.
  * Depending on the patient's reputation, the pain therapy gets a tougher weapon
  * @returns {void} - Nothing
  */

--- a/BondageClub/Screens/Room/Cafe/Cafe.js
+++ b/BondageClub/Screens/Room/Cafe/Cafe.js
@@ -14,68 +14,68 @@ var CafePrice = 0;
  * CHecks, if the player can be served
  * @returns {boolean} - Returns true, if the player can be served, false otherwise
  */
-function CafeMaidCanServe() { return (!CafeMaid.IsRestrained() && !Player.IsRestrained()) }
+function CafeMaidCanServe() { return (!CafeMaid.IsRestrained() && !Player.IsRestrained()); }
 
 /**
  * Checks, if the maid from the cafe can serve the player
  * @returns {boolean} - Returns true, if the maid is able to serve, false otherwise
  */
-function CafeMaidCannotServe() { return (CafeMaid.IsRestrained()) }
+function CafeMaidCannotServe() { return (CafeMaid.IsRestrained()); }
 
 /**
  * Checks, if the player is able to consume a dring
  * @returns {boolean} - Returns true, if player and maid are unrestrained, false otherwise
  */
-function CafePlayerCannotConsume() { return (!CafeMaid.IsRestrained() && Player.IsRestrained()) }
+function CafePlayerCannotConsume() { return (!CafeMaid.IsRestrained() && Player.IsRestrained()); }
 
 /**
  * CHecks, if the player has completed the only serving task
  * @returns {boolean} - Returns true, if the player is done, false otherwise
  */
-function CafeOnlineDrinkCompleted() { return (MaidQuartersOnlineDrinkCount >= 5) }
+function CafeOnlineDrinkCompleted() { return (MaidQuartersOnlineDrinkCount >= 5); }
 
 /**
  * Checks, if the player is a head maid and gagged
  * @returns {boolean} - Returns true, if the player is a head maid and gagged
  */
-function CafeIsGaggedHeadMaid() { return (!Player.CanTalk() && CafeIsHeadMaid && !Player.IsBlind()) }
+function CafeIsGaggedHeadMaid() { return (!Player.CanTalk() && CafeIsHeadMaid && !Player.IsBlind()); }
 
 /**
  * Checks if the player is gagged and an experienced maid (reputation higher than 50)
  * @returns {boolean} - Returns true, if the player is gagged and a senior maid, false otherwise
  */
-function CafeIsGaggedSeniorMaid() { return (!Player.CanTalk() && !CafeIsHeadMaid && ReputationGet("Maid") >= 50 && !Player.IsBlind()) }
+function CafeIsGaggedSeniorMaid() { return (!Player.CanTalk() && !CafeIsHeadMaid && ReputationGet("Maid") >= 50 && !Player.IsBlind()); }
 
 /**
  * Checks if the player is gagged and an ordinary maid
  * @returns {boolean} - Returns true if the player is gagged and an ordinary maid, false otherwise
  */
-function CafeIsGaggedMaid() { return (!Player.CanTalk() && !CafeIsHeadMaid && ReputationGet("Maid") > 50 && !Player.IsBlind()) }
+function CafeIsGaggedMaid() { return (!Player.CanTalk() && !CafeIsHeadMaid && ReputationGet("Maid") > 50 && !Player.IsBlind()); }
 
 /**
  * Checks if the player is an experinced maid, but no head maid
  * @returns {boolean} - Returns true, if the player is no head maid and has a reputation of more than 50, false otherwise
  */
-function CafeIsMaidChoice() { return (ReputationGet("Maid") >= 50 && !CafeIsHeadMaid) }
+function CafeIsMaidChoice() { return (ReputationGet("Maid") >= 50 && !CafeIsHeadMaid); }
 
 /**
  * Checks, if the player is an ordinary maid
  * @returns {boolean} - Returns true if the player is no head maid and has a reputation of less than 50
  */
-function CafeIsMaidNoChoice() { return (ReputationGet("Maid") < 50 && !CafeIsHeadMaid) }
+function CafeIsMaidNoChoice() { return (ReputationGet("Maid") < 50 && !CafeIsHeadMaid); }
 
 /**
  * Checks, if a dildo can be applied to the player
  * @returns {boolean} - Returns true, if a dildo can be applied, false otherwise
  */
-function CafeCanDildo() { return (!Player.IsVulvaChaste() && InventoryGet(Player, "ItemVulva") == null) }
+function CafeCanDildo() { return (!Player.IsVulvaChaste() && InventoryGet(Player, "ItemVulva") == null); }
 
 /**
  * Checks, if the player aked for a certain speciality
  * @param {string} Type - The type of cafe speciality
  * @returns {boolean} - Returns true, if the player asked for a given speciality, false otherwise
  */
-function CafeEquired(Type) { return (Type == CafeAskedFor) }
+function CafeEquired(Type) { return (Type == CafeAskedFor); }
 
 //
 /**
@@ -90,7 +90,7 @@ function CafeLoad() {
 }
 
 /**
- * Run the Cafe room and draw characters. This function is called dynamically at short intervals. 
+ * Run the Cafe room and draw characters. This function is called dynamically at short intervals.
  * Don't use expensive loops or functions from here
  * @returns {void} - Nothing
  */
@@ -147,7 +147,7 @@ function CafeConsumeSpeciiality() {
 	}
 	else {
 		CharacterChangeMoney(Player, CafePrice * -1);
-		if (!LogQuery("ModifierDuration", "SkillModifier")) LogAdd("ModifierLevel", "SkillModifier", 0)
+		if (!LogQuery("ModifierDuration", "SkillModifier")) LogAdd("ModifierLevel", "SkillModifier", 0);
 			SkillModifier = LogValue("ModifierLevel", "SkillModifier");
 
 		if (CafeAskedFor == "EnergyDrink") {
@@ -183,7 +183,7 @@ function CafeServiceBound(Style) {
 	var Form = null;
 	var Option = null;
 
-	CharacterRelease(Player)
+	CharacterRelease(Player);
 
 	if (Style == "Shibari") {
 
@@ -322,7 +322,7 @@ function CafeServiceBound(Style) {
 	}
 
 	if (Style == "Heavy") {
-		
+
 		// Arms
 		RandomNumber = Math.floor(Math.random() * 4);
 		if (RandomNumber >= 0) Bondage = "LeatherArmbinder";
@@ -331,7 +331,7 @@ function CafeServiceBound(Style) {
 		if (RandomNumber >= 3) Bondage = "StraitDressOpen";
 		if (RandomNumber >= 2) RandomColor = '#'+Math.floor(Math.random()*16777215).toString(16);
 		InventoryWear(Player, Bondage, "ItemArms", RandomColor, 20);
-		
+
 		if (Bondage == "StraitJacket") {
             Player.FocusGroup = AssetGroupGet("Female3DCG", "ItemArms");
 			DialogExtendItem(InventoryGet(Player, "ItemArms"));
@@ -396,7 +396,7 @@ function CafeServiceBound(Style) {
 		if (RandomNumber >= 12) Bondage = "LeatherHoodSealed";
 		if (RandomNumber >= 8) InventoryWear(Player, Bondage, "ItemHood");
 		if (RandomNumber >= 4 && RandomNumber < 8) InventoryWear(Player, Bondage, "ItemHead");
-		
+
 		// Locks
 		InventoryFullLockRandom(Player);
 	}
@@ -423,7 +423,7 @@ function CafeRamdomBound() {
  */
 function CafeRefillTray() {
 	if (MaidQuartersOnlineDrinkCount >= 4) ReputationProgress("Maid", 4);								// bonus rep on refill if served enough
-	MaidQuartersOnlineDrinkValue = MaidQuartersOnlineDrinkValue + (MaidQuartersOnlineDrinkCount * 3)	// top up equiverlant to basic pay for serving a tray + a small bonus
+	MaidQuartersOnlineDrinkValue = MaidQuartersOnlineDrinkValue + (MaidQuartersOnlineDrinkCount * 3);	// top up equiverlant to basic pay for serving a tray + a small bonus
 	MaidQuartersOnlineDrinkCount = 0;																	// Refill try ready to serve again.
 	MaidQuartersOnlineDrinkCustomer = [];																// Allow serving the previous customers again.
 	InventoryWear(Player, "WoodenMaidTrayFull", "ItemMisc");											// Make sure tray is not empty.

--- a/BondageClub/Screens/Room/Cell/Cell.js
+++ b/BondageClub/Screens/Room/Cell/Cell.js
@@ -56,7 +56,7 @@ function CellClick() {
 
 /**
  * Locks the player in the cell for the given amount of time
- * @param {number} LockTime - Number of minutes to be locked for 
+ * @param {number} LockTime - Number of minutes to be locked for
  * @returns {void} - Nothing
  */
 function CellLock(LockTime) {
@@ -66,7 +66,7 @@ function CellLock(LockTime) {
 
 /**
  * Takes away the player's keys for the given amount of time
- * @param {number} DepositTime - Number of hours to lose the keys for 
+ * @param {number} DepositTime - Number of hours to lose the keys for
  * @returns {void} - Nothing
  */
 function CellDepositKeys(DepositTime) {

--- a/BondageClub/Screens/Room/CollegeCafeteria/CollegeCafeteria.js
+++ b/BondageClub/Screens/Room/CollegeCafeteria/CollegeCafeteria.js
@@ -11,13 +11,13 @@ var CollegeCafeteriaStudentFarRight = null;
  * @param {string} QueryStatus - The query to compare
  * @returns {boolean} - Returns true, if the query matches the state of Sidney, false otherwise
  */
-function CollegeCafeteriaSidneyStatusIs(QueryStatus) { return (QueryStatus == CollegeCafeteriaSidneyStatus) }
+function CollegeCafeteriaSidneyStatusIs(QueryStatus) { return (QueryStatus == CollegeCafeteriaSidneyStatus); }
 
 /**
  * CHecks, if Sidney can be invited to the player's room
  * @returns {boolean} - Returns true, if the player can invite Sidney, false otherwise
  */
-function CollegeCafeteriaCanInviteToPrivateRoom() { return (LogQuery("RentRoom", "PrivateRoom") && (PrivateCharacter.length < PrivateCharacterMax) && (CollegeCafeteriaSidneyLove > 10)) }
+function CollegeCafeteriaCanInviteToPrivateRoom() { return (LogQuery("RentRoom", "PrivateRoom") && (PrivateCharacter.length < PrivateCharacterMax) && (CollegeCafeteriaSidneyLove > 10)); }
 
 /**
  * Loads the cafeteria and generates Sidney according to her current state
@@ -39,7 +39,7 @@ function CollegeCafeteriaLoad() {
 
 	// Generates a full Sidney model based on the Bondage College template
 	if (CollegeCafeteriaSidney == null) {
-		
+
 		// If Sidney is away, we generate a random girl
 		CollegeCafeteriaSidney = CharacterLoadNPC("NPC_CollegeCafeteria_Sidney");
 		CollegeCafeteriaSidney.AllowItem = false;
@@ -76,7 +76,7 @@ function CollegeCafeteriaLoad() {
 		CollegeCafeteriaStudentFarRight = CharacterLoadNPC("NPC_CollegeCafeteria_FarRight");
 		CollegeCafeteriaStudentFarRight.AllowItem = false;
 		CollegeEntranceWearStudentClothes(CollegeCafeteriaStudentFarRight);
-		
+
 		// Sets the starting love level
 		if (CollegeCafeteriaSidneyStatus == "Lover") CollegeCafeteriaSidneyLove = 5;
 		if (CollegeCafeteriaSidneyStatus == "ExLover") CollegeCafeteriaSidneyLove = -2;

--- a/BondageClub/Screens/Room/CollegeChess/CollegeChess.js
+++ b/BondageClub/Screens/Room/CollegeChess/CollegeChess.js
@@ -7,9 +7,9 @@ var CollegeChessPlayerAppearance = null;
 var CollegeChessOpponentAppearance = null;
 
 // Quick functions for player interactions with the chess opponent
-function CollegeChessCanStripPlayer() { return !CharacterIsNaked(Player) }
-function CollegeChessCanStripOpponent() { return !CharacterIsNaked(CollegeChessOpponent) }
-function CollegeChessCanMakeLove() { return (CharacterIsNaked(Player) && CharacterIsNaked(CollegeChessOpponent) && !Player.IsChaste()) }
+function CollegeChessCanStripPlayer() { return !CharacterIsNaked(Player); }
+function CollegeChessCanStripOpponent() { return !CharacterIsNaked(CollegeChessOpponent); }
+function CollegeChessCanMakeLove() { return (CharacterIsNaked(Player) && CharacterIsNaked(CollegeChessOpponent) && !Player.IsChaste()); }
 
 /**
  * Loads the college chest screen by generating the opponent.

--- a/BondageClub/Screens/Room/CollegeDetention/CollegeDetention.js
+++ b/BondageClub/Screens/Room/CollegeDetention/CollegeDetention.js
@@ -9,32 +9,32 @@ var CollegeDetentionYukiWillReleaseAt = 0;
  * Checks, if Yuki can be invited to the private room
  * @returns {boolean} - Returns true, if Yuki can be invited, false otherwise
  */
-function CollegeDetentionCanInviteToPrivateRoom() { return (LogQuery("RentRoom", "PrivateRoom") && (PrivateCharacter.length < PrivateCharacterMax)) }
+function CollegeDetentionCanInviteToPrivateRoom() { return (LogQuery("RentRoom", "PrivateRoom") && (PrivateCharacter.length < PrivateCharacterMax)); }
 
 /**
  * Checks Yuki's current love level
  * @param {string} LoveLevel - The love level that should be checked
  * @returns {boolean} - Returns true, if Yuki's love is greater or equal the given level, false otherwise
  */
-function CollegeDetentionYukiLoveIs(LoveLevel) { return (CollegeDetentionYukiLove >= parseInt(LoveLevel)) }
+function CollegeDetentionYukiLoveIs(LoveLevel) { return (CollegeDetentionYukiLove >= parseInt(LoveLevel)); }
 
 /**
  * Adds the sleeping pill to the player's invertory
  * @returns {void} - Nothing
  */
-function CollegeDetentionGetSleepingPills() { InventoryAdd(Player, "RegularSleepingPill", "ItemMouth") }
+function CollegeDetentionGetSleepingPills() { InventoryAdd(Player, "RegularSleepingPill", "ItemMouth"); }
 
 /**
  * Adds the teacher key to the players 'inventory'
  * @returns {void} - Nothing
  */
-function CollegeDetentionGetTeacherKey() { LogAdd("TeacherKey", "College") }
+function CollegeDetentionGetTeacherKey() { LogAdd("TeacherKey", "College"); }
 
 /**
  * Checks, if Yuki will release the player
  * @returns {boolean} - Returns true if the detention time is over, flase otherwise
  */
-function CollegeDetentionYukiWillRelease() { return (CollegeDetentionYukiWillReleaseAt < CurrentTime) }
+function CollegeDetentionYukiWillRelease() { return (CollegeDetentionYukiWillReleaseAt < CurrentTime); }
 
 /**
  * Creates a fully dressed Yuki
@@ -76,7 +76,7 @@ function CollegeDetentionLoad() {
 			for (let P = 1; P < PrivateCharacter.length; P++)
 				if (PrivateCharacter[P].Name == "Yuki")
 					return;
-		
+
 		// Generates the model
 		CollegeDetentionYuki = CharacterLoadNPC("NPC_CollegeDetention_Yuki");
 		CollegeDetentionYuki.AllowItem = false;
@@ -194,13 +194,13 @@ function CollegeDetentionRestrainPlayer(Type) {
  */
 function CollegeDetentionInviteToPrivateRoom() {
 	CollegeDetentionDressBack();
-	
+
 	var ItemsToEarn = [];
 	ItemsToEarn.push({Name: "Ribbons2", Group: "HairAccessory1"});
 	ItemsToEarn.push({Name: "Ribbons2", Group: "HairAccessory3"});
 	ItemsToEarn.push({Name: "RegularSleepingPill", Group: "ItemMouth"});
 	InventoryAddMany(Player, ItemsToEarn);
-	
+
 	CommonSetScreen("Room", "Private");
 	PrivateAddCharacter(CollegeDetentionYuki, null, true);
 	var C = PrivateCharacter[PrivateCharacter.length - 1];

--- a/BondageClub/Screens/Room/CollegeEntrance/CollegeEntrance.js
+++ b/BondageClub/Screens/Room/CollegeEntrance/CollegeEntrance.js
@@ -6,22 +6,22 @@ var CollegeEntranceStudent = null;
  * Checks if the player can go to the tennis court
  * @returns {boolean} - Returns true if the player can go to the tennis court
  */
-function CollegeEntranceCanGoTennis() { return (Player.CanWalk() && Player.CanTalk() && !Player.IsRestrained() && CollegeEntranceIsWearingTennisClothes()) }
+function CollegeEntranceCanGoTennis() { return (Player.CanWalk() && Player.CanTalk() && !Player.IsRestrained() && CollegeEntranceIsWearingTennisClothes()); }
 /**
  * Checks if the player can go inside the college
  * @returns {boolean} - Returns true if the player can go inside the college
  */
-function CollegeEntranceCanGoInside() { return (Player.CanWalk() && Player.CanTalk() && !Player.IsRestrained() && CollegeEntranceIsWearingCollegeClothes()) }
+function CollegeEntranceCanGoInside() { return (Player.CanWalk() && Player.CanTalk() && !Player.IsRestrained() && CollegeEntranceIsWearingCollegeClothes()); }
 /**
  * Checks if the player can go to the detention room
  * @returns {boolean} - Returns true if the player can go to the detention room
  */
-function CollegeEntranceCanGoDetention() { return (Player.CanWalk() && Player.CanTalk() && !Player.IsRestrained() && CollegeEntranceIsWearingCollegeClothes()) }
+function CollegeEntranceCanGoDetention() { return (Player.CanWalk() && Player.CanTalk() && !Player.IsRestrained() && CollegeEntranceIsWearingCollegeClothes()); }
 /**
  * Checks if the player can go to the teacher room
  * @returns {boolean} - Returns true if the player can go to the teacher room
  */
-function CollegeEntranceCanGoTeacher() { return (Player.CanWalk() && Player.CanTalk() && !Player.IsRestrained() && CollegeEntranceIsWearingCollegeClothes() && LogQuery("TeacherKey", "College")) }
+function CollegeEntranceCanGoTeacher() { return (Player.CanWalk() && Player.CanTalk() && !Player.IsRestrained() && CollegeEntranceIsWearingCollegeClothes() && LogQuery("TeacherKey", "College")); }
 
 /**
  * Loads the college entrance room and its student NPC
@@ -66,7 +66,7 @@ function CollegeEntranceClick() {
 	if (MouseIn(1885, 343, 90, 90) && CollegeEntranceCanGoTennis()) CommonSetScreen("Room", "CollegeTennis");
 	if (MouseIn(1885, 449, 90, 90) && CollegeEntranceCanGoInside()) CommonSetScreen("Room", "CollegeCafeteria");
 	if (MouseIn(1885, 555, 90, 90) && CollegeEntranceCanGoInside()) CommonSetScreen("Room", "CollegeTheater");
-	if (MouseIn(1885, 661, 90, 90) && CollegeEntranceCanGoInside()) CommonSetScreen("Room", "CollegeChess");	
+	if (MouseIn(1885, 661, 90, 90) && CollegeEntranceCanGoInside()) CommonSetScreen("Room", "CollegeChess");
 	if (MouseIn(1885, 767, 90, 90) && CollegeEntranceCanGoDetention()) CommonSetScreen("Room", "CollegeDetention");
 	if (MouseIn(1885, 873, 90, 90) && CollegeEntranceCanGoTeacher()) CommonSetScreen("Room", "CollegeTeacher");
 }

--- a/BondageClub/Screens/Room/CollegeTeacher/CollegeTeacher.js
+++ b/BondageClub/Screens/Room/CollegeTeacher/CollegeTeacher.js
@@ -8,14 +8,14 @@ var CollegeTeacherMildredLove = 0;
  * Checks, if the teacher can be invited to the player's room
  * @returns {boolean} - Returns true, if the player can invite the teacher to her room, false otherwise
  */
-function CollegeTeacherCanInviteToPrivateRoom() { return (LogQuery("RentRoom", "PrivateRoom") && (PrivateCharacter.length < PrivateCharacterMax)) }
+function CollegeTeacherCanInviteToPrivateRoom() { return (LogQuery("RentRoom", "PrivateRoom") && (PrivateCharacter.length < PrivateCharacterMax)); }
 
 /**
  * Checks, if Mildred's love level is higher than a given value
  * @param {string} LoveLevel - The level of love to check against
  * @returns {boolean} - Returns true, if Mildred's love is equal or higher than the given level, false otherwise
  */
-function CollegeTeacherMildredLoveIs(LoveLevel) { return (CollegeTeacherMildredLove >= parseInt(LoveLevel)) }
+function CollegeTeacherMildredLoveIs(LoveLevel) { return (CollegeTeacherMildredLove >= parseInt(LoveLevel)); }
 
 /**
  * Fully dress-up Mildred
@@ -57,7 +57,7 @@ function CollegeTeacherLoad() {
 			for (let P = 1; P < PrivateCharacter.length; P++)
 				if (PrivateCharacter[P].Name == "Mildred")
 					return;
-		
+
 		// Generates the model
 		CollegeTeacherMildred = CharacterLoadNPC("NPC_CollegeTeacher_Mildred");
 		CollegeTeacherMildred.AllowItem = false;
@@ -92,7 +92,7 @@ function CollegeTeacherClick() {
 }
 
 /**
- * When Mildred love towards the player changes, it can also trigger an event.  
+ * When Mildred love towards the player changes, it can also trigger an event.
  * When a good or bad move is done, her expression will change quickly.
  * @param {string} LoveChange - The amount, the teacher's love changes
  * @param {string} Event - The event to trigger
@@ -111,7 +111,7 @@ function CollegeTeacherMildredLoveChange(LoveChange, Event) {
 	if (Event == "Hit") {
 		CharacterSetFacialExpression(Player, "Eyes", "Closed", 3);
 		CharacterSetFacialExpression(Player, "Blush", "Medium", 3);
-	}		
+	}
 	if (Event == "Gag") InventoryWear(Player, "DogMuzzleExposed", "ItemMouth");
 }
 

--- a/BondageClub/Screens/Room/CollegeTennis/CollegeTennis.js
+++ b/BondageClub/Screens/Room/CollegeTennis/CollegeTennis.js
@@ -9,12 +9,12 @@ var CollegeTennisJenniferWillJoinRoom = false;
  * @param {string} QueryStatus - Status to query
  * @returns {boolean} - Returns TRUE if Jennifer is currently in that status
  */
-function CollegeTennisJenniferStatusIs(QueryStatus) { return (QueryStatus == CollegeTennisJenniferStatus) }
+function CollegeTennisJenniferStatusIs(QueryStatus) { return (QueryStatus == CollegeTennisJenniferStatus); }
 /**
  * Checks if the player can invite a new character to a private room. (Used for Jennifer.)
  * @returns {boolean} - Returns TRUE if the player has a private room and an empty spot in it.
  */
-function CollegeTennisCanInviteToPrivateRoom() { return (LogQuery("RentRoom", "PrivateRoom") && (PrivateCharacter.length < PrivateCharacterMax)) }
+function CollegeTennisCanInviteToPrivateRoom() { return (LogQuery("RentRoom", "PrivateRoom") && (PrivateCharacter.length < PrivateCharacterMax)); }
 
 /**
  * Loads the tennis screen by generating Jennifer. The player's relationship with her from the bondage college is taken into consideration.
@@ -36,11 +36,11 @@ function CollegeTennisLoad() {
 
 	// Generates a full Jennifer model based on the Bondage College template
 	if (CollegeTennisJennifer == null) {
-		
+
 		// If Jennifer is away, we generate a random girl
 		CollegeTennisJennifer = CharacterLoadNPC("NPC_CollegeTennis_Jennifer");
 		CollegeTennisJennifer.AllowItem = false;
-		CharacterNaked(CollegeTennisJennifer);			
+		CharacterNaked(CollegeTennisJennifer);
 		if (CollegeTennisJenniferStatus != "Away") {
 			CollegeTennisJennifer.Name = "Jennifer";
 			InventoryWear(CollegeTennisJennifer, "PussyLight1", "Pussy", "#edd6b0");

--- a/BondageClub/Screens/Room/CollegeTheater/CollegeTheater.js
+++ b/BondageClub/Screens/Room/CollegeTheater/CollegeTheater.js
@@ -9,23 +9,23 @@ var CollegeTheaterRandomColors = ["#AA4444", "#44AA44", "#4444AA", "#AAAA44", "#
  * Checks if the player can invite an extra player to their private room. (Used for Julia.)
  * @returns {boolean} - Returns TRUE if the player has a private room and at least one empty place in it.
  */
-function CollegeTheaterCanInviteToPrivateRoom() { return (LogQuery("RentRoom", "PrivateRoom") && (PrivateCharacter.length < PrivateCharacterMax)) }
+function CollegeTheaterCanInviteToPrivateRoom() { return (LogQuery("RentRoom", "PrivateRoom") && (PrivateCharacter.length < PrivateCharacterMax)); }
 /**
  * Checks if Julia's love level is of a given level.
  * @param {number} LoveLevel - The love level threshold to check for.
  * @returns {boolean} - Returns TRUE if the current love level of Julia is at or above the given level
  */
-function CollegeTheaterJuliaLoveIs(LoveLevel) { return (CollegeTheaterJuliaLove >= parseInt(LoveLevel)) }
+function CollegeTheaterJuliaLoveIs(LoveLevel) { return (CollegeTheaterJuliaLove >= parseInt(LoveLevel)); }
 /**
  * Checks if the player can pick their role. The player can pick their role when they are a switch (not too submissive or dominant)
  * @returns {boolean} - Returns TRUE if the player can choose her role.
  */
-function CollegeTheaterCanChooseRole() { return ((ReputationGet("Dominant") > -30) && (ReputationGet("Dominant") < 30)) }
+function CollegeTheaterCanChooseRole() { return ((ReputationGet("Dominant") > -30) && (ReputationGet("Dominant") < 30)); }
 /**
  * Gives the teacher room key to the player.
  * @returns {void} - Nothing
  */
-function CollegeTheaterGetTeacherKey() { LogAdd("TeacherKey", "College") }
+function CollegeTheaterGetTeacherKey() { LogAdd("TeacherKey", "College"); }
 
 /**
  * Dresses Julia in her full theater outfit.
@@ -65,7 +65,7 @@ function CollegeTheaterLoad() {
 			for (let P = 1; P < PrivateCharacter.length; P++)
 				if (PrivateCharacter[P].Name == "Julia")
 					return;
-		
+
 		// Generates the model
 		CollegeTheaterJulia = CharacterLoadNPC("NPC_CollegeTheater_Julia");
 		CollegeTheaterJulia.AllowItem = false;
@@ -73,7 +73,7 @@ function CollegeTheaterLoad() {
 		CollegeTheaterJulia.GoneAway = false;
 		CollegeTheaterJuliaClothes();
 		CharacterRefresh(CollegeTheaterJulia);
-		
+
 	}
 
 }
@@ -138,7 +138,7 @@ function CollegeTheaterRandomBelt(C) {
 
 /**
  * Strips a character to her underwear
- * @param {Character} C - Character to strip 
+ * @param {Character} C - Character to strip
  * @returns {void} - Nothing
  */
 function CollegeTheaterUnderwear(C) {
@@ -150,7 +150,7 @@ function CollegeTheaterUnderwear(C) {
 
 /**
  * Triggered when Julia's love towards the player changes, it can also trigger an event.  When a good or bad move is done, her expression will change quickly.
- * @param {string} LoveChange - Number representing the change in love 
+ * @param {string} LoveChange - Number representing the change in love
  * @param {string} Event - The event that may have occured for the love factor to change.
  * @returns {void} - Nothing
  */
@@ -194,13 +194,13 @@ function CollegeTheaterDressBack() {
  */
 function CollegeTheaterInviteToPrivateRoom(Role) {
 	CollegeTheaterDressBack();
-	if (Role == "Witch") { 
+	if (Role == "Witch") {
 		let ItemsToEarn = [];
 		ItemsToEarn.push({Name: "WitchHat1", Group: "Hat"});
 		ItemsToEarn.push({Name: "BondageDress2", Group: "Cloth"});
 		InventoryAddMany(Player, ItemsToEarn);
 	}
-	if (Role == "Maiden") { 
+	if (Role == "Maiden") {
 		let ItemsToEarn = [];
 		ItemsToEarn.push({Name: "BatWings", Group: "Wings"});
 		ItemsToEarn.push({Name: "Dress2", Group: "Cloth"});

--- a/BondageClub/Screens/Room/DailyJob/DailyJob.js
+++ b/BondageClub/Screens/Room/DailyJob/DailyJob.js
@@ -12,7 +12,7 @@ var DailyJobDojoTeacher = null;
  * Triggered when a player is fully restrained from a daily job dialog
  * @returns {void} - Nothing
  */
-function DailyJobPlayerFullRestrain() { CharacterFullRandomRestrain(Player, "ALL") }
+function DailyJobPlayerFullRestrain() { CharacterFullRandomRestrain(Player, "ALL"); }
 
 /**
  * Loads a puppy girl and fully restrain her
@@ -211,7 +211,7 @@ function DailyJobDojoGameStart() {
 }
 
 /**
- * Triggered at the end of the dojo struggle job minigame 
+ * Triggered at the end of the dojo struggle job minigame
  * @returns {void} - Nothing
  */
 function DailyJobDojoGameEnd() {

--- a/BondageClub/Screens/Room/Empty/Empty.js
+++ b/BondageClub/Screens/Room/Empty/Empty.js
@@ -7,22 +7,22 @@ var EmptyCharacterOffset = 0;
  * Checks if the player struggled successfully within the allowed time
  * @returns {boolean} - Returns TRUE if the player managed to struggle out in time
  */
-function EmptyStruggleSuccess() { return (!Player.IsRestrained() && Player.CanTalk() && (CurrentTime < ManagementTimer)) }
+function EmptyStruggleSuccess() { return (!Player.IsRestrained() && Player.CanTalk() && (CurrentTime < ManagementTimer)); }
 /**
  * Checks if the player has not managed to struggle out in time
  * @returns {boolean} - Returns TRUE if the player has failed to struggle out.
  */
-function EmptyStruggleFail() { return (CurrentTime >= ManagementTimer) }
+function EmptyStruggleFail() { return (CurrentTime >= ManagementTimer); }
 /**
  * Checks if the player is in struggle mode.
  * @returns {boolean} - Returns TRUE if the player still has time to try to struggle out.
  */
-function EmptyStruggleProgress() { return ((Player.IsRestrained() || !Player.CanTalk()) && (CurrentTime < ManagementTimer)) }
+function EmptyStruggleProgress() { return ((Player.IsRestrained() || !Player.CanTalk()) && (CurrentTime < ManagementTimer)); }
 /**
  * Checks if the player can do a bondage training.
  * @returns {boolean} - Whether the player is ready to do a bondage training or not.
  */
-function EmptySlaveMarketReadyForBondageTraining() { return (Player.CanInteract() && !CurrentCharacter.CanTalk() && CurrentCharacter.IsBlind() && !CurrentCharacter.CanInteract() && !CurrentCharacter.CanWalk()) }
+function EmptySlaveMarketReadyForBondageTraining() { return (Player.CanInteract() && !CurrentCharacter.CanTalk() && CurrentCharacter.IsBlind() && !CurrentCharacter.CanInteract() && !CurrentCharacter.CanWalk()); }
 
 /**
  * Loads the empty room screen. Does nothing, required for future use and because it is called dynamically when loading the screen.
@@ -46,7 +46,7 @@ function EmptyRun() {
  */
 function EmptyClick() {
 	for (let C = 0; C < EmptyCharacter.length; C++)
-		if ((MouseX >= 1000 - EmptyCharacter.length * 250 + C * 500 + EmptyCharacterOffset) && (MouseX < 1500 - EmptyCharacter.length * 250 + C * 500 + EmptyCharacterOffset) && (MouseY >= 0) && (MouseY < 1000)) 
+		if ((MouseX >= 1000 - EmptyCharacter.length * 250 + C * 500 + EmptyCharacterOffset) && (MouseX < 1500 - EmptyCharacter.length * 250 + C * 500 + EmptyCharacterOffset) && (MouseY >= 0) && (MouseY < 1000))
 			CharacterSetCurrent(EmptyCharacter[C]);
 }
 
@@ -92,7 +92,7 @@ function EmptyShopEnd(Sold) {
 	CharacterSetCurrent(ShopVendor);
 	ShopVendor.CurrentDialog = DialogFind(ShopVendor, (Sold) ? "ItemSold" : "ItemNotSold").replace("MoneyAmount", ShopDemoItemPayment.toString());
 	CharacterAppearanceFullRandom(ShopCustomer, false);
-	CharacterRandomName(ShopCustomer)
+	CharacterRandomName(ShopCustomer);
 }
 
 /**
@@ -124,18 +124,18 @@ function EmptySlaveMarketTrainingLevelIs(TestLevel) {
  * @returns {void} - Nothing
  */
 function EmptySlaveMarketTrainingProgress(Intensity) {
-	
+
 	// Intensity of activity gets added minus from 0 to 3 of random decay
 	CurrentCharacter.TrainingIntensity = CurrentCharacter.TrainingIntensity + parseInt(Intensity) - Math.floor(Math.random() * 4);
 	if (CurrentCharacter.TrainingIntensity < 0) CurrentCharacter.TrainingIntensity = 0;
 	if (CurrentCharacter.TrainingIntensity > 10) CurrentCharacter.TrainingIntensity = 10;
 	CurrentCharacter.TrainingCount++;
-	
+
 	// Between 4 and 6 intensity is the sweet spot where training is successful
 	if (CurrentCharacter.TrainingIntensity <= 3) CurrentCharacter.TrainingCountLow++;
 	if ((CurrentCharacter.TrainingIntensity >= 4) && (CurrentCharacter.TrainingIntensity <= 6)) CurrentCharacter.TrainingCountPerfect++;
 	if (CurrentCharacter.TrainingIntensity >= 7) CurrentCharacter.TrainingCountHigh++;
-	
+
 	// When training is over, we take a different path depending if it was too soft, too rough or perfect
 	if (CurrentCharacter.TrainingCount == 10) {
 		CurrentCharacter.CurrentDialog = DialogFind(CurrentCharacter, "TrainingEnd");

--- a/BondageClub/Screens/Room/Gambling/Gambling.js
+++ b/BondageClub/Screens/Room/Gambling/Gambling.js
@@ -25,7 +25,7 @@ var GamblingToothpickCount = 0; // available Toothpicks
  * Checks if the player is helpless (maids disabled) or not.
  * @returns {boolean} - Returns true if the player still has time remaining after asking the maids to stop helping in the maid quarters
  */
-function GamblingIsMaidsDisabled() {  var expire = LogValue("MaidsDisabled", "Maid") - CurrentTime ; return (expire > 0)  }
+function GamblingIsMaidsDisabled() {  var expire = LogValue("MaidsDisabled", "Maid") - CurrentTime ; return (expire > 0);  }
 
 
 // Returns TRUE if a dialog is permitted
@@ -58,34 +58,34 @@ function GamblingSecondCanPlay() {return (!Player.IsRestrained() && Player.CanTa
  * Checks, if the simple dice game can be offered
  * @returns {boolean} - Returns true, if the left sub can offer games, false otherwise
  */
-function GamblingCanPlaySimpleDice() {return GamblingFirstCanPlay()}
+function GamblingCanPlaySimpleDice() {return GamblingFirstCanPlay();}
 /**
  * Checks, if the game of 21 can be offered
- * @returns {boolean} - Returns true, if the left sub can offer games 
+ * @returns {boolean} - Returns true, if the left sub can offer games
  * and the player's reputation is higer than 10, false otherwise
  */
 function GamblingCanPlayTwentyOne() {return (GamblingFirstCanPlay() && ReputationGet("Gambling") >= 10);}
 /**
  * Checks, if the toothpick game can be offered
- * @returns {boolean} - Returns true, if the left sub can offer games 
+ * @returns {boolean} - Returns true, if the left sub can offer games
  * and the player's reputation is higer than 20, false otherwise
  */
 function GamblingCanPlayToothpick() {return (GamblingFirstCanPlay() && ReputationGet("Gambling") >= 20);}
 /**
  * Checks, if the game 'Catch the fox' can be offered
- * @returns {boolean} - Returns true, if the right sub can offer games, the player's reputation is higer than 30 
+ * @returns {boolean} - Returns true, if the right sub can offer games, the player's reputation is higer than 30
  * and she has enough money, false otherwise
  */
 function GamblingCanPlayFox() {return (GamblingSecondCanPlay() && (ReputationGet("Gambling") >= 30) && (Player.Money >= 10));}
 /**
  * Checks, if the game 'Street to Roissy' can be offered
- * @returns {boolean} - Returns true, if the right sub can offer games, the player's reputation is higer than 40 
+ * @returns {boolean} - Returns true, if the right sub can offer games, the player's reputation is higer than 40
  * and she has enough money, false otherwise
  */
 function GamblingCanPlayStreetRoissy() {return (GamblingSecondCanPlay() && (ReputationGet("Gambling") >= 40) && (Player.Money >= 30));}
 /**
  * Checks, if the game 'Dare Six' can be offered
- * @returns {boolean} - Returns true, if the right sub can offer games, the player's reputation is higer than 50 
+ * @returns {boolean} - Returns true, if the right sub can offer games, the player's reputation is higer than 50
  * and she has enough money, false otherwise
  */
 function GamblingCanPlayDaredSix() {return (GamblingSecondCanPlay() && (ReputationGet("Gambling") >= 50) && (Player.Money >= 50));}
@@ -94,44 +94,44 @@ function GamblingCanPlayDaredSix() {return (GamblingSecondCanPlay() && (Reputati
  * Checks, if the player can take one toothpick
  * @returns {boolean} - Returns true, if there is more than one pick left, false otherwise
  */
-function GamblingToothpickCanPickOne() {return GamblingToothpickCount >= 1}
+function GamblingToothpickCanPickOne() {return GamblingToothpickCount >= 1;}
 /**
  * Checks, if the player can take two toothpicks
  * @returns {boolean} - Returns true, if there are more than two picks left, false otherwise
  */
-function GamblingToothpickCanPickTwo() {return GamblingToothpickCount >= 2}
+function GamblingToothpickCanPickTwo() {return GamblingToothpickCount >= 2;}
 /**
  * Checks, if the player can take three toothpicks
  * @returns {boolean} - Returns true, if there are more than three picks left, false otherwise
  */
-function GamblingToothpickCanPickThree() {return GamblingToothpickCount >= 3}
+function GamblingToothpickCanPickThree() {return GamblingToothpickCount >= 3;}
 
 /**
  * Checks, if the player is restrained with a locked item
  * @returns {boolean} - Returns true if a restraint is locked on the player, false otherwise
  */
-function GamblingIsRestrainedWithLock() { return InventoryCharacterHasLockedRestraint(Player) }
+function GamblingIsRestrainedWithLock() { return InventoryCharacterHasLockedRestraint(Player); }
 /**
  * Checks, wether the player is restrained but no lock is used
  * @returns {boolean} - Returns true, if the player is restarined, but no lock was used, false otherwise
  */
-function GamblingIsRestrainedWithoutLock() { return (Player.IsRestrained() && !InventoryCharacterHasLockedRestraint(Player)) }
+function GamblingIsRestrainedWithoutLock() { return (Player.IsRestrained() && !InventoryCharacterHasLockedRestraint(Player)); }
 
 /**
  * Checks, if the player owns enough money to pay for her release
  * @returns {boolean} - Returns true, if the player is not restrained with a lock and owns at least $25, false otherwise
  */
-function GamblingCanPayToRelease() { return ((Player.Money >= 25) && !InventoryCharacterHasLockedRestraint(Player)) }
+function GamblingCanPayToRelease() { return ((Player.Money >= 25) && !InventoryCharacterHasLockedRestraint(Player)); }
 /**
  * Checks, if the player is too poor to pay for her release
  * @returns {boolean} - Returns true, if the player is not restrained with a lock and owns less than $25, false otherwise
  */
-function GamblingCannotPayToRelease() { return ((Player.Money < 25) && !InventoryCharacterHasLockedRestraint(Player)) }
+function GamblingCannotPayToRelease() { return ((Player.Money < 25) && !InventoryCharacterHasLockedRestraint(Player)); }
 /**
  * Checks, if the player can steal the dice
  * @returns {boolean} - Returns true, if the player is able to steal the dice, false otherwise
  */
-function GamblingCanStealDice() {return (LogQuery("Joined", "BadGirl") && !(LogQuery("Stolen", "BadGirl") || LogQuery("Hide", "BadGirl"))) }
+function GamblingCanStealDice() {return (LogQuery("Joined", "BadGirl") && !(LogQuery("Stolen", "BadGirl") || LogQuery("Hide", "BadGirl"))); }
 
 /**
  * Loads the Gambling Hall and creates the two subs. If the player is on a rescue mission, the restraints are created.
@@ -139,7 +139,7 @@ function GamblingCanStealDice() {return (LogQuery("Joined", "BadGirl") && !(LogQ
  * @returns {void} - Nothing
  */
 function GamblingLoad() {
-	
+
 	// Default load
 	if (GamblingFirstSub == null) {
 		GamblingFirstSub =  CharacterLoadNPC("NPC_Gambling_FirstSub");
@@ -149,26 +149,26 @@ function GamblingLoad() {
 		GamblingAppearanceFirst = GamblingFirstSub.Appearance.slice();
 		GamblingAppearanceSecond = GamblingSecondSub.Appearance.slice();
 	}
-	
+
 	GamblingAppearancePlayer = Player.Appearance.slice();
 	GamblingIllegalChange = false;
-	
+
 	// Rescue mission load
 	if ((MaidQuartersCurrentRescue == "Gambling") && !MaidQuartersCurrentRescueStarted) {
 		MaidQuartersCurrentRescueStarted = true;
 		CharacterNaked(GamblingFirstSub);
-		InventoryWearRandom(GamblingFirstSub, "ItemLegs"); 
-		InventoryWearRandom(GamblingFirstSub, "ItemFeet"); 
-		InventoryWearRandom(GamblingFirstSub, "ItemArms"); 
-		InventoryWearRandom(GamblingFirstSub, "ItemMouth"); 
+		InventoryWearRandom(GamblingFirstSub, "ItemLegs");
+		InventoryWearRandom(GamblingFirstSub, "ItemFeet");
+		InventoryWearRandom(GamblingFirstSub, "ItemArms");
+		InventoryWearRandom(GamblingFirstSub, "ItemMouth");
 		InventoryWear(GamblingFirstSub, "LeatherBlindfold", "ItemHead");
 		GamblingFirstSub.AllowItem = true;
 		GamblingFirstSub.Stage = "MaidRescue";
 		CharacterNaked(GamblingSecondSub);
-		InventoryWearRandom(GamblingSecondSub, "ItemLegs"); 
-		InventoryWearRandom(GamblingSecondSub, "ItemFeet"); 
-		InventoryWearRandom(GamblingSecondSub, "ItemArms"); 
-		InventoryWearRandom(GamblingSecondSub, "ItemMouth"); 
+		InventoryWearRandom(GamblingSecondSub, "ItemLegs");
+		InventoryWearRandom(GamblingSecondSub, "ItemFeet");
+		InventoryWearRandom(GamblingSecondSub, "ItemArms");
+		InventoryWearRandom(GamblingSecondSub, "ItemMouth");
 		InventoryWear(GamblingSecondSub, "LeatherBlindfold", "ItemHead");
 		GamblingSecondSub.AllowItem = true;
 		GamblingSecondSub.Stage = "MaidRescue";
@@ -176,7 +176,7 @@ function GamblingLoad() {
 }
 
 /**
- * Run the Gambling Hall, draw all characters. This function is called dynamically at very short intervals. 
+ * Run the Gambling Hall, draw all characters. This function is called dynamically at very short intervals.
  * Don't use expensive loops or call expensive functions from here
  * @returns {void} - Nothing
  */
@@ -270,7 +270,7 @@ function GamblingSimpleDiceController(SimpleDiceState) {
 			GamblingFirstSub.AllowItem = false;
 			GamblingFirstSub.Stage = 82;
 			}
-		if (GamblingPlayerDice == GamblingNpcDice) { 
+		if (GamblingPlayerDice == GamblingNpcDice) {
 			GamblingFirstSub.AllowItem = false;
 			GamblingFirstSub.Stage = 83;
 			}
@@ -295,7 +295,7 @@ function GamblingShowToothpickStack () {
 	for (let i = 0; i < GamblingToothpickCount; i++) {
 		DrawImageResize("Screens/Room/Gambling/toothpick.png", 410, 45 + 26 * i, 160, 7);
 	}
-	DrawText(GamblingToothpickCount, 490, 25, "white", "black")
+	DrawText(GamblingToothpickCount, 490, 25, "white", "black");
 	return true;
 }
 
@@ -307,28 +307,28 @@ function GamblingShowToothpickStack () {
 function GamblingToothpickController (ToothpickState) {
 	if (ToothpickState == "new") {
 		GamblingToothpickCount = 15;
-		GamblingFirstSub.Stage = 200
+		GamblingFirstSub.Stage = 200;
 	}
 
 	else if (ToothpickState == "give_up") {
 		GamblingFirstSub.Stage = 203;
 	}
-	
+
 	else if (ToothpickState == "win") {
 		ReputationProgress("Gambling", 1);
 		GamblingFirstSub.AllowItem = true;
 	}
-	
+
 	else if (ToothpickState == "lost") {
-		var difficulty = Math.floor(Math.random() * 5) + 2
+		var difficulty = Math.floor(Math.random() * 5) + 2;
 		InventoryWearRandom(Player, "ItemArms", difficulty);
-		InventoryWearRandom(Player, "ItemMouth", difficulty); 
-		InventoryWearRandom(Player, "ItemLegs", difficulty); 
-		InventoryWearRandom(Player, "ItemFeet", difficulty); 
+		InventoryWearRandom(Player, "ItemMouth", difficulty);
+		InventoryWearRandom(Player, "ItemLegs", difficulty);
+		InventoryWearRandom(Player, "ItemFeet", difficulty);
 	}
 
 	else {
-		GamblingToothpickCount -= ToothpickState
+		GamblingToothpickCount -= ToothpickState;
 
 		// has player lost?
 		if (GamblingToothpickCount <= 0) {
@@ -338,12 +338,12 @@ function GamblingToothpickController (ToothpickState) {
 
 		// NPC
 		if (GamblingToothpickCount > 0) {
-			var npc_choice = GamblingToothpickNPCChoice()
-			GamblingFirstSub.Stage = 201
+			var npc_choice = GamblingToothpickNPCChoice();
+			GamblingFirstSub.Stage = 201;
 			GamblingFirstSub.CurrentDialog = DialogFind(GamblingFirstSub, "Toothpick" + npc_choice.toString());
-			GamblingToothpickCount -= npc_choice
-			GamblingFirstSub.Stage = 200
-		
+			GamblingToothpickCount -= npc_choice;
+			GamblingFirstSub.Stage = 200;
+
 			// has NPC lost?
 			if (GamblingToothpickCount <= 0) {
 				GamblingFirstSub.Stage = 201;
@@ -357,13 +357,13 @@ function GamblingToothpickController (ToothpickState) {
  * @returns {number} - The toothpicks the NPC draws
  */
 function GamblingToothpickNPCChoice() {
-	var max_pick = (GamblingToothpickCount >= 3) ? 3 : GamblingToothpickCount
+	var max_pick = (GamblingToothpickCount >= 3) ? 3 : GamblingToothpickCount;
 	var choice = Math.floor(Math.random() * max_pick) + 1;
-	if (GamblingToothpickCount == 6) {choice = 1}
-	else if (GamblingToothpickCount == 4) {choice = 3}
-	else if (GamblingToothpickCount == 3) {choice = 2}
-	else if (GamblingToothpickCount == 2) {choice = 1}
-	return choice
+	if (GamblingToothpickCount == 6) {choice = 1;}
+	else if (GamblingToothpickCount == 4) {choice = 3;}
+	else if (GamblingToothpickCount == 3) {choice = 2;}
+	else if (GamblingToothpickCount == 2) {choice = 1;}
+	return choice;
 }
 
 /**
@@ -372,7 +372,7 @@ function GamblingToothpickNPCChoice() {
  * @returns {void} - Nothing
  */
 function GamblingTwentyOneController(TwentyOneState) {
-	
+
 	if (TwentyOneState == "new") {
 		// Start a New Game
 		Player.Appearance = GamblingAppearancePlayer.slice();
@@ -390,11 +390,11 @@ function GamblingTwentyOneController(TwentyOneState) {
 			GamblingPlayerDiceStack[GamblingPlayerDiceStack.length] = GamblingPlayerDice;
 		}
 		GamblingFirstSub.Stage = 100 + GamblingDiceStackSum(GamblingPlayerDiceStack);
-	
+
 	} else if (TwentyOneState == "add") {
 		//Get on more Dice
 		GamblingPlayerDice = Math.floor(Math.random() * 6) + 1;
-		GamblingPlayerDiceStack[GamblingPlayerDiceStack.length] = GamblingPlayerDice; 
+		GamblingPlayerDiceStack[GamblingPlayerDiceStack.length] = GamblingPlayerDice;
 		GamblingFirstSub.Stage = 100 + GamblingDiceStackSum(GamblingPlayerDiceStack);
 		if (GamblingDiceStackSum(GamblingPlayerDiceStack) > 21) {
 			GamblingPlayerSubState = GamblingPlayerSubState +1;
@@ -404,13 +404,13 @@ function GamblingTwentyOneController(TwentyOneState) {
 			GamblingNpcSubState = GamblingNpcSubState +1;
 			GamblingFirstSub.Stage = 160 + GamblingNpcSubState;
 		}
-	
+
 	} else if (TwentyOneState == "fin") {
 		//The Player is fin in this turn
 		//The GamblingFirstSub dices as she win or over 21
 		while (GamblingDiceStackSum(GamblingNpcDiceStack) <= GamblingDiceStackSum(GamblingPlayerDiceStack) && GamblingDiceStackSum(GamblingNpcDiceStack) < 22) {
 			GamblingNpcDice = Math.floor(Math.random() * 6) + 1;
-			GamblingNpcDiceStack[GamblingNpcDiceStack.length] = GamblingNpcDice; 
+			GamblingNpcDiceStack[GamblingNpcDiceStack.length] = GamblingNpcDice;
 		}
 		if (GamblingDiceStackSum(GamblingNpcDiceStack) > GamblingDiceStackSum(GamblingPlayerDiceStack) && GamblingDiceStackSum(GamblingNpcDiceStack) < 22) {
 			GamblingPlayerSubState = GamblingPlayerSubState +1;
@@ -419,7 +419,7 @@ function GamblingTwentyOneController(TwentyOneState) {
 			GamblingNpcSubState = GamblingNpcSubState +1;
 			GamblingFirstSub.Stage = 160 + GamblingNpcSubState;
 		}
-	
+
 	} else if (TwentyOneState == "win_next") {
 		//The winner stiped the loser
 		//the next turn started automaticly
@@ -428,10 +428,10 @@ function GamblingTwentyOneController(TwentyOneState) {
 			Player.Appearance = GamblingAppearancePlayer.slice();
 			CharacterRefresh(Player);
 			GamblingFirstSub.AllowItem = true;
-			GamblingFirstSub.Stage = 0; 
+			GamblingFirstSub.Stage = 0;
 			ReputationProgress("Gambling", 3);
-			}		
-		
+			}
+
 		GamblingPlayerDiceStack = [];
 		GamblingNpcDiceStack = [];
 		for (let i = 1; i <= 3; i++) {
@@ -439,7 +439,7 @@ function GamblingTwentyOneController(TwentyOneState) {
 			GamblingPlayerDiceStack[GamblingPlayerDiceStack.length] = GamblingPlayerDice;
 		}
 		if (GamblingFirstSub.Stage != 0) {GamblingFirstSub.Stage = 100 + GamblingDiceStackSum(GamblingPlayerDiceStack); }
-	
+
 	} else if (TwentyOneState == "lost_next") {
 		//the loser Player ist stipped by winner
 		//the next turn started automaticly
@@ -447,7 +447,7 @@ function GamblingTwentyOneController(TwentyOneState) {
 			CharacterRelease(GamblingFirstSub);
 			GamblingFirstSub.Appearance = GamblingAppearanceFirst.slice();
 			CharacterRefresh(GamblingFirstSub);
-			GamblingFirstSub.Stage = 0; 
+			GamblingFirstSub.Stage = 0;
 			}
 
 		GamblingPlayerDiceStack = [];
@@ -469,13 +469,13 @@ function GamblingFoxController(FoxState) {
 			GamblingPlayerDiceStack = [];
 			GamblingNpcDiceStack = [];
 			GamblingShowMoney = true;
-		} else if (FoxState == "fox") { 
+		} else if (FoxState == "fox") {
 			GamblingPlayerIsFox = true;
 			GamblingPlayerDice = Math.floor(Math.random() * 6) + 1;
 			GamblingPlayerDiceStack[GamblingPlayerDiceStack.length] = GamblingPlayerDice;
 			GamblingMoneyBet = 5;
 			GamblingSecondSub.Stage = 101;
-		} else if (FoxState == "hunter") { 
+		} else if (FoxState == "hunter") {
 			GamblingPlayerIsFox = false;
 			GamblingMoneyBet = 5;
 			CharacterChangeMoney(Player, GamblingMoneyBet * -1);
@@ -486,7 +486,7 @@ function GamblingFoxController(FoxState) {
 			GamblingPlayerDice = Math.floor(Math.random() * 6) + 1;
 			GamblingPlayerDiceStack[GamblingPlayerDiceStack.length] = GamblingPlayerDice;
 			GamblingNpcDice = Math.floor(Math.random() * 6) + 1;
-			GamblingNpcDiceStack[GamblingNpcDiceStack.length] = GamblingNpcDice; 
+			GamblingNpcDiceStack[GamblingNpcDiceStack.length] = GamblingNpcDice;
 			if (GamblingPlayerIsFox && GamblingDiceStackSum(GamblingPlayerDiceStack) >= 30) {
 				//player has won
 				GamblingSecondSub.Stage = 102;
@@ -513,14 +513,14 @@ function GamblingFoxController(FoxState) {
 			GamblingShowMoney = false;
 		} else if (FoxState == "player_fox_lost") {
 			GamblingSecondSub.AllowItem = false;
-			InventoryWearRandom(Player, "ItemLegs"); 
-			InventoryWearRandom(Player, "ItemFeet"); 
-			InventoryWearRandom(Player, "ItemArms"); 
+			InventoryWearRandom(Player, "ItemLegs");
+			InventoryWearRandom(Player, "ItemFeet");
+			InventoryWearRandom(Player, "ItemArms");
 			GamblingPlayerDiceStack = [];
 			GamblingNpcDiceStack = [];
 			GamblingShowMoney = false;
 		} else if (FoxState == "player_hunter_win") {
-			InventoryWearRandom(GamblingSecondSub, "ItemArms"); 
+			InventoryWearRandom(GamblingSecondSub, "ItemArms");
 			GamblingSecondSub.AllowItem = true;
 			GamblingSecondSub.CurrentDialog = GamblingSecondSub.CurrentDialog.replace("REPLACEMONEY", GamblingMoneyBet.toString());
 			CharacterChangeMoney(Player, GamblingMoneyBet);
@@ -574,7 +574,7 @@ function GamblingStreetRoissyController (StreetRoissyState) {
 				//Player win
 				GamblingSecondSub.Stage = 240 + GamblingPlayerSubState;
 			}
-		} else { 
+		} else {
 			if (GamblingNpcDice == GamblingNpcSubState) {
 				//NPC win turn
 				GamblingSecondSub.Stage = 230 + GamblingNpcSubState;
@@ -596,7 +596,7 @@ function GamblingStreetRoissyController (StreetRoissyState) {
 		GamblingNpcSubState++;
 		GamblingSecondSub.Stage = 200;
 	} else if (StreetRoissyState == "win") {
-		GamblingSecondSub.Stage = 0; 
+		GamblingSecondSub.Stage = 0;
 		if (GamblingStripTied(GamblingSecondSub, GamblingPlayerSubState)) {
 			ReputationProgress("Gambling", 2);
 			CharacterRelease(Player);
@@ -611,7 +611,7 @@ function GamblingStreetRoissyController (StreetRoissyState) {
 			GamblingSecondSub.Stage = 200;
 		}
 	} else if (StreetRoissyState == "lost") {
-		GamblingSecondSub.Stage = 0; 
+		GamblingSecondSub.Stage = 0;
 		if (GamblingStripTied(Player, GamblingNpcSubState)) {
 			CharacterRelease(GamblingSecondSub);
 			GamblingSecondSub.CurrentDialog = GamblingSecondSub.CurrentDialog.replace("REPLACEMONEY", GamblingMoneyBet.toString());
@@ -619,19 +619,19 @@ function GamblingStreetRoissyController (StreetRoissyState) {
 			CharacterRefresh(GamblingSecondSub);
 			GamblingSecondSub.AllowItem = false;
 			GamblingStreetRoissyController ("end");
-		} else {	
+		} else {
 			GamblingNpcSubState++;
 			GamblingSecondSub.Stage = 200;
 		}
 	} else if (StreetRoissyState == "end") {
 		GamblingMoneyBet = 0;
 		GamblingPlayerSubState = 1;
-		GamblingNpcSubState = 1; 
+		GamblingNpcSubState = 1;
 		GamblingPlayerDiceStack = [];
 		GamblingNpcDiceStack = [];
 		GamblingShowDiceSum = true;
 		GamblingShowMoney = false;
-	}		
+	}
 }
 
 /**
@@ -646,7 +646,7 @@ function GamblingDaredSixController(DaredSixState) {
 		Player.Appearance = GamblingAppearancePlayer.slice();
 		GamblingSecondSub.Appearance = GamblingAppearanceSecond.slice();
 		GamblingPlayerSubState = GamblingDressingLevel(Player) + 1;
-		GamblingNpcSubState = 1; 
+		GamblingNpcSubState = 1;
 		GamblingPlayerDiceStack = [];
 		GamblingNpcDiceStack = [];
 		CharacterRefresh(GamblingSecondSub);
@@ -662,13 +662,13 @@ function GamblingDaredSixController(DaredSixState) {
 		{
 			//Player lost automaticly
 			GamblingSecondSub.Stage = 310 + GamblingPlayerSubState;
-		} 
+		}
 	} else if (DaredSixState == "fin") {
 		do {
 		GamblingNpcDice = Math.floor(Math.random() * 6) + 1;
 		GamblingNpcDiceStack[GamblingNpcDiceStack.length] = GamblingNpcDice;
 		GamblingMoneyBet++;
-		} while (GamblingDiceStackSum(GamblingNpcDiceStack) <= GamblingDiceStackSum(GamblingPlayerDiceStack) && GamblingNpcDice != 6 ); 
+		} while (GamblingDiceStackSum(GamblingNpcDiceStack) <= GamblingDiceStackSum(GamblingPlayerDiceStack) && GamblingNpcDice != 6 );
 		if (GamblingNpcDice == 6)
 		{
 			//GamblingNpcDice lost automaticly
@@ -686,12 +686,12 @@ function GamblingDaredSixController(DaredSixState) {
 			Player.Appearance = GamblingAppearancePlayer.slice();
 			CharacterRefresh(Player);
 			GamblingSecondSub.AllowItem = true;
-			GamblingSecondSub.Stage = 330; 
+			GamblingSecondSub.Stage = 330;
 			GamblingSecondSub.CurrentDialog = GamblingSecondSub.CurrentDialog.replace("REPLACEMONEY", GamblingMoneyBet.toString());
 			GamblingMoneyBet = 0;
 			ReputationProgress("Gambling", 3);
 			GamblingShowMoney = false;
-		} else {		
+		} else {
 			GamblingNpcSubState++;
 			GamblingDaredSixController("add");
 		}
@@ -703,7 +703,7 @@ function GamblingDaredSixController(DaredSixState) {
 			GamblingSecondSub.Appearance = GamblingAppearanceSecond.slice();
 			CharacterRefresh(GamblingSecondSub);
 			GamblingSecondSub.AllowItem = false;
-			GamblingSecondSub.Stage = 340; 
+			GamblingSecondSub.Stage = 340;
 			GamblingSecondSub.CurrentDialog = GamblingSecondSub.CurrentDialog.replace("REPLACEMONEY", GamblingMoneyBet.toString());
 			GamblingMoneyBet = 0;
 			GamblingShowMoney = false;
@@ -711,8 +711,8 @@ function GamblingDaredSixController(DaredSixState) {
 			GamblingPlayerSubState++;
 			GamblingDaredSixController("add");
 		}
-	}		
-}	
+	}
+}
 
 /**
  * Get the dressinglevel for characters
@@ -737,23 +737,23 @@ function GamblingDressingLevel(C) {
 function GamblingStripTied(gstCarachter, gstLevel) {
 	var r = false;
 	if (gstLevel == 1) {
-		InventoryRemove(gstCarachter, "Hat"); 
-		InventoryRemove(gstCarachter, "Shoes"); 
-		InventoryRemove(gstCarachter, "Gloves"); 
+		InventoryRemove(gstCarachter, "Hat");
+		InventoryRemove(gstCarachter, "Shoes");
+		InventoryRemove(gstCarachter, "Gloves");
 	} else if (gstLevel == 2) {
-		InventoryRemove(gstCarachter, "Cloth"); 
-		InventoryRemove(gstCarachter, "ClothLower"); 
+		InventoryRemove(gstCarachter, "Cloth");
+		InventoryRemove(gstCarachter, "ClothLower");
 	} else if (gstLevel == 3) {
-		InventoryRemove(gstCarachter, "Bra"); 
-		InventoryRemove(gstCarachter, "Panties"); 
-		InventoryRemove(gstCarachter, "Socks"); 
+		InventoryRemove(gstCarachter, "Bra");
+		InventoryRemove(gstCarachter, "Panties");
+		InventoryRemove(gstCarachter, "Socks");
 	} else if (gstLevel == 4) {
-		InventoryWearRandom(gstCarachter, "ItemLegs"); 
-		InventoryWearRandom(gstCarachter, "ItemFeet"); 
+		InventoryWearRandom(gstCarachter, "ItemLegs");
+		InventoryWearRandom(gstCarachter, "ItemFeet");
 	} else if (gstLevel == 5) {
-		InventoryWearRandom(gstCarachter, "ItemArms"); 
+		InventoryWearRandom(gstCarachter, "ItemArms");
 	} else if (gstLevel == 6) {
-		InventoryWearRandom(gstCarachter, "ItemMouth"); 
+		InventoryWearRandom(gstCarachter, "ItemMouth");
 		r = true;
 	}
 	return r;

--- a/BondageClub/Screens/Room/Infiltration/Infiltration.js
+++ b/BondageClub/Screens/Room/Infiltration/Infiltration.js
@@ -11,19 +11,19 @@ var InfiltrationTarget = {};
  * Returns TRUE if the mission can complete as a success
  * @returns {boolean} - TRUE if successful
  */
-function InfiltrationCanSuccess() { return ((InfiltrationTarget != null) && (InfiltrationTarget.Found != null) && (InfiltrationTarget.Found == true)) }
+function InfiltrationCanSuccess() { return ((InfiltrationTarget != null) && (InfiltrationTarget.Found != null) && (InfiltrationTarget.Found == true)); }
 
 /**
  * Returns TRUE if the mission can complete as a failure
  * @returns {boolean} - TRUE if successful
  */
-function InfiltrationCanFail() { return ((InfiltrationTarget == null) || (InfiltrationTarget.Found == null) || (InfiltrationTarget.Found == false)) }
+function InfiltrationCanFail() { return ((InfiltrationTarget == null) || (InfiltrationTarget.Found == null) || (InfiltrationTarget.Found == false)); }
 
 /**
  * Returns TRUE if the player can go back to Pandora's Box to pursue her mission
  * @returns {boolean} - TRUE if successful
  */
-function InfiltrationCanGoBack() { return (((InfiltrationTarget == null) || (InfiltrationTarget.Fail == null) || (InfiltrationTarget.Fail == false)) && !InfiltrationCanSuccess()) }
+function InfiltrationCanGoBack() { return (((InfiltrationTarget == null) || (InfiltrationTarget.Fail == null) || (InfiltrationTarget.Fail == false)) && !InfiltrationCanSuccess()); }
 
 /**
  * Loads the infiltration screen by generating the supervisor.

--- a/BondageClub/Screens/Room/InfiltrationPerks/InfiltrationPerks.js
+++ b/BondageClub/Screens/Room/InfiltrationPerks/InfiltrationPerks.js
@@ -79,7 +79,7 @@ function InfiltrationPerksRun() {
  */
 function InfiltrationPerksClick() {
 	if (MouseIn(1815, 75, 90, 90)) InfiltrationPerksExit();
-	if (InfiltrationSupervisor.Stage !== "End") 
+	if (InfiltrationSupervisor.Stage !== "End")
 		for (let P = 0; P < InfiltrationPerksList.length; P++)
 			if (MouseIn(150 + Math.floor(P / 8) * 850, 115 + ((P % 8) * 100), 64, 64))
 				InfiltrationPerksActivate(InfiltrationPerksList[P]);

--- a/BondageClub/Screens/Room/Introduction/Introduction.js
+++ b/BondageClub/Screens/Room/Introduction/Introduction.js
@@ -23,42 +23,42 @@ var IntroductionJobMember = [];
  * @param {string} ScenarioName - Name of the rescue scenario to check for.
  * @returns {boolean} - Returns TRUE if the given scenario is the current active one.
  */
-function IntroductionIsRescueScenario(ScenarioName) { return (IntroductionRescueScenario == ScenarioName) }
+function IntroductionIsRescueScenario(ScenarioName) { return (IntroductionRescueScenario == ScenarioName); }
 /**
  * Checks if the two NPCs in the introduction room are free.
  * @returns {boolean} - Returns TRUE if both the maid and the sub is free.
  */
-function IntroductionIsBothFree() { return (!IntroductionMaid.IsRestrained() && IntroductionMaid.CanTalk() && !IntroductionSub.IsRestrained() && IntroductionMaid.CanTalk()) }
+function IntroductionIsBothFree() { return (!IntroductionMaid.IsRestrained() && IntroductionMaid.CanTalk() && !IntroductionSub.IsRestrained() && IntroductionMaid.CanTalk()); }
 /**
  * Checks if the introduction maid is restrained.
  * @returns {boolean} - Returns TRUE if the introduction maid is restrained
  */
-function IntroductionIsMaidRestrained() { return (IntroductionMaid.IsRestrained() || !IntroductionMaid.CanTalk()) }
+function IntroductionIsMaidRestrained() { return (IntroductionMaid.IsRestrained() || !IntroductionMaid.CanTalk()); }
 /**
  * Checks if the player has no title
  * @returns {boolean} - Returns TRUE if the player is not a maid or a mistress.
  */
-function IntroductionNoTitle() { return (!LogQuery("JoinedSorority", "Maid") && !LogQuery("ClubMistress", "Management")) }
+function IntroductionNoTitle() { return (!LogQuery("JoinedSorority", "Maid") && !LogQuery("ClubMistress", "Management")); }
 /**
  * Checks if the introduction job is completed
  * @returns {boolean} - Returns TRUE if the introduction job was done.
  */
-function IntroductionJobIsComplete() { return (IntroductionJobCount <= 0) }
+function IntroductionJobIsComplete() { return (IntroductionJobCount <= 0); }
 /**
  * Checks if the player can take a job.
  * @returns {boolean} - Returns TRUE if a job is available and the player is able to take one.
  */
-function IntroductionCanTakeJob() { return (IntroductionJobAnyAvailable() && !Player.IsRestrained() && Player.CanTalk() && !IntroductionMaid.IsRestrained() && IntroductionMaid.CanTalk() && !ManagementIsClubSlave()) }
+function IntroductionCanTakeJob() { return (IntroductionJobAnyAvailable() && !Player.IsRestrained() && Player.CanTalk() && !IntroductionMaid.IsRestrained() && IntroductionMaid.CanTalk() && !ManagementIsClubSlave()); }
 /**
  * Checks if the player is able to take a job, but none are available.
  * @returns {boolean} - Returns TRUE if there is no job available while the player is able to take one.
  */
-function IntroductionCannotTakeJobDone() { return (!IntroductionJobAnyAvailable() && !Player.IsRestrained() && Player.CanTalk() && !IntroductionMaid.IsRestrained() && IntroductionMaid.CanTalk() && !ManagementIsClubSlave()) }
+function IntroductionCannotTakeJobDone() { return (!IntroductionJobAnyAvailable() && !Player.IsRestrained() && Player.CanTalk() && !IntroductionMaid.IsRestrained() && IntroductionMaid.CanTalk() && !ManagementIsClubSlave()); }
 /**
  * Checks if the player has jobs available, but is restrained
  * @returns {boolean} - Returns TRUE if the players is restrained while a job is available.
  */
-function IntroductionCannotTakeJobRestrained() { return (IntroductionJobAnyAvailable() && (Player.IsRestrained() || !Player.CanTalk() || IntroductionMaid.IsRestrained() || !IntroductionMaid.CanTalk()) && !ManagementIsClubSlave()) }
+function IntroductionCannotTakeJobRestrained() { return (IntroductionJobAnyAvailable() && (Player.IsRestrained() || !Player.CanTalk() || IntroductionMaid.IsRestrained() || !IntroductionMaid.CanTalk()) && !ManagementIsClubSlave()); }
 
 /**
  * Loads the introduction room and its 2 NPCS
@@ -70,7 +70,7 @@ function IntroductionLoad() {
 	IntroductionHasBasicItems = (InventoryAvailable(Player, "NylonRope", "ItemFeet") && InventoryAvailable(Player, "NylonRope", "ItemLegs") && InventoryAvailable(Player, "NylonRope", "ItemArms") && InventoryAvailable(Player, "ClothGag", "ItemMouth"));
 	IntroductionIsMaid = LogQuery("JoinedSorority", "Maid");
 	IntroductionIsHeadMaid = LogQuery("LeadSorority", "Maid");
-	
+
 	// Creates two characters to begin with
 	IntroductionMaid = CharacterLoadNPC("NPC_Introduction_Maid");
 	IntroductionSub = CharacterLoadNPC("NPC_Introduction_Sub");

--- a/BondageClub/Screens/Room/KidnapLeague/KidnapLeague.js
+++ b/BondageClub/Screens/Room/KidnapLeague/KidnapLeague.js
@@ -20,47 +20,47 @@ var KidnapLeagueVisitRoom = false;
  * Checks if the player can be kidnapped
  * @returns {boolean} - Returns TRUE if the player is restrained and the trainer is not.
  */
-function KidnapLeagueAllowKidnap() { return (!Player.IsRestrained() && !KidnapLeagueTrainer.IsRestrained()) }
+function KidnapLeagueAllowKidnap() { return (!Player.IsRestrained() && !KidnapLeagueTrainer.IsRestrained()); }
 /**
  * Checks if the kidnap league trainer is restrained.
  * @returns {boolean} - Returns TRUE if the kidnap league trainer is restrained.
  */
-function KidnapLeagueIsTrainerRestrained() { return KidnapLeagueTrainer.IsRestrained() }
+function KidnapLeagueIsTrainerRestrained() { return KidnapLeagueTrainer.IsRestrained(); }
 /**
  * Checks if the player can take a new kidnap league bounty.
  * @returns {boolean} - Returns TRUE if the player has no active bounty.
  */
-function KidnapLeagueCanTakeBounty() { return ((ReputationGet("Kidnap") > 0) && (KidnapLeagueBounty == null)) }
+function KidnapLeagueCanTakeBounty() { return ((ReputationGet("Kidnap") > 0) && (KidnapLeagueBounty == null)); }
 /**
  * Checks if a kidnap league bounty was taken.
  * @returns {boolean} - Returns TRUE if the player has an active and unfinished bounty.
  */
-function KidnapLeagueBountyTaken() { return ((ReputationGet("Kidnap") > 0) && (KidnapLeagueBounty != null) && (KidnapLeagueBountyVictory == null)) }
+function KidnapLeagueBountyTaken() { return ((ReputationGet("Kidnap") > 0) && (KidnapLeagueBounty != null) && (KidnapLeagueBountyVictory == null)); }
 /**
  * Checks if the current bounty resulted in a victory.
  * @returns {boolean} - Returns TRUE if the current bounty resulted in a victory.
  */
-function KidnapLeagueBountyWasVictory() { return ((ReputationGet("Kidnap") > 0) && (KidnapLeagueBounty != null) && (KidnapLeagueBountyVictory == true)) }
+function KidnapLeagueBountyWasVictory() { return ((ReputationGet("Kidnap") > 0) && (KidnapLeagueBounty != null) && (KidnapLeagueBountyVictory == true)); }
 /**
  * Checks if the current bounty resulted in a defeat.
  * @returns {boolean} - Returns TRUE if the current bounty resulted in a defeat.
  */
-function KidnapLeagueBountyWasDefeat() { return ((ReputationGet("Kidnap") > 0) && (KidnapLeagueBounty != null) && (KidnapLeagueBountyVictory == false)) }
+function KidnapLeagueBountyWasDefeat() { return ((ReputationGet("Kidnap") > 0) && (KidnapLeagueBounty != null) && (KidnapLeagueBountyVictory == false)); }
 /**
  * Checks if a NPC can be transfered to the player's private room.
  * @returns {boolean} - Returns TRUE if the player has an accessible private room and a free spot for a NPC.
  */
-function KidnapLeagueCanTransferToRoom() { return (LogQuery("RentRoom", "PrivateRoom") && (PrivateCharacter.length < PrivateCharacterMax) && !LogQuery("LockOutOfPrivateRoom", "Rule")) }
+function KidnapLeagueCanTransferToRoom() { return (LogQuery("RentRoom", "PrivateRoom") && (PrivateCharacter.length < PrivateCharacterMax) && !LogQuery("LockOutOfPrivateRoom", "Rule")); }
 /**
  * Checks if the NPC will not visit the player's private room.
  * @returns {boolean} - Returns TRUE if the NPC won't come to the private room even if it's possible
  */
-function KidnapLeagueWontVisitRoom() { return (!KidnapLeagueVisitRoom && KidnapLeagueCanTransferToRoom()) }
+function KidnapLeagueWontVisitRoom() { return (!KidnapLeagueVisitRoom && KidnapLeagueCanTransferToRoom()); }
 /**
  * Checks if both players can kiss.
  * @returns {boolean} - Returns TRUE if both players are able to talk which means they can kiss.
  */
-function KidnapLeagueCanKiss() { return (Player.CanTalk() && CurrentCharacter.CanTalk()) }
+function KidnapLeagueCanKiss() { return (Player.CanTalk() && CurrentCharacter.CanTalk()); }
 
 /**
  * Loads the kidnap league NPC
@@ -165,7 +165,7 @@ function KidnapLeagueBountyFightEnd() {
 	KidnapLeagueBounty.Stage = (KidnapVictory) ? "101" : "201";
 	KidnapLeagueRandomKidnapper = KidnapLeagueBounty;
 	if (!KidnapVictory) CharacterRelease(KidnapLeagueBounty);
-	CommonSetScreen("Room", "KidnapLeague");	
+	CommonSetScreen("Room", "KidnapLeague");
 	KidnapLeagueBackground = KidnapLeagueBountyLocation;
 	CharacterSetCurrent(KidnapLeagueBounty);
 	KidnapLeagueBounty.CurrentDialog = DialogFind(KidnapLeagueBounty, (KidnapVictory) ? "BountyVictory" : "BountyDefeat");
@@ -225,7 +225,7 @@ function KidnapLeagueResetTrainer() {
 	CharacterRelease(Player);
 	CharacterRelease(KidnapLeagueTrainer);
 	if ((InventoryGet(Player, "Cloth") == null) && (KidnapPlayerCloth != null)) {
-		InventoryWear(Player, KidnapPlayerCloth.Asset.Name, "Cloth", KidnapPlayerCloth.Color);		
+		InventoryWear(Player, KidnapPlayerCloth.Asset.Name, "Cloth", KidnapPlayerCloth.Color);
 		if (KidnapPlayerClothAccessory != null) InventoryWear(Player, KidnapPlayerClothAccessory.Asset.Name, "ClothAccessory", KidnapPlayerClothAccessory.Color);
 		if (KidnapPlayerClothLower != null) InventoryWear(Player, KidnapPlayerClothLower.Asset.Name, "ClothLower", KidnapPlayerClothLower.Color);
 	}
@@ -241,15 +241,15 @@ function KidnapLeagueResetTrainer() {
  * @returns {void} - Nothing
  */
 function KidnapLeagueRandomIntro() {
-	
+
 	// Sets the kidnapping scene
 	CommonSetScreen("Room", "KidnapLeague");
 	KidnapLeagueBackground = "MainHall";
 	KidnapLeagueRandomKidnapper = null;
-	CharacterDelete("NPC_KidnapLeague_RandomKidnapper");	
-	KidnapLeagueRandomKidnapper = CharacterLoadNPC("NPC_KidnapLeague_RandomKidnapper");	
+	CharacterDelete("NPC_KidnapLeague_RandomKidnapper");
+	KidnapLeagueRandomKidnapper = CharacterLoadNPC("NPC_KidnapLeague_RandomKidnapper");
 	CharacterSetCurrent(KidnapLeagueRandomKidnapper);
-	
+
 	// A Mistress can pop if the player is a master kidnapper
 	if ((ReputationGet("Kidnap") >= 100) && (Math.floor(Math.random() * 10) == 0)) {
 		CharacterArchetypeClothes(KidnapLeagueRandomKidnapper, "Mistress");
@@ -261,7 +261,7 @@ function KidnapLeagueRandomIntro() {
 		KidnapLeagueRandomKidnapperDifficulty = Math.floor(Math.random() * 6);
 		KidnapLeagueArchetype = "";
 	}
-	
+
 	// If the player is already tied up, we skip the fight
 	if (Player.CanInteract()) {
 		KidnapLeagueRandomKidnapper.Stage = KidnapLeagueRandomKidnapperScenario.toString();
@@ -279,12 +279,12 @@ function KidnapLeagueRandomIntro() {
  */
 function KidnapLeagueRandomOutro(Surrender) {
 	KidnapLeagueRandomActivityCount = 0;
-	CommonSetScreen("Room", "KidnapLeague");	
+	CommonSetScreen("Room", "KidnapLeague");
 	SkillProgress("Willpower", ((Player.KidnapMaxWillpower - Player.KidnapWillpower) + (KidnapLeagueRandomKidnapper.KidnapMaxWillpower - KidnapLeagueRandomKidnapper.KidnapWillpower)) * 2);
 	KidnapLeagueBackground = "MainHall";
 	if ((Surrender == null) || (Surrender == false)) ReputationProgress("Kidnap", KidnapVictory ? 4 : 2);
 	KidnapLeagueRandomKidnapper.AllowItem = KidnapVictory;
-	KidnapLeagueRandomKidnapper.Stage = (KidnapVictory) ? "100" : "200";	
+	KidnapLeagueRandomKidnapper.Stage = (KidnapVictory) ? "100" : "200";
 	KidnapLeagueWillPayForFreedom = (Math.random() >= 0.5);
 	if (!KidnapVictory) CharacterRelease(KidnapLeagueRandomKidnapper);
 	CharacterSetCurrent(KidnapLeagueRandomKidnapper);
@@ -329,7 +329,7 @@ function KidnapLeagueRandomSurrender() {
  */
 function KidnapLeagueRandomEnd() {
 	if ((InventoryGet(Player, "Cloth") == null) && (KidnapPlayerCloth != null)) {
-		InventoryWear(Player, KidnapPlayerCloth.Asset.Name, "Cloth", KidnapPlayerCloth.Color);		
+		InventoryWear(Player, KidnapPlayerCloth.Asset.Name, "Cloth", KidnapPlayerCloth.Color);
 		if (KidnapPlayerClothAccessory != null) InventoryWear(Player, KidnapPlayerClothAccessory.Asset.Name, "ClothAccessory", KidnapPlayerClothAccessory.Color);
 		if (KidnapPlayerClothLower != null) InventoryWear(Player, KidnapPlayerClothLower.Asset.Name, "ClothLower", KidnapPlayerClothLower.Color);
 	}
@@ -375,18 +375,18 @@ function KidnapLeagueRandomActivityStart(A) {
  * @returns {void} - Nothing
  */
 function KidnapLeagueRandomActivityLaunch() {
-	
+
 	// After 4 activities, there's more and more chances that the player will be released
 	KidnapLeagueRandomActivityCount++;
 	if (Math.random() * KidnapLeagueRandomActivityCount >= 4) {
 		KidnapLeagueRandomActivityCount = 0;
 		if ((InventoryGet(Player, "Cloth") == null) && (KidnapPlayerCloth != null)) {
-			InventoryWear(Player, KidnapPlayerCloth.Asset.Name, "Cloth", KidnapPlayerCloth.Color);		
+			InventoryWear(Player, KidnapPlayerCloth.Asset.Name, "Cloth", KidnapPlayerCloth.Color);
 			if (KidnapPlayerClothAccessory != null) InventoryWear(Player, KidnapPlayerClothAccessory.Asset.Name, "ClothAccessory", KidnapPlayerClothAccessory.Color);
 			if (KidnapPlayerClothLower != null) InventoryWear(Player, KidnapPlayerClothLower.Asset.Name, "ClothLower", KidnapPlayerClothLower.Color);
 		}
 		if ((!InventoryCharacterHasOwnerOnlyRestraint(Player)) && (!InventoryCharacterHasLoverOnlyRestraint(Player))){
-			CharacterRelease(Player);		
+			CharacterRelease(Player);
 			KidnapLeagueRandomActivityStart("End");
 			KidnapLeagueVisitRoom = ((Math.random() >= 0.5) && KidnapLeagueCanTransferToRoom());
 		} else KidnapLeagueRandomActivityStart("EndNoRelease");
@@ -395,10 +395,10 @@ function KidnapLeagueRandomActivityLaunch() {
 
 	// Finds an activity to do on the player
 	while (true) {
-		
+
 		// Picks an activity at random
 		KidnapLeagueRandomActivity = CommonRandomItemFromList(KidnapLeagueRandomActivity, KidnapLeagueRandomActivityList);
-				
+
 		// Add or remove an item
 		if ((KidnapLeagueRandomActivity == "AddGag") && (InventoryGet(Player, "ItemMouth") == null)) { InventoryWearRandom(Player, "ItemMouth", KidnapLeagueRandomKidnapperDifficulty); KidnapLeagueRandomActivityStart(KidnapLeagueRandomActivity); return; }
 		if ((KidnapLeagueRandomActivity == "RemoveGag") && (InventoryGet(Player, "ItemMouth") != null) && !InventoryOwnerOnlyItem(InventoryGet(Player, "ItemMouth")) && !InventoryLoverOnlyItem(InventoryGet(Player, "ItemMouth"))){
@@ -409,11 +409,11 @@ function KidnapLeagueRandomActivityLaunch() {
 		if ((KidnapLeagueRandomActivity == "AddLegs") && (InventoryGet(Player, "ItemLegs") == null) && !Player.IsKneeling()) { InventoryWearRandom(Player, "ItemLegs", KidnapLeagueRandomKidnapperDifficulty); KidnapLeagueRandomActivityStart(KidnapLeagueRandomActivity); return; }
 		if ((KidnapLeagueRandomActivity == "RemoveLegs") && (InventoryGet(Player, "ItemLegs") != null) && !InventoryOwnerOnlyItem(InventoryGet(Player, "ItemLegs")) && !InventoryLoverOnlyItem(InventoryGet(Player, "ItemLegs"))) {
 			InventoryRemove(Player, "ItemLegs"); KidnapLeagueRandomActivityStart(KidnapLeagueRandomActivity); return; }
-		
+
 		// Physical activities
 		if ((KidnapLeagueRandomActivity == "Kiss") && (InventoryGet(Player, "ItemMouth") == null)) { KidnapLeagueRandomActivityStart(KidnapLeagueRandomActivity); return; }
 		if ((KidnapLeagueRandomActivity == "Spank") || (KidnapLeagueRandomActivity == "Fondle") || (KidnapLeagueRandomActivity == "Tickle")) { KidnapLeagueRandomActivityStart(KidnapLeagueRandomActivity); return; }
-		
+
 	}
 }
 

--- a/BondageClub/Screens/Room/LARP/LARP.js
+++ b/BondageClub/Screens/Room/LARP/LARP.js
@@ -7,7 +7,7 @@ var LARPOrganiser = null;
  * @returns {void} - Nothing
  */
 function LARPLoad() {
-	if (LARPOrganiser == null) {		
+	if (LARPOrganiser == null) {
 		LARPOrganiser = CharacterLoadNPC("NPC_LARP_Organiser");
 		CharacterNaked(LARPOrganiser);
 		InventoryWear(LARPOrganiser, "SteampunkCorsetTop1", "Cloth", "Default");
@@ -26,7 +26,7 @@ function LARPRun() {
 	if (!DailyJobSubSearchIsActive()) DrawCharacter(LARPOrganiser, 1000, 0, 1);
 	DrawButton(1885, 25, 90, 90, "", "White", "Icons/Exit.png", TextGet("Leave"));
 	DrawButton(1885, 145, 90, 90, "", "White", "Icons/Character.png", TextGet("Profile"));
-	if ((ReputationGet("LARP") >= 1) && (Player.Game != null) && (Player.Game.LARP != null) && (Player.Game.LARP.Class != null)) 
+	if ((ReputationGet("LARP") >= 1) && (Player.Game != null) && (Player.Game.LARP != null) && (Player.Game.LARP.Class != null))
 		DrawButton(1885, 265, 90, 90, "", Player.CanChange() ? "White" : "Pink", "Icons/Battle.png", TextGet("Battle"));
 	DailyJobSubSearchRun();
 }
@@ -37,7 +37,7 @@ function LARPRun() {
  */
 function LARPClick() {
 	if (!DailyJobSubSearchIsActive() && MouseIn(500, 0, 500, 1000)) CharacterSetCurrent(Player);
-	if (!DailyJobSubSearchIsActive() && MouseIn(1000, 0, 500, 1000)) CharacterSetCurrent(LARPOrganiser);	
+	if (!DailyJobSubSearchIsActive() && MouseIn(1000, 0, 500, 1000)) CharacterSetCurrent(LARPOrganiser);
 	if (MouseIn(1885, 25, 90, 90)) CommonSetScreen("Room", "MainHall");
 	if (MouseIn(1885, 145, 90, 90)) InformationSheetLoadCharacter(Player);
 	if (MouseIn(1885, 265, 90, 90) && (ReputationGet("LARP") >= 1) && (Player.Game != null) && (Player.Game.LARP != null) && (Player.Game.LARP.Class != null) && Player.CanChange()) ChatRoomStart("", "LARP", "LARP", "WrestlingRing", BackgroundsTagList);

--- a/BondageClub/Screens/Room/Magic/Magic.js
+++ b/BondageClub/Screens/Room/Magic/Magic.js
@@ -33,39 +33,39 @@ var MagicShowState = 1;
  * @param {number} QState - The state that is queried
  * @returns {boolean} - Returns true, if the queried state matches with the current state of the magic show, flase otherwise
  */
-function MagicShowIsState(QState) { return ((QState == MagicShowState) ? true : false) }
+function MagicShowIsState(QState) { return ((QState == MagicShowState) ? true : false); }
 
 /**
  * Checks, if the magician's assistant has been released
  * @returns {boolean} - Returns true, if the assistant has been released, false otherwise
  */
-function MagicAssistantIsReleased() { return (MagicShowIsState(4) && !MagicAssistant.IsRestrained()) }
+function MagicAssistantIsReleased() { return (MagicShowIsState(4) && !MagicAssistant.IsRestrained()); }
 
 /**
  * Checks, if the magician is bound by the minal required number of items (gag, arms, feet, legs, head)
  * @param {number} MinItem - The minimal number of items that must be used on the magician
  * @returns {boolean} - Returns true, if the required number of items is reached or exceeded, false otherwise
  */
-function MagicRestrainPerformerMinItem(MinItem) { return MagicRestrainMinItem(MagicPerformer, MinItem) }
+function MagicRestrainPerformerMinItem(MinItem) { return MagicRestrainMinItem(MagicPerformer, MinItem); }
 
 /**
  * Checks, if the magician's assistant is bound by the minal required number of items (gag, arms, feet, legs, head)
  * @param {number} MinItem - The minimal number of items that must be used on the magician's assistant
  * @returns {boolean} - Returns true, if the required number of items is reached or exceeded, false otherwise
  */
-function MagicRestrainAssistantMinItem(MinItem) { return MagicRestrainMinItem(MagicAssistant, MinItem) }
+function MagicRestrainAssistantMinItem(MinItem) { return MagicRestrainMinItem(MagicAssistant, MinItem); }
 
 /**
  * Checks wether the assistant is restrained and should redress
  * @returns {boolean} - Returns true, if the assistant should redress and is currently restrained
  */
-function MagicAssistantIsDressRestrain() { return (MagicShowIsState(8) && MagicAssistant.IsRestrained()) }
+function MagicAssistantIsDressRestrain() { return (MagicShowIsState(8) && MagicAssistant.IsRestrained()); }
 
 /**
  * Checks wether the assistant is free and should redress
  * @returns {boolean} - Returns true, if the assistant should redress and is currently free
  */
-function MagicAssistantIsntDressRestrain() { return (MagicShowIsState(8) && !MagicAssistant.IsRestrained()) }
+function MagicAssistantIsntDressRestrain() { return (MagicShowIsState(8) && !MagicAssistant.IsRestrained()); }
 
 /**
  * Checks, wether a given character is bound by the minal required number of items (gag, arms, feet, legs, head)
@@ -81,7 +81,7 @@ function MagicRestrainMinItem(C, MinItem) {
 			GagApplied = true;
 		}
 		else if ((C.Appearance[E].Asset.Group.Name == "ItemArms") || (C.Appearance[E].Asset.Group.Name == "ItemFeet") || (C.Appearance[E].Asset.Group.Name == "ItemLegs") || (C.Appearance[E].Asset.Group.Name == "ItemHead") || (C.Appearance[E].Asset.Group.Name == "ItemMisc")|| (C.Appearance[E].Asset.Group.Name == "ItemHood")) {
-			CurItem++
+			CurItem++;
 		}
 	}
 	return (CurItem + (GagApplied ? 1 : 0)) >= MinItem;
@@ -264,7 +264,7 @@ function MagicSelectTrick() {
 }
 
 /**
- * Copies the restraints currently on the magician randomly 
+ * Copies the restraints currently on the magician randomly
  * either to the player or the assistant and gets the appropriate dialog option
  * @returns {void} - Nothing
  */
@@ -343,7 +343,7 @@ function MagicTrickBoxMilkCan() {
  * @returns {void} - Nothing
  */
 function MagicTrickBoxWaterCell() {
-	InventoryWear(Player, "HempRope", "ItemFeet"); 
+	InventoryWear(Player, "HempRope", "ItemFeet");
 	InventoryGet(Player, "ItemFeet").Property = { Type: "Suspension", SetPose: ["LegsClosed", "Suspension"], Difficulty: 6, OverrideHeight: { Height: -150, Priority: 41, HeightRatioProportion: 0 }, };
 	InventoryWear(Player, "HempRope", "ItemLegs");
 	InventoryWear(Player, "HempRope", "ItemArms");
@@ -368,7 +368,7 @@ function MagicTrickGetCoin() {
  */
 function MagicSongLeavePerformer() {
 	MagicShowState = 6;
-	DialogLeave()
+	DialogLeave();
 }
 
 /**
@@ -419,7 +419,7 @@ function MagicTrickAsstantChange() {
 }
 
 /**
- * Ends the show. Release everybody, dress everybody back to their clothes 
+ * Ends the show. Release everybody, dress everybody back to their clothes
  * from the start and bring the player back to the mein hall
  * @returns {void} - Nothing
  */

--- a/BondageClub/Screens/Room/MaidQuarters/MaidQuarters.js
+++ b/BondageClub/Screens/Room/MaidQuarters/MaidQuarters.js
@@ -25,92 +25,92 @@ var MaidQuartersOnlineDrinkFromOwner = false;
  * Checks if the player is helpless (maids disabled) or not.
  * @returns {boolean} - Returns true if the player still has time remaining after asking the maids to stop helping
  */
-function MaidQuartersIsMaidsDisabled() { var expire = LogValue("MaidsDisabled", "Maid") - CurrentTime ; return (expire > 0 ) }
+function MaidQuartersIsMaidsDisabled() { var expire = LogValue("MaidsDisabled", "Maid") - CurrentTime ; return (expire > 0 ); }
 /**
  * Checks if the player is helpless (maids disabled) or not and also if they have reputation to do work
  * @returns {boolean} - Returns true if the player has maids enabled and also has rep
  */
-function MaidQuartersCanDoWorkForMaids() { return (DialogReputationGreater("Maid", 1) && !MaidQuartersIsMaidsDisabled()) }
+function MaidQuartersCanDoWorkForMaids() { return (DialogReputationGreater("Maid", 1) && !MaidQuartersIsMaidsDisabled()); }
 /**
  * Checks if the player is helpless (maids disabled) or not and also if they have reputation to do work
  * @returns {boolean} - Returns true if the player has maids enabled and also has rep
  */
-function MaidQuartersCanDoWorkButMaidsDisabled() { return (DialogReputationGreater("Maid", 1) && MaidQuartersIsMaidsDisabled()) }
+function MaidQuartersCanDoWorkButMaidsDisabled() { return (DialogReputationGreater("Maid", 1) && MaidQuartersIsMaidsDisabled()); }
 /**
  * CHecks for appropriate dressing
  * @returns {boolean} - Returns true if the player wears a maid dress and a maid hair band, false otherwise
  */
 function MaidQuartersPlayerInMaidUniform() {
 	const clothes = CharacterAppearanceGetCurrentValue(Player, "Cloth", "Name");
-	return ((clothes == "MaidOutfit1" || clothes == "MaidOutfit2") && (CharacterAppearanceGetCurrentValue(Player, "Hat", "Name") == "MaidHairband1"))
+	return ((clothes == "MaidOutfit1" || clothes == "MaidOutfit2") && (CharacterAppearanceGetCurrentValue(Player, "Hat", "Name") == "MaidHairband1"));
 }
 /**
  * Checks, if the player is able to do the 'serve drinks' job
  * @returns {boolean} - Returns true, if the player can do the job, false otherwise
  */
-function MaidQuartersAllowMaidDrinks() { return (!Player.IsRestrained() && !MaidQuartersMaid.IsRestrained() && !LogQuery("ClubMistress", "Management")) }
+function MaidQuartersAllowMaidDrinks() { return (!Player.IsRestrained() && !MaidQuartersMaid.IsRestrained() && !LogQuery("ClubMistress", "Management")); }
 /**
  * Checks, if the player can do the 'clean room job'
  * @returns {boolean} - Returns true, if the player can do the job, false otherwise
  */
-function MaidQuartersAllowMaidCleaning() { return (!Player.IsRestrained() && !MaidQuartersMaid.IsRestrained() && !LogQuery("ClubMistress", "Management")) }
+function MaidQuartersAllowMaidCleaning() { return (!Player.IsRestrained() && !MaidQuartersMaid.IsRestrained() && !LogQuery("ClubMistress", "Management")); }
 /**
  * Checks, if the player can do the 'play music' job
  * @returns {boolean} - Returns true, if the player can do the job, false otherwise
  */
-function MaidQuartersAllowMaidPlayMusic() { return (!Player.IsRestrained()) }
+function MaidQuartersAllowMaidPlayMusic() { return (!Player.IsRestrained()); }
 /**
  * Checks, if the player can do a rescue mission
  * @returns {boolean} - Returns true, if the player can do the job, false otherwise
  */
-function MaidQuartersAllowRescue() { return (!Player.IsRestrained()) }
+function MaidQuartersAllowRescue() { return (!Player.IsRestrained()); }
 /**
  * Checks, if the player is on a running rescue mission
  * @returns {boolean} - Returns true, if the player has a running but unfinished rescue mission, false otherwise
  */
-function MaidQuartersAllowCancelRescue() { return (MaidQuartersCurrentRescueStarted && !MaidQuartersCurrentRescueCompleted) }
+function MaidQuartersAllowCancelRescue() { return (MaidQuartersCurrentRescueStarted && !MaidQuartersCurrentRescueCompleted); }
 /**
  * Checks, if the 'Unlock Sarah' quest is available
  * @returns {boolean} - Returns true, if the quest is available, false otherwise
  */
-function MaidQuartersCanFreeSarah() { return (SarahUnlockQuest && LogQuery("LeadSorority", "Maid")) }
+function MaidQuartersCanFreeSarah() { return (SarahUnlockQuest && LogQuery("LeadSorority", "Maid")); }
 /**
  * Checks, if the maid can release the player from her restraint
  * @returns {boolean} - Returns true, if the player can be released, false otherwise
  */
-function MaidQuartersCanReleasePlayer() { return (Player.IsRestrained() && !InventoryCharacterHasOwnerOnlyRestraint(Player) && !InventoryCharacterHasLockedRestraint(Player) && CurrentCharacter.CanTalk() && CurrentCharacter.CanInteract()) && !MaidQuartersIsMaidsDisabled()}
+function MaidQuartersCanReleasePlayer() { return (Player.IsRestrained() && !InventoryCharacterHasOwnerOnlyRestraint(Player) && !InventoryCharacterHasLockedRestraint(Player) && CurrentCharacter.CanTalk() && CurrentCharacter.CanInteract()) && !MaidQuartersIsMaidsDisabled();}
 /**
  * Checks, if the maid is unable to free the player
  * @returns {boolean} - Returns true, if the maid is unable to free the player, false otherwise
  */
-function MaidQuartersCannotReleasePlayer() { return (Player.IsRestrained() && (InventoryCharacterHasOwnerOnlyRestraint(Player) || InventoryCharacterHasLockedRestraint(Player) || !CurrentCharacter.CanTalk() || !CurrentCharacter.CanInteract())) }
+function MaidQuartersCannotReleasePlayer() { return (Player.IsRestrained() && (InventoryCharacterHasOwnerOnlyRestraint(Player) || InventoryCharacterHasLockedRestraint(Player) || !CurrentCharacter.CanTalk() || !CurrentCharacter.CanInteract())); }
 /**
  * Checks, if the player can get the duster gag
  * @returns {boolean} - Returns true, if the player can get the duster gag, false otherwise
  */
-function MaidQuartersCanGetDusterGag() { return (!SarahUnlockQuest && LogQuery("JoinedSorority", "Maid") && Player.CanTalk() && CurrentCharacter.CanTalk() && CurrentCharacter.CanInteract() && (!InventoryAvailable(Player, "DusterGag", "ItemMouth") || !InventoryAvailable(Player, "DusterGag", "ItemMouth2") || !InventoryAvailable(Player, "DusterGag", "ItemMouth3"))) }
+function MaidQuartersCanGetDusterGag() { return (!SarahUnlockQuest && LogQuery("JoinedSorority", "Maid") && Player.CanTalk() && CurrentCharacter.CanTalk() && CurrentCharacter.CanInteract() && (!InventoryAvailable(Player, "DusterGag", "ItemMouth") || !InventoryAvailable(Player, "DusterGag", "ItemMouth2") || !InventoryAvailable(Player, "DusterGag", "ItemMouth3"))); }
 /**
  * Checks, if the player has finished the 'serve drinks' job
  * @returns {boolean} - Returns true, if the job is finished, false otherwise
  */
-function MaidQuartersOnlineDrinkCompleted() { return (MaidQuartersOnlineDrinkCount >= 5) }
+function MaidQuartersOnlineDrinkCompleted() { return (MaidQuartersOnlineDrinkCount >= 5); }
 /**
  * Checks if the player can talk after being rewarded for the online drinks mini-game
  * @returns {boolean} - Returns true, if the player is gagged or restrained.
  */
-function MaidQuartersOnlineDrinkIsRestrained() { return Player.IsRestrained() || !Player.CanTalk()}
+function MaidQuartersOnlineDrinkIsRestrained() { return Player.IsRestrained() || !Player.CanTalk();}
 /**
  * Checks if the player can get ungagged by the maids
  * @returns {boolean} - Returns true, if the maids can remove the gag, false otherwise
  */
-function MaidQuartersCanUngag() { return (!Player.CanTalk() && !InventoryCharacterHasOwnerOnlyRestraint(Player) && !MaidQuartersIsMaidsDisabled()) }
-function MaidQuartersCanUngagAndMaidsDisabled() { return MaidQuartersIsMaidsDisabled() && (!Player.CanTalk()) }
+function MaidQuartersCanUngag() { return (!Player.CanTalk() && !InventoryCharacterHasOwnerOnlyRestraint(Player) && !MaidQuartersIsMaidsDisabled()); }
+function MaidQuartersCanUngagAndMaidsDisabled() { return MaidQuartersIsMaidsDisabled() && (!Player.CanTalk()); }
 /**
  * Checks, if the maids are unable to remove the gag (if there is one)
  * @returns {boolean} - Returns true, if the player cannot be ungagged by the maids, false otherwise
  */
-function MaidQuartersCannotUngag() { return (!Player.CanTalk() && InventoryCharacterHasOwnerOnlyRestraint(Player)) }
-function MaidQuartersCannotUngagAndMaidsNotDisabled() { return !MaidQuartersIsMaidsDisabled() && (!Player.CanTalk() && InventoryCharacterHasOwnerOnlyRestraint(Player)) }
+function MaidQuartersCannotUngag() { return (!Player.CanTalk() && InventoryCharacterHasOwnerOnlyRestraint(Player)); }
+function MaidQuartersCannotUngagAndMaidsNotDisabled() { return !MaidQuartersIsMaidsDisabled() && (!Player.CanTalk() && InventoryCharacterHasOwnerOnlyRestraint(Player)); }
 
 /**
  * Loads the maid quarters. This function is called dynamically, as soon, as the player enters the maid quarters
@@ -126,7 +126,7 @@ function MaidQuartersLoad() {
 }
 
 /**
- * Runs the maid quarters dialog 
+ * Runs the maid quarters dialog
  * This function is called periodically so don't use it for extensive use or the call of other complex functions
  * @returns {void} - Nothing
  */
@@ -153,11 +153,11 @@ function MaidQuartersClick() {
 	if (!DailyJobSubSearchIsActive() && (MouseX >= 1000) && (MouseX < 1500) && (MouseY >= 0) && (MouseY < 1000)) {
 		ManagementClubSlaveDialog(MaidQuartersMaid);
 		CharacterSetCurrent(MaidQuartersMaid);
-		if (MaidQuartersMaid.Stage == "285") { 
+		if (MaidQuartersMaid.Stage == "285") {
 			let MaidDialog = "";
 			if (MaidQuartersOnlineDrinkCompleted()) MaidDialog = "MaidDrinkOnlineComplete";
 			if (!MaidQuartersOnlineDrinkCompleted()) {
-				if (!InventoryGet(Player, "ItemMisc") || InventoryGet(Player, "ItemMisc").Asset.Name !== "WoodenMaidTrayFull") { 
+				if (!InventoryGet(Player, "ItemMisc") || InventoryGet(Player, "ItemMisc").Asset.Name !== "WoodenMaidTrayFull") {
 					MaidDialog = "MaidDrinkOnlineIncompleteMissingTray";
 					InventoryWear(Player, "WoodenMaidTrayFull", "ItemMisc");
 				} else {
@@ -237,7 +237,7 @@ function MaidQuartersMiniGameStart(GameType, Difficulty) {
 }
 
 /**
- * Is called when the mini game ends and sends the player back to the maid quarters. 
+ * Is called when the mini game ends and sends the player back to the maid quarters.
  * Depending on the choosen game, the next dialog option is selected
  * @returns {void} - Nothing
  */
@@ -351,7 +351,7 @@ function MaidQuartersBecomMaid() {
 	ItemsToEarn.push({Name: "MaidApron1", Group: "Cloth"});
 	ItemsToEarn.push({Name: "MaidHairband1", Group: "Hat"});
 	InventoryAddMany(Player, ItemsToEarn);
-	
+
 	InventoryWear(Player, "MaidOutfit1", "Cloth", "Default");
 	InventoryWear(Player, "MaidHairband1", "Hat", "Default");
 	LogAdd("JoinedSorority", "Maid");
@@ -452,7 +452,7 @@ function MaidQuartersOnlineDrinkPick(MemberNumber, DrinkValue) {
 }
 
 /**
- * Calculates the player's earnings from the online drink serving. 
+ * Calculates the player's earnings from the online drink serving.
  * When the maid tray is empty, the player can get paid (40% of drink value + 10$)
  * @returns {void} - Nothing
  */
@@ -467,13 +467,13 @@ function MaidQuartersOnlineDrinkPay() {
 
 /**
  * Flags the online drink serving as not initiated by the player's owner
- * @returns {void} - Nothing	
+ * @returns {void} - Nothing
  */
 function MaidQuartersNotFromOwner() {
 	MaidQuartersOnlineDrinkFromOwner = false;
 }
 
 function MaidQuartersSetMaidsDisabled(minutes) {
-	var millis = minutes * 60000
+	var millis = minutes * 60000;
 	LogAdd("MaidsDisabled", "Maid", CurrentTime + millis);
 }

--- a/BondageClub/Screens/Room/MainHall/MainHall.js
+++ b/BondageClub/Screens/Room/MainHall/MainHall.js
@@ -38,7 +38,7 @@ var MainHallRopeColor = "Default";
  * @returns {boolean} - True if player has any restraints or locks, False otherwise
  */
 function MainHallPlayerNeedsHelpAndHasNoOwnerOrLoverItem() {
-	var needsHelp = false
+	var needsHelp = false;
 
 	for (let E = Player.Appearance.length - 1; E >= 0; E--) {
 		if (Player.Appearance[E].Asset.IsRestraint) {
@@ -49,7 +49,7 @@ function MainHallPlayerNeedsHelpAndHasNoOwnerOrLoverItem() {
 		let LockList = MainHallStrongLocks.map(L => L.Name);
 		for (let L = 0; L < LockList.length; L++) {
 			if (((Player.Appearance[E].Property != null) && (Player.Appearance[E].Property.LockedBy == LockList[L]))) {
-				needsHelp = true
+				needsHelp = true;
 				break;
 			}
 		}
@@ -63,57 +63,57 @@ function MainHallPlayerNeedsHelpAndHasNoOwnerOrLoverItem() {
  * Checks if the maid will help the player or not.  Maids are disabled from the quarters or when playing hardcore.
  * @returns {boolean} - Returns true if the player still has time remaining after asking the maids to stop helping in the maid quarters
  */
-function MainHallIsMaidsDisabled() { return ((LogValue("MaidsDisabled", "Maid") > CurrentTime) || (Player.GetDifficulty() >= 2)) }
+function MainHallIsMaidsDisabled() { return ((LogValue("MaidsDisabled", "Maid") > CurrentTime) || (Player.GetDifficulty() >= 2)); }
 
 /**
  * Checks if the maid will not help the player because she's playing on hardcore
  * @returns {boolean} - Returns TRUE if the difficulty is hardcore or more
  */
-function MainHallMaidsPlayingHardcore() { return (Player.GetDifficulty() >= 2) }
+function MainHallMaidsPlayingHardcore() { return (Player.GetDifficulty() >= 2); }
 
 /**
  * Checks for the dialog options to help the player know how much time is left before the maids can help them
  * @returns {boolean} - Returns TRUE if the remaining duration fits within the time range
  */
-function MainHallMaidsDisabledMinutesLeft() { var expire = LogValue("MaidsDisabled", "Maid") - CurrentTime; return (expire > 0 && expire < 600000 && Player.GetDifficulty() < 2) }
-function MainHallMaidsDisabledHourLeft() { var expire = LogValue("MaidsDisabled", "Maid") - CurrentTime; return (expire >= 600000 && expire < 3600000 && Player.GetDifficulty() < 2) }
-function MainHallMaidsDisabledDaysLeft1() { var expire = LogValue("MaidsDisabled", "Maid") - CurrentTime; return (expire >= 3600000 && expire < 86400000 && Player.GetDifficulty() < 2) }
-function MainHallMaidsDisabledDaysLeft2() { var expire = LogValue("MaidsDisabled", "Maid") - CurrentTime; return (expire >= 86400000 && expire < 172800000 && Player.GetDifficulty() < 2) }
-function MainHallMaidsDisabledDaysLeft3() { var expire = LogValue("MaidsDisabled", "Maid") - CurrentTime; return (expire >= 172800000 && expire < 259200000 && Player.GetDifficulty() < 2) }
-function MainHallMaidsDisabledDaysLeft4() { var expire = LogValue("MaidsDisabled", "Maid") - CurrentTime; return (expire >= 259200000 && expire < 345600000 && Player.GetDifficulty() < 2) }
-function MainHallMaidsDisabledDaysLeft5() { var expire = LogValue("MaidsDisabled", "Maid") - CurrentTime; return (expire >= 345600000 && expire < 432000000 && Player.GetDifficulty() < 2) }
-function MainHallMaidsDisabledDaysLeft6() { var expire = LogValue("MaidsDisabled", "Maid") - CurrentTime; return (expire >= 432000000 && expire < 518400000 && Player.GetDifficulty() < 2) }
-function MainHallMaidsDisabledDaysLeft7() { var expire = LogValue("MaidsDisabled", "Maid") - CurrentTime; return (expire >= 518400000 && expire < 604800000 && Player.GetDifficulty() < 2) }
-function MainHallMaidsDisabledBegForMore() { return ((LogValue("MaidsDisabled", "Maid") > CurrentTime) && (Player.GetDifficulty() < 2)) }
+function MainHallMaidsDisabledMinutesLeft() { var expire = LogValue("MaidsDisabled", "Maid") - CurrentTime; return (expire > 0 && expire < 600000 && Player.GetDifficulty() < 2); }
+function MainHallMaidsDisabledHourLeft() { var expire = LogValue("MaidsDisabled", "Maid") - CurrentTime; return (expire >= 600000 && expire < 3600000 && Player.GetDifficulty() < 2); }
+function MainHallMaidsDisabledDaysLeft1() { var expire = LogValue("MaidsDisabled", "Maid") - CurrentTime; return (expire >= 3600000 && expire < 86400000 && Player.GetDifficulty() < 2); }
+function MainHallMaidsDisabledDaysLeft2() { var expire = LogValue("MaidsDisabled", "Maid") - CurrentTime; return (expire >= 86400000 && expire < 172800000 && Player.GetDifficulty() < 2); }
+function MainHallMaidsDisabledDaysLeft3() { var expire = LogValue("MaidsDisabled", "Maid") - CurrentTime; return (expire >= 172800000 && expire < 259200000 && Player.GetDifficulty() < 2); }
+function MainHallMaidsDisabledDaysLeft4() { var expire = LogValue("MaidsDisabled", "Maid") - CurrentTime; return (expire >= 259200000 && expire < 345600000 && Player.GetDifficulty() < 2); }
+function MainHallMaidsDisabledDaysLeft5() { var expire = LogValue("MaidsDisabled", "Maid") - CurrentTime; return (expire >= 345600000 && expire < 432000000 && Player.GetDifficulty() < 2); }
+function MainHallMaidsDisabledDaysLeft6() { var expire = LogValue("MaidsDisabled", "Maid") - CurrentTime; return (expire >= 432000000 && expire < 518400000 && Player.GetDifficulty() < 2); }
+function MainHallMaidsDisabledDaysLeft7() { var expire = LogValue("MaidsDisabled", "Maid") - CurrentTime; return (expire >= 518400000 && expire < 604800000 && Player.GetDifficulty() < 2); }
+function MainHallMaidsDisabledBegForMore() { return ((LogValue("MaidsDisabled", "Maid") > CurrentTime) && (Player.GetDifficulty() < 2)); }
 
 /**
  * Checks for the dialog options to help the maid determine which dialog options she can give the player to extend the duration
  * @returns {boolean} - Returns TRUE if the remaining duration fits within the time range
  */
-function MainHallMaidsDisabledAtLeast30MinutesLeft() { var expire = LogValue("MaidsDisabled", "Maid") - CurrentTime; return (expire < 1800000) }
-function MainHallMaidsDisabledAtLeast1HourLeft() { var expire = LogValue("MaidsDisabled", "Maid") - CurrentTime; return (expire < 3600000) }
-function MainHallMaidsDisabledAtLeast12HourLeft() { var expire = LogValue("MaidsDisabled", "Maid") - CurrentTime; return (expire < 43200000) }
-function MainHallMaidsDisabledAtLeastDaysLeft1() { var expire = LogValue("MaidsDisabled", "Maid") - CurrentTime; return (expire < 86400000) }
-function MainHallMaidsDisabledAtLeastDaysLeft3() { var expire = LogValue("MaidsDisabled", "Maid") - CurrentTime; return (expire < 259200000) }
-function MainHallMaidsDisabledAtLeastDaysLeft7() { var expire = LogValue("MaidsDisabled", "Maid") - CurrentTime; return (expire < 604800000) }
+function MainHallMaidsDisabledAtLeast30MinutesLeft() { var expire = LogValue("MaidsDisabled", "Maid") - CurrentTime; return (expire < 1800000); }
+function MainHallMaidsDisabledAtLeast1HourLeft() { var expire = LogValue("MaidsDisabled", "Maid") - CurrentTime; return (expire < 3600000); }
+function MainHallMaidsDisabledAtLeast12HourLeft() { var expire = LogValue("MaidsDisabled", "Maid") - CurrentTime; return (expire < 43200000); }
+function MainHallMaidsDisabledAtLeastDaysLeft1() { var expire = LogValue("MaidsDisabled", "Maid") - CurrentTime; return (expire < 86400000); }
+function MainHallMaidsDisabledAtLeastDaysLeft3() { var expire = LogValue("MaidsDisabled", "Maid") - CurrentTime; return (expire < 259200000); }
+function MainHallMaidsDisabledAtLeastDaysLeft7() { var expire = LogValue("MaidsDisabled", "Maid") - CurrentTime; return (expire < 604800000); }
 
 /**
  * Checks if the dialog option to trick the maid is available
  * @returns {boolean} - Returns TRUE if the maid can be tricked
  */
-function MainHallCanTrickMaid() { return (ManagementIsClubSlave() && SarahUnlockQuest) }
+function MainHallCanTrickMaid() { return (ManagementIsClubSlave() && SarahUnlockQuest); }
 
 /**
  * Checks, if the player has an owner or lover lock on her
  * @returns {boolean} - Returns true, if the player has either a lover or owner item on herself, false otherwise
  */
-function MainHallHasOwnerOrLoverItem() { return MainHallHasLoverLock || MainHallHasOwnerLock }
-function MainHallHasOwnerOrLoverItemAndMaidsNotDisabled() { return MainHallHasOwnerOrLoverItem() && !MainHallIsMaidsDisabled() }
-function MainHallHasNoOwnerOrLoverItemAndMaidsNotDisabled() { return !MainHallHasOwnerOrLoverItem() && !MainHallIsMaidsDisabled() }
-function MainHallHasOwnerItemAndMaidsNotDisabled() { return MainHallHasOwnerLock && !MainHallIsMaidsDisabled() }
-function MainHallHasLoverItemAndMaidsNotDisabled() { return MainHallHasLoverLock && !MainHallIsMaidsDisabled() }
-function MainHallHasSlaveCollarAndMaidsNotDisabled() { return MainHallHasSlaveCollar && !MainHallIsMaidsDisabled() }
-function MainHallPlayerNeedsHelpAndHasNoOwnerOrLoverItemAndMaidsNotDisabled() { return  MainHallPlayerNeedsHelpAndHasNoOwnerOrLoverItem() && !MainHallIsMaidsDisabled() }
+function MainHallHasOwnerOrLoverItem() { return MainHallHasLoverLock || MainHallHasOwnerLock; }
+function MainHallHasOwnerOrLoverItemAndMaidsNotDisabled() { return MainHallHasOwnerOrLoverItem() && !MainHallIsMaidsDisabled(); }
+function MainHallHasNoOwnerOrLoverItemAndMaidsNotDisabled() { return !MainHallHasOwnerOrLoverItem() && !MainHallIsMaidsDisabled(); }
+function MainHallHasOwnerItemAndMaidsNotDisabled() { return MainHallHasOwnerLock && !MainHallIsMaidsDisabled(); }
+function MainHallHasLoverItemAndMaidsNotDisabled() { return MainHallHasLoverLock && !MainHallIsMaidsDisabled(); }
+function MainHallHasSlaveCollarAndMaidsNotDisabled() { return MainHallHasSlaveCollar && !MainHallIsMaidsDisabled(); }
+function MainHallPlayerNeedsHelpAndHasNoOwnerOrLoverItemAndMaidsNotDisabled() { return  MainHallPlayerNeedsHelpAndHasNoOwnerOrLoverItem() && !MainHallIsMaidsDisabled(); }
 
 /**
  * Loads the main hall by setting up the NPCs, CSVs and global variables required.
@@ -453,7 +453,7 @@ function MainHallMaidReleasePlayer() {
 		// Added to remove maids being disabled
 		if (LogQuery("MaidsDisabled", "Maid")) {
 
-			LogDelete("MaidsDisabled", "Maid")
+			LogDelete("MaidsDisabled", "Maid");
 		}
 		MainHallMaid.Stage = "10";
 	} else MainHallMaid.CurrentDialog = DialogFind(MainHallMaid, "CannotRelease");
@@ -499,8 +499,8 @@ function MainHallPunishFromChatroom() {
 	MainHallHasLoverLock = InventoryCharacterHasLoverOnlyRestraint(Player);
 	if (ReputationGet("Dominant") > 10) ReputationProgress("Dominant", -10);
 	if (ReputationGet("Dominant") < -10) ReputationProgress("Dominant", 10);
-	
-	
+
+
 }
 /**
  * Triggered when the maid unlocks the player from a chat room
@@ -509,11 +509,11 @@ function MainHallPunishFromChatroom() {
 function MainHallPunishFromChatroomStartPunishment() {
 	CharacterRelease(Player);
 	CharacterNaked(Player);
-	
+
 	// Apply one of several preset restraints
 	// Also  apply timer locks to everything
-	var I = Math.floor(Math.random() * MainHallPunishmentList.length)
-	MainHallPunishmentChoice = I
+	var I = Math.floor(Math.random() * MainHallPunishmentList.length);
+	MainHallPunishmentChoice = I;
 }
 
 
@@ -522,7 +522,7 @@ function MainHallPunishFromChatroomStartPunishment() {
  * @returns {void} - Nothing
  */
 function MainHallPunishFromListEnd() {
-	ChatRoomSetLastChatRoom("")
+	ChatRoomSetLastChatRoom("");
 }
 
 /**
@@ -530,16 +530,16 @@ function MainHallPunishFromListEnd() {
  * @returns {void} - Nothing
  */
 function MainHallPunishFromChatroomInsertToy() {
-	var I = MainHallPunishmentChoice
+	var I = MainHallPunishmentChoice;
 	// We might lock in a toy under the chastity
 	if (MainHallPunishmentList[I].ItemVulva && InventoryGet(Player, "ItemVulva") == null) {
 		InventoryWear(Player, MainHallPunishmentList[I].ItemVulva, "ItemVulva");
 		InventoryGet(Player, "ItemVulva").Property = { Intensity: 1 };
 	}
-	
+
 	CharacterRefresh(Player);
-	
-	
+
+
 }
 
 /**
@@ -547,14 +547,14 @@ function MainHallPunishFromChatroomInsertToy() {
  * @returns {void} - Nothing
  */
 function MainHallPunishFromChatroomApplyChastity() {
-	var I = MainHallPunishmentChoice
+	var I = MainHallPunishmentChoice;
 	if (MainHallPunishmentList[I].ItemPelvis && InventoryGet(Player, "ItemPelvis") == null) {
 		InventoryWear(Player, MainHallPunishmentList[I].ItemPelvis, "ItemPelvis", "Default", Math.floor(Math.random()*10));
 	}
 	if (MainHallPunishmentList[I].ItemBreast && InventoryGet(Player, "ItemBreast") == null) {
 		InventoryWear(Player, MainHallPunishmentList[I].ItemBreast, "ItemBreast", "Default", Math.floor(Math.random()*10));
 	}
-	
+
 	CharacterRefresh(Player);
 }
 
@@ -564,14 +564,14 @@ function MainHallPunishFromChatroomApplyChastity() {
  * @returns {void} - Nothing
  */
 function MainHallPunishFromChatroomLockChastity() {
-	var I = MainHallPunishmentChoice
+	var I = MainHallPunishmentChoice;
 	if (MainHallPunishmentList[I].ItemPelvis && InventoryGet(Player, "ItemPelvis") == null) {
 		InventoryLock(Player, "ItemPelvis", "TimerPadlock", null);
 	}
 	if (MainHallPunishmentList[I].ItemBreast && InventoryGet(Player, "ItemBreast") == null) {
 		InventoryLock(Player, "ItemBreast", "TimerPadlock", null);
 	}
-	
+
 	CharacterRefresh(Player);
 }
 
@@ -580,8 +580,8 @@ function MainHallPunishFromChatroomLockChastity() {
  * @returns {void} - Nothing
  */
 function MainHallPunishFromChatroomGag() {
-	var I = MainHallPunishmentChoice
-	
+	var I = MainHallPunishmentChoice;
+
 	if (MainHallPunishmentList[I].ItemMouth) {
 		InventoryWear(Player, MainHallPunishmentList[I].ItemMouth, "ItemMouth", "Default", Math.floor(Math.random()*10)); InventoryLock(Player, "ItemMouth", "TimerPadlock", null);
 	}
@@ -593,32 +593,32 @@ function MainHallPunishFromChatroomGag() {
  * @returns {void} - Nothing
  */
 function MainHallPunishFromChatroomArms() {
-	var I = MainHallPunishmentChoice
+	var I = MainHallPunishmentChoice;
 	if (I == 0) { // We do rope bondage, excluding the feet, but with a ballgag
 
-		MainHallRopeColor = "#F49EFF"
-		var roperand = Math.random()
+		MainHallRopeColor = "#F49EFF";
+		var roperand = Math.random();
 		if (roperand > 0.33) // Random chance of different color {
-			MainHallRopeColor = "#FF0000"
+			MainHallRopeColor = "#FF0000";
 		else if (roperand > 0.67)
-			MainHallRopeColor = "Default"
-		
-		
+			MainHallRopeColor = "Default";
+
+
 		// Wears more item with higher levels
 		InventoryWear(Player, "HempRope", "ItemArms", MainHallRopeColor, Math.floor(Math.random()*10));
 		if (Math.random() > 0.5) // Random chance of wrist elbow tie instead of boxtie
 			InventoryGet(Player, "ItemArms").Property = { Type: "WristElbowHarnessTie", Effect: ["Block", "Prone"], SetPose: ["BackElbowTouch"], Difficulty: 3};
 	} else {
 		if (MainHallPunishmentList[I].ItemArms) {
-			var ArmsColor = "Default"
+			var ArmsColor = "Default";
 			if (MainHallPunishmentList[I].ItemArms == "LatexBoxtieLeotard" || MainHallPunishmentList[I].ItemArms == "SeamlessStraitDress" ) {
-				ArmsColor = "#252525"
+				ArmsColor = "#252525";
 			}
 			InventoryWear(Player, MainHallPunishmentList[I].ItemArms, "ItemArms", ArmsColor, Math.floor(Math.random()*10)); InventoryLock(Player, "ItemArms", "TimerPadlock", null);
 		}
 	}
-	
-	
+
+
 	if (MainHallPunishmentList[I].ItemHands && Math.random() > 0.33) {
 		InventoryWear(Player, MainHallPunishmentList[I].ItemHands, "ItemHands", "Default", Math.floor(Math.random()*10)); InventoryLock(Player, "ItemHands", "TimerPadlock", null);
 	}
@@ -630,17 +630,17 @@ function MainHallPunishFromChatroomArms() {
  * @returns {void} - Nothing
  */
 function MainHallPunishFromChatroomRest() {
-	var I = MainHallPunishmentChoice
-	
+	var I = MainHallPunishmentChoice;
+
 	if (I == 0) { // We do rope bondage, excluding the feet, but with a ballgag
-		
+
 
 		InventoryWear(Player, "HempRope", "ItemLegs", MainHallRopeColor, Math.floor(Math.random()*10));
 
-			
+
 
 	} else {
-	
+
 
 
 		if (MainHallPunishmentList[I].ItemLegs) {
@@ -658,11 +658,11 @@ function MainHallPunishFromChatroomRest() {
 			InventoryWear(Player, MainHallPunishmentList[I].ItemBoots, "ItemBoots", "Default", Math.floor(Math.random()*10)); InventoryLock(Player, "ItemBoots", "TimerPadlock", null);
 		}
 	}
-	
+
 	CharacterRefresh(Player);
-	
+
 	MainHallBeingPunished = false;
-	ChatRoomSetLastChatRoom("")
+	ChatRoomSetLastChatRoom("");
 }
 
 
@@ -746,6 +746,6 @@ function MainHallMaidIntroductionDone() {
 }
 
 function MainHallSetMaidsDisabled(minutes) {
-	var millis = minutes * 60000
+	var millis = minutes * 60000;
 	LogAdd("MaidsDisabled", "Maid", CurrentTime + millis);
 }

--- a/BondageClub/Screens/Room/Management/Management.js
+++ b/BondageClub/Screens/Room/Management/Management.js
@@ -23,163 +23,163 @@ var ManagementTimer = 0;
  * Checks if the player is helpless (maids disabled) or not.
  * @returns {boolean} - Returns true if the player still has time remaining after asking the maids to stop helping
  */
-function ManagementIsMaidsDisabled() { var expire = LogValue("MaidsDisabled", "Maid") - CurrentTime ; return (expire > 0 ) }
+function ManagementIsMaidsDisabled() { var expire = LogValue("MaidsDisabled", "Maid") - CurrentTime ; return (expire > 0 ); }
 /**
  * Checks if the player has a special title such as maid, mistress, kidnapper, etc.
  * @returns {boolean} - TRUE if the player has a special title.
  */
-function ManagementNoTitle() { return (!LogQuery("JoinedSorority", "Maid") && !LogQuery("ClubMistress", "Management") && (ReputationGet("Kidnap") < 50) && !SarahUnlockQuest) }
+function ManagementNoTitle() { return (!LogQuery("JoinedSorority", "Maid") && !LogQuery("ClubMistress", "Management") && (ReputationGet("Kidnap") < 50) && !SarahUnlockQuest); }
 /**
  * Checks if the player has unlocked sarah's quest.
  * @returns {boolean} - TRUE if the player has unlocked sarah's quest.
  */
-function ManagementSarahUnlockQuest() { return (SarahUnlockQuest) }
+function ManagementSarahUnlockQuest() { return (SarahUnlockQuest); }
 /**
  * Checks if the player is Sarah's owner.
  * @returns {boolean} - TRUE if the player is Sarah's owner.
  */
-function ManagementIsSarahOwner() { return (SarahUnlockQuest && (Sarah.Owner == Player.Name)) }
+function ManagementIsSarahOwner() { return (SarahUnlockQuest && (Sarah.Owner == Player.Name)); }
 /**
  * Checks if the mistress has been angered for a given amount of times.
  * @param {number} InCount - Number of times the mistress has to have been angered.
  * @returns {boolean} - TRUE if the mistress has been angered the specified amount.
  */
-function ManagementGetMistressAngryCount(InCount) { return (InCount == ManagementMistressAngryCount) }
+function ManagementGetMistressAngryCount(InCount) { return (InCount == ManagementMistressAngryCount); }
 /**
  * Increments the amount of times the mistress has been angered.
  * @returns {void} - Nothing
  */
-function ManagementMistressAngryAdd() { ManagementMistressAngryCount++ }
+function ManagementMistressAngryAdd() { ManagementMistressAngryCount++; }
 /**
  * Checks if the mistress is willing to release the player. (Based on the release timer)
  * @returns {boolean} - TRUE if the mistress will release the player
  */
-function ManagementMistressWillRelease() { return (CommonTime() >= ManagementMistressReleaseTimer) }
+function ManagementMistressWillRelease() { return (CommonTime() >= ManagementMistressReleaseTimer); }
 /**
  * Checks if the player is about to play with the submissive, albeit without the consent of the mistress.
  * @returns {boolean} - TRUE if the dialog option is available.
  */
-function ManagementCanPlayWithoutPermission() { return (!ManagementMistressAllowPlay && Player.CanInteract() && (ManagementMistressReleaseTimer == 0) && !ManagementIsClubSlave()) } 
+function ManagementCanPlayWithoutPermission() { return (!ManagementMistressAllowPlay && Player.CanInteract() && (ManagementMistressReleaseTimer == 0) && !ManagementIsClubSlave()); }
 /**
  * Checks if the player is owned by one of the bondage college NPCs.
  * @returns {boolean} - TRUE if the player is owned by a bondage college NPC
  */
-function ManagementOwnerFromBondageCollege() { return ((Player.Owner == "NPC-Sidney") || (Player.Owner == "NPC-Amanda") || (Player.Owner == "NPC-Jennifer")) }
+function ManagementOwnerFromBondageCollege() { return ((Player.Owner == "NPC-Sidney") || (Player.Owner == "NPC-Amanda") || (Player.Owner == "NPC-Jennifer")); }
 /**
  * Checks if the player's owner is a NPC in her private room.
  * @returns {boolean} - TRUE if the player's owner is in the player's private room.
  */
-function ManagementOwnerInPrivateRoom() { return PrivateOwnerInRoom() }
+function ManagementOwnerInPrivateRoom() { return PrivateOwnerInRoom(); }
 /**
  * Checks if the player's owner is not one of the bondage college NPC.
  * @returns {boolean} - TRUE if the player is NOT owned by a bondage college NPC
  */
-function ManagementOwnerAway() { return !((Player.Owner == "NPC-Sidney") || (Player.Owner == "NPC-Amanda") || (Player.Owner == "NPC-Jennifer")) }
+function ManagementOwnerAway() { return !((Player.Owner == "NPC-Sidney") || (Player.Owner == "NPC-Amanda") || (Player.Owner == "NPC-Jennifer")); }
 /**
  * Checks if the player is wearing any chastity item that can currently be removed by the mistress.
  * @returns {boolean} - TRUE if there is at least one chastity item that can be removed.
  */
-function ManagementAllowReleaseChastity() { return (Player.IsChaste() && !ManagementIsMaidsDisabled() && ManagementCanReleaseChastity && (ManagementCanUnlockBra() || ManagementCanUnlockBelt() || ManagementCanUnlockButt() || ManagementCanUnlockVulva() || ManagementCanUnlockNipples()) )}
+function ManagementAllowReleaseChastity() { return (Player.IsChaste() && !ManagementIsMaidsDisabled() && ManagementCanReleaseChastity && (ManagementCanUnlockBra() || ManagementCanUnlockBelt() || ManagementCanUnlockButt() || ManagementCanUnlockVulva() || ManagementCanUnlockNipples()) );}
 /**
  * Checks if the player is chaste, but cannot be released.
  * @returns {boolean} - TRUE if the player is chaste and cannot be released.
  */
-function ManagementRefuseReleaseChastity() { return (Player.IsChaste() && (!ManagementCanReleaseChastity || ManagementIsMaidsDisabled())) }
+function ManagementRefuseReleaseChastity() { return (Player.IsChaste() && (!ManagementCanReleaseChastity || ManagementIsMaidsDisabled())); }
 /**
  * Checks if the player cannot be released by the mistress.
  * @returns {boolean} - TRUE if the player cannot be released.
  */
-function ManagementOwnerPending() { return (CommonTime() < ManagementMistressReleaseTimer) }
+function ManagementOwnerPending() { return (CommonTime() < ManagementMistressReleaseTimer); }
 /**
  * Checks if the player can be released from her chastity items by the mistress
  * @returns {boolean} - TRUE if the release timer has expired and the mistress can release the player from chastity.
  */
-function ManagementOwnerAccepted() { return ((CommonTime() >= ManagementMistressReleaseTimer) && ManagementCanReleaseChastity) }
+function ManagementOwnerAccepted() { return ((CommonTime() >= ManagementMistressReleaseTimer) && ManagementCanReleaseChastity); }
 /**
  * Checks if the player can be released by the mistress (timer), but cannot be released from chastity due to her owner.
  * @returns {boolean} - TRUE if the player can be released, but cannot be released from chastity.
  */
-function ManagementOwnerRefused() { return ((CommonTime() >= ManagementMistressReleaseTimer) && !ManagementCanReleaseChastity) }
+function ManagementOwnerRefused() { return ((CommonTime() >= ManagementMistressReleaseTimer) && !ManagementCanReleaseChastity); }
 /**
  * Checks if the mistress can remove the player's chastity bra
  * @returns {boolean} - TRUE if the mistress can remove the item. (Not owner locked while owned and has at least 25$.)
  */
-function ManagementCanUnlockBra() { return ((Player.Money >= 25) && InventoryItemHasEffect(InventoryGet(Player, "ItemBreast"), "BreastChaste") && (!InventoryOwnerOnlyItem(InventoryGet(Player, "ItemBreast")) || !Player.IsOwned() )) }
+function ManagementCanUnlockBra() { return ((Player.Money >= 25) && InventoryItemHasEffect(InventoryGet(Player, "ItemBreast"), "BreastChaste") && (!InventoryOwnerOnlyItem(InventoryGet(Player, "ItemBreast")) || !Player.IsOwned() )); }
 /**
  * Checks if the mistress can remove the player's butt item with a chaste effect
  * @returns {boolean} - TRUE if the mistress can remove the item. (Not owner locked while owned and has at least 25$.)
  */
-function ManagementCanUnlockButt() { return ((Player.Money >= 25) && InventoryItemHasEffect(InventoryGet(Player, "ItemButt"), "Chaste") && !InventoryGroupIsBlocked(Player, "ItemButt") && (!InventoryOwnerOnlyItem(InventoryGet(Player, "ItemButt")) || !Player.IsOwned())) }
+function ManagementCanUnlockButt() { return ((Player.Money >= 25) && InventoryItemHasEffect(InventoryGet(Player, "ItemButt"), "Chaste") && !InventoryGroupIsBlocked(Player, "ItemButt") && (!InventoryOwnerOnlyItem(InventoryGet(Player, "ItemButt")) || !Player.IsOwned())); }
 /**
  * Checks if the mistress can remove the player's vulva item with a chaste effect
  * @returns {boolean} - TRUE if the mistress can remove the item. (Not owner locked while owned and has at least 25$.)
  */
-function ManagementCanUnlockVulva() { return ((Player.Money >= 25) && InventoryItemHasEffect(InventoryGet(Player, "ItemVulvaPiercings"), "Chaste") && !InventoryGroupIsBlocked(Player, "ItemVulvaPiercings") && (!InventoryOwnerOnlyItem(InventoryGet(Player, "ItemVulvaPiercings")) || !Player.IsOwned())) }
+function ManagementCanUnlockVulva() { return ((Player.Money >= 25) && InventoryItemHasEffect(InventoryGet(Player, "ItemVulvaPiercings"), "Chaste") && !InventoryGroupIsBlocked(Player, "ItemVulvaPiercings") && (!InventoryOwnerOnlyItem(InventoryGet(Player, "ItemVulvaPiercings")) || !Player.IsOwned())); }
 /**
  * Checks if the mistress can remove the player's nipple item with a chaste effect
  * @returns {boolean} - TRUE if the mistress can remove the item. (Not owner locked while owned and has at least 25$.)
  */
-function ManagementCanUnlockNipples() { return ((Player.Money >= 25) && InventoryItemHasEffect(InventoryGet(Player, "ItemNipplesPiercings"), "BreastChaste") && !InventoryGroupIsBlocked(Player, "ItemNipplesPiercings") && (!InventoryOwnerOnlyItem(InventoryGet(Player, "ItemNipplesPiercings")) ||!Player.IsOwned())) }
+function ManagementCanUnlockNipples() { return ((Player.Money >= 25) && InventoryItemHasEffect(InventoryGet(Player, "ItemNipplesPiercings"), "BreastChaste") && !InventoryGroupIsBlocked(Player, "ItemNipplesPiercings") && (!InventoryOwnerOnlyItem(InventoryGet(Player, "ItemNipplesPiercings")) ||!Player.IsOwned())); }
 /**
  * Checks if the mistress can remove the player's pelvis item with a chaste effect
  * @returns {boolean} - TRUE if the mistress can remove the item. (Not owner locked while owned and has at least 25$.)
  */
-function ManagementCanUnlockBelt() { return ((Player.Money >= 25) && InventoryItemHasEffect(InventoryGet(Player, "ItemPelvis"), "Chaste") && (!InventoryOwnerOnlyItem(InventoryGet(Player, "ItemPelvis")) || !Player.IsOwned())) }
+function ManagementCanUnlockBelt() { return ((Player.Money >= 25) && InventoryItemHasEffect(InventoryGet(Player, "ItemPelvis"), "Chaste") && (!InventoryOwnerOnlyItem(InventoryGet(Player, "ItemPelvis")) || !Player.IsOwned())); }
 /**
  * Sets the player's chastity release timer to 0.
  * @returns {void} - Nothing.
  */
-function ManagementEndChastityRelease() { ManagementMistressReleaseTimer = 0 }
+function ManagementEndChastityRelease() { ManagementMistressReleaseTimer = 0; }
 /**
  * Checks if the player can be released from her owner, but for the first time ever.
  * @returns {boolean} - TRUE if the player has at least 60$ and has never been released from an owner before.
  */
-function ManagementCanReleaseFromOwnerFirst() { return ((Player.Money >= 60) && !LogQuery("ReleasedFromOwner", "Management")) }
+function ManagementCanReleaseFromOwnerFirst() { return ((Player.Money >= 60) && !LogQuery("ReleasedFromOwner", "Management")); }
 /**
  * Checks if the player can be released from her owner, but has been released before.
  * @returns {boolean} - TRUE if the player has at least 200$ and has been released from an owner before.
  */
-function ManagementCanReleaseFromOwner() { return ((Player.Money >= 200) && LogQuery("ReleasedFromOwner", "Management")) }
+function ManagementCanReleaseFromOwner() { return ((Player.Money >= 200) && LogQuery("ReleasedFromOwner", "Management")); }
 /**
  * Checks if the player can break an online ownership trial.
  * @returns {boolean} - TRUE if the player can break her trial.
  */
-function ManagementCanBreakTrialOnline() { return ((Player.Owner == "") && (Player.Ownership != null) && (Player.Ownership.Stage != null) && (Player.Ownership.Stage == 0)) }
+function ManagementCanBreakTrialOnline() { return ((Player.Owner == "") && (Player.Ownership != null) && (Player.Ownership.Stage != null) && (Player.Ownership.Stage == 0)); }
 /**
  * Checks if the player can part ways from their online owner. (7 days wait time over)
  * @returns {boolean} - TRUE if the player can break her full collar.
  */
-function ManagementCanBeReleasedOnline() { return ((Player.Owner != "") && (Player.Ownership != null) && (Player.Ownership.Start != null) && (Player.Ownership.Start + 604800000 <= CurrentTime) && (Player.GetDifficulty() <= 2)) }
+function ManagementCanBeReleasedOnline() { return ((Player.Owner != "") && (Player.Ownership != null) && (Player.Ownership.Start != null) && (Player.Ownership.Start + 604800000 <= CurrentTime) && (Player.GetDifficulty() <= 2)); }
 /**
  * Checks if the player cannot part ways from their online owner. (7 days wait time not over)
  * @returns {boolean} - TRUE if the player cannot break her full collar.
  */
-function ManagementCannotBeReleasedOnline() { return ((Player.Owner != "") && (Player.Ownership != null) && (Player.Ownership.Start != null) && (Player.Ownership.Start + 604800000 > CurrentTime) && (Player.GetDifficulty() <= 2)) }
+function ManagementCannotBeReleasedOnline() { return ((Player.Owner != "") && (Player.Ownership != null) && (Player.Ownership.Start != null) && (Player.Ownership.Start + 604800000 > CurrentTime) && (Player.GetDifficulty() <= 2)); }
 /**
  * Checks if the player can part ways from her owner. (The NPC left the private room.)
  * @returns {boolean} - TRUE if the player can part ways with her current NPC owner.
  */
-function ManagementCanBeReleased() { return ((Player.Owner != "") && (Player.Ownership == null) && !PrivateOwnerInRoom() && (Player.GetDifficulty() <= 2)) }
+function ManagementCanBeReleased() { return ((Player.Owner != "") && (Player.Ownership == null) && !PrivateOwnerInRoom() && (Player.GetDifficulty() <= 2)); }
 /**
  * Checks if the player cannot part ways from her owner. (The NPC is still in the private room.)
  * @returns {boolean} - TRUE if the player cannot part ways with her current NPC owner.
  */
-function ManagementCannotBeReleased() { return ((Player.Owner != "") && (Player.Ownership == null) && PrivateOwnerInRoom() && (Player.GetDifficulty() <= 2)) }
+function ManagementCannotBeReleased() { return ((Player.Owner != "") && (Player.Ownership == null) && PrivateOwnerInRoom() && (Player.GetDifficulty() <= 2)); }
 /**
  * Checks if the player cannot part ways from her owner because she's on the Extreme difficulty.
  * @returns {boolean} - TRUE if the player cannot part ways with her current owner.
  */
-function ManagementCannotBeReleasedExtreme() { return ((Player.Owner != "") && (Player.GetDifficulty() >= 3)) }
+function ManagementCannotBeReleasedExtreme() { return ((Player.Owner != "") && (Player.GetDifficulty() >= 3)); }
 /**
  * Checks if the player can be owned by the mistress.
  * @returns {boolean} - TRUE if the player is fully submissive, the player is not owned, the mistress has not been angered and the mistress can enter the private room.
  */
-function ManagementWillOwnPlayer() { return ((Player.Owner == "") && (ReputationGet("Dominant") <= -100) && (ManagementMistressAngryCount == 0) && (PrivateCharacter.length <= PrivateCharacterMax) && !PrivatePlayerIsOwned() && ManagementNoMistressInPrivateRoom()) }
+function ManagementWillOwnPlayer() { return ((Player.Owner == "") && (ReputationGet("Dominant") <= -100) && (ManagementMistressAngryCount == 0) && (PrivateCharacter.length <= PrivateCharacterMax) && !PrivatePlayerIsOwned() && ManagementNoMistressInPrivateRoom()); }
 /**
  * Checks if the mistress is not willing to own the player.
  * @returns {boolean} - TRUE if the player can be owned, but is not submissive enough.
  */
-function ManagementWontOwnPlayer() { return ((Player.Owner == "") && (ReputationGet("Dominant") <= -1) && (ReputationGet("Dominant") >= -99) && (PrivateCharacter.length <= PrivateCharacterMax) && !PrivatePlayerIsOwned() && ManagementNoMistressInPrivateRoom()) }
+function ManagementWontOwnPlayer() { return ((Player.Owner == "") && (ReputationGet("Dominant") <= -1) && (ReputationGet("Dominant") >= -99) && (PrivateCharacter.length <= PrivateCharacterMax) && !PrivatePlayerIsOwned() && ManagementNoMistressInPrivateRoom()); }
 /**
  * Checks if the player has at least one lover who is a NPC from bondage college.
  * @returns {boolean} - TRUE if the player has at least one lover who is a NPC from bondage college.
@@ -202,109 +202,109 @@ function ManagementCanBreakUpLoverOnline(L) { return ((Player.Lovership.length >
  * @param {number} L - Index of the potential lover
  * @returns {boolean} - TRUE if the they cannot get divorced
  */
-function ManagementCannotBreakUpLoverOnline(L) { return ((Player.Lovership.length > L) && (Player.Lovership[L].Stage != null) && (Player.Lovership[L].Stage == 2) && (Player.Lovership[L].Start != null) && (Player.Lovership[L].Start + 604800000 >= CurrentTime)) }
+function ManagementCannotBreakUpLoverOnline(L) { return ((Player.Lovership.length > L) && (Player.Lovership[L].Stage != null) && (Player.Lovership[L].Stage == 2) && (Player.Lovership[L].Start != null) && (Player.Lovership[L].Start + 604800000 >= CurrentTime)); }
 /**
  * Checks if the player can stop dating the given NPC lover (1 to 5)
  * @param {number} L - Index of the potential lover
  * @returns {boolean} - TRUE if the player can stop dating the specified lover. (The NPC is gone from the room.)
  */
-function ManagementCanBreakUpLoverNPC(L) { return ((Player.Lovership.length > L) && (Player.Lovership[L].MemberNumber == null) && !PrivateLoverInRoom(L)) }
+function ManagementCanBreakUpLoverNPC(L) { return ((Player.Lovership.length > L) && (Player.Lovership[L].MemberNumber == null) && !PrivateLoverInRoom(L)); }
 /**
  * Checks if the player cannot stop dating the given NPC lover (1 to 5)
  * @param {number} L - Index of the potential lover
  * @returns {boolean} - TRUE if the player cannot stop dating the specified lover (The lover is still in the player's private room.)
  */
-function ManagementCannotBreakUpLoverNPC(L) { return ((Player.Lovership.length > L) && (Player.Lovership[L].MemberNumber == null) && PrivateLoverInRoom(L)) }
+function ManagementCannotBreakUpLoverNPC(L) { return ((Player.Lovership.length > L) && (Player.Lovership[L].MemberNumber == null) && PrivateLoverInRoom(L)); }
 /**
  * Checks if the player is currently a club slave.
  * @returns {boolean} - TRUE if the player is a club slave.
  */
-function ManagementIsClubSlave() { return ((InventoryGet(Player, "ItemNeck") != null) && (InventoryGet(Player, "ItemNeck").Asset.Name == "ClubSlaveCollar")) }
+function ManagementIsClubSlave() { return ((InventoryGet(Player, "ItemNeck") != null) && (InventoryGet(Player, "ItemNeck").Asset.Name == "ClubSlaveCollar")); }
 /**
  * Checks if the player is wearing a slave collar.
  * @returns {boolean} - TRUE if the player is wearing a slave collar.
  */
-function ManagementWearingSlaveCollar() { return ((InventoryGet(Player, "ItemNeck") != null) && (InventoryGet(Player, "ItemNeck").Asset.Name == "SlaveCollar")) }
+function ManagementWearingSlaveCollar() { return ((InventoryGet(Player, "ItemNeck") != null) && (InventoryGet(Player, "ItemNeck").Asset.Name == "SlaveCollar")); }
 /**
  * Checks if a NPC can be transfered to the player's private room.
  * @returns {boolean} - TRUE if the player owns a private room, has space for an extra NPC and is not locked out of her room.
  */
-function ManagementCanTransferToRoom() { return (LogQuery("RentRoom", "PrivateRoom") && (PrivateCharacter.length < PrivateCharacterMax) && !LogQuery("LockOutOfPrivateRoom", "Rule")) }
+function ManagementCanTransferToRoom() { return (LogQuery("RentRoom", "PrivateRoom") && (PrivateCharacter.length < PrivateCharacterMax) && !LogQuery("LockOutOfPrivateRoom", "Rule")); }
 /**
  * Checks if the mistress is not willing to visit the player's room.
  * @returns {boolean} - TRUE if the mistress could transfer to the player's room, but is not willing to.
  */
-function ManagementWontVisitRoom() { return (!ManagementVisitRoom && ManagementCanTransferToRoom()) }
+function ManagementWontVisitRoom() { return (!ManagementVisitRoom && ManagementCanTransferToRoom()); }
 /**
  * Checks if the player can become a club mistress.
  * @returns {boolean} - TRUE if the player is fully dominant, has been in the club for more than a month, is currently not restrained, is not kneeling, can currently change and is currently not a club mistress.
  */
-function ManagementCanBeClubMistress() { return ((ReputationGet("Dominant") >= 100) && ((Math.floor((CurrentTime - Player.Creation) / 86400000)) >= 30) && !LogQuery("ClubMistress", "Management") && !Player.IsRestrained() && !Player.IsKneeling() && Player.CanChange()) }
+function ManagementCanBeClubMistress() { return ((ReputationGet("Dominant") >= 100) && ((Math.floor((CurrentTime - Player.Creation) / 86400000)) >= 30) && !LogQuery("ClubMistress", "Management") && !Player.IsRestrained() && !Player.IsKneeling() && Player.CanChange()); }
 /**
  * Checks if the player is not able to become a club mistress due to her reputation.
  * @returns {boolean} - TRUE if the player could be a club mistress, but has a dominant reputation between 50 and 99.
  */
-function ManagementCannotBeClubMistress() { return ((ReputationGet("Dominant") < 100) && (ReputationGet("Dominant") >= 50) && ((Math.floor((CurrentTime - Player.Creation) / 86400000)) >= 30) && !LogQuery("ClubMistress", "Management") && !Player.IsRestrained() && !Player.IsKneeling() && Player.CanChange()) }
+function ManagementCannotBeClubMistress() { return ((ReputationGet("Dominant") < 100) && (ReputationGet("Dominant") >= 50) && ((Math.floor((CurrentTime - Player.Creation) / 86400000)) >= 30) && !LogQuery("ClubMistress", "Management") && !Player.IsRestrained() && !Player.IsKneeling() && Player.CanChange()); }
 /**
  * Checks if the player is not able to become a club mistress due to her reputation (by a large amount, which makes the mistress laugh.)
  * @returns {boolean} - TRUE if the player could be a club mistress, but has a dominant reputation below 50.
  */
-function ManagementCannotBeClubMistressLaugh() { return ((ReputationGet("Dominant") < 50) && ((Math.floor((CurrentTime - Player.Creation) / 86400000)) >= 30) && !LogQuery("ClubMistress", "Management") && !Player.IsRestrained() && !Player.IsKneeling() && Player.CanChange()) }
+function ManagementCannotBeClubMistressLaugh() { return ((ReputationGet("Dominant") < 50) && ((Math.floor((CurrentTime - Player.Creation) / 86400000)) >= 30) && !LogQuery("ClubMistress", "Management") && !Player.IsRestrained() && !Player.IsKneeling() && Player.CanChange()); }
 /**
  * Checks if the player is not able to become a club mistress due to her short time in the club.
  * @returns {boolean} - TRUE if the player has been in the club for less than a month.
  */
-function ManagementCannotBeClubMistressTime() { return (((Math.floor((CurrentTime - Player.Creation) / 86400000)) < 30) && !LogQuery("ClubMistress", "Management") && !Player.IsRestrained() && !Player.IsKneeling() && Player.CanChange()) }
+function ManagementCannotBeClubMistressTime() { return (((Math.floor((CurrentTime - Player.Creation) / 86400000)) < 30) && !LogQuery("ClubMistress", "Management") && !Player.IsRestrained() && !Player.IsKneeling() && Player.CanChange()); }
 /**
  * Checks if the player can receive her club mistress pay check.
  * @returns {boolean} - TRUE if the player is a club mistress and has not been paid this week.
  */
-function ManagementMistressCanBePaid() { return (LogQuery("ClubMistress", "Management") && !LogQuery("MistressWasPaid", "Management")) }
+function ManagementMistressCanBePaid() { return (LogQuery("ClubMistress", "Management") && !LogQuery("MistressWasPaid", "Management")); }
 /**
  * Checks if the player cannot receive her club mistress pay check.
  * @returns {boolean} - TRUE if the player is a club mistress, but has already been paid this week.
  */
-function ManagementMistressCannotBePaid() { return (LogQuery("ClubMistress", "Management") && LogQuery("MistressWasPaid", "Management")) }
+function ManagementMistressCannotBePaid() { return (LogQuery("ClubMistress", "Management") && LogQuery("MistressWasPaid", "Management")); }
 /**
  * Checks if the player can be a club slave.
  * @returns {boolean} - TRUE if the player is not wearing an owner/lover only restraint and is not too dominant.
  */
-function ManagementCanBeClubSlave() { return (!InventoryCharacterHasOwnerOnlyRestraint(Player) && !InventoryCharacterHasLoverOnlyRestraint(Player) && DialogReputationLess("Dominant", -50)) }
+function ManagementCanBeClubSlave() { return (!InventoryCharacterHasOwnerOnlyRestraint(Player) && !InventoryCharacterHasLoverOnlyRestraint(Player) && DialogReputationLess("Dominant", -50)); }
 /**
  * Checks if the player cannot be a club slave due to her dominant reputation.
  * @returns {boolean} - TRUE if the player is not wearing an owner/lover only restraint, but is too dominant.
  */
-function ManagementCannotBeClubSlaveDominant() { return (!InventoryCharacterHasOwnerOnlyRestraint(Player) && !InventoryCharacterHasLoverOnlyRestraint(Player) && DialogReputationGreater("Dominant", -49)) }
+function ManagementCannotBeClubSlaveDominant() { return (!InventoryCharacterHasOwnerOnlyRestraint(Player) && !InventoryCharacterHasLoverOnlyRestraint(Player) && DialogReputationGreater("Dominant", -49)); }
 /**
  * Checks if the player cannot be a club slave due to her currently worn owner-only restraint(s).
  * @returns {boolean} - TRUE if the player is wearing an owner-only restraint.
  */
-function ManagementCannotBeClubSlaveOwnerLock() { return InventoryCharacterHasOwnerOnlyRestraint(Player) }
+function ManagementCannotBeClubSlaveOwnerLock() { return InventoryCharacterHasOwnerOnlyRestraint(Player); }
 /**
  * Checks if the player cannot be a club slave due to her currently worn lover-only restraint(s).
  * @returns {boolean} - TRUE if the player is wearing a lover-only restraint.
  */
-function ManagementCannotBeClubSlaveLoverLock() { return InventoryCharacterHasLoverOnlyRestraint(Player) }
+function ManagementCannotBeClubSlaveLoverLock() { return InventoryCharacterHasLoverOnlyRestraint(Player); }
 /**
  * Checks if the player can kiss the current NPC.
- * @returns {boolean} - TRUE if both the NPC and the player can talk. 
+ * @returns {boolean} - TRUE if both the NPC and the player can talk.
  */
-function ManagementCanKiss() { return (Player.CanTalk() && CurrentCharacter.CanTalk()) }
+function ManagementCanKiss() { return (Player.CanTalk() && CurrentCharacter.CanTalk()); }
 /**
  * Checks if the player can masturbate the current NPC.
  * @returns {boolean} - TRUE if the NPC is not chaste and the player can interact.
  */
-function ManagementCanMasturbate() { return (Player.CanInteract() && !CurrentCharacter.IsVulvaChaste()) }
+function ManagementCanMasturbate() { return (Player.CanInteract() && !CurrentCharacter.IsVulvaChaste()); }
 /**
  * Checks if the player can play with the management submissive NPC.
  * @returns {boolean} - TRUE if the player's dominant reputation is below 23 and the player is not wearing a locked restraint.
  */
-function ManagementCanPlayWithSub() { return (DialogReputationLess("Dominant", 24) && !InventoryCharacterHasLockedRestraint(Player)) }
+function ManagementCanPlayWithSub() { return (DialogReputationLess("Dominant", 24) && !InventoryCharacterHasLockedRestraint(Player)); }
 /**
  * Checks if the player cannot play with the management submissive NPC due to a locked restraint.
  * @returns {boolean} - TRUE if the player's dominant reputation is below 23, but the player is wearing a locked restraint.
  */
-function ManagementCannotPlayWithSubLock() { return (DialogReputationLess("Dominant", 24) && InventoryCharacterHasLockedRestraint(Player)) }
+function ManagementCannotPlayWithSubLock() { return (DialogReputationLess("Dominant", 24) && InventoryCharacterHasLockedRestraint(Player)); }
 
 /**
  * Checks if there is no mistress in the player's private room.
@@ -373,7 +373,7 @@ function ManagementRun() {
  */
 function ManagementClick() {
 	if (MouseIn(250, 0, 500, 1000)) CharacterSetCurrent(Player);
-	if (MouseIn(750, 0, 500, 1000) && !ManagementEmpty) {		
+	if (MouseIn(750, 0, 500, 1000) && !ManagementEmpty) {
 		if ((ManagementMistress.Stage == "0") && ManagementIsClubSlave()) ManagementMistress.Stage = "350";
 		if ((ManagementMistress.Stage == "0") && (ReputationGet("Dominant") < 50) && (CheatFactor("CantLoseMistress", 0) == 1) && LogQuery("ClubMistress", "Management")) {
 			ManagementMistress.Stage = "500";
@@ -534,7 +534,7 @@ function ManagementBreakTrialOnline() {
 
 /**
  * Triggered when the Mistress breaks the bond between lovers.
- * @param {number} L - Index of the lover to remove. 
+ * @param {number} L - Index of the lover to remove.
  * @returns {void} - Nothing.
  */
 function ManagementBreakLover(L) {
@@ -592,13 +592,13 @@ function ManagementFinishClubSlave(RepChange) {
  * @returns {void} - Nothing.
  */
 function ManagementClubSlaveRandomIntro() {
-	
+
 	// Sets the girl that greets the club slave player
 	CommonSetScreen("Room", "Management");
 	ManagementBackground = "MainHall";
 	ManagementRandomGirl = null;
-	CharacterDelete("NPC_Management_RandomGirl");	
-	ManagementRandomGirl = CharacterLoadNPC("NPC_Management_RandomGirl");	
+	CharacterDelete("NPC_Management_RandomGirl");
+	ManagementRandomGirl = CharacterLoadNPC("NPC_Management_RandomGirl");
 	CharacterSetCurrent(ManagementRandomGirl);
 	ManagementRandomGirl.AllowItem = false;
 	ManagementRandomActivityCount = 0;
@@ -673,7 +673,7 @@ function ManagementRandomActivityStart(A) {
  * @returns {void} - Nothing.
  */
 function ManagementClubSlaveRandomActivityLaunch() {
-	
+
 	// After 4 activities, there's more and more chances that it will stop
 	ManagementRandomActivityCount++;
 	if (Math.random() * ManagementRandomActivityCount >= 4) {
@@ -709,7 +709,7 @@ function ManagementClubSlaveRandomActivityLaunch() {
 		if ((A == "Spank") || (A == "Tickle")) { ManagementRandomActivityStart(A); return; }
 		if ((A == "Fondle") && !Player.IsBreastChaste()) { ManagementRandomActivityStart(A); return; }
 		if ((A == "Masturbate") && !Player.IsVulvaChaste()) { ManagementRandomActivityStart(A); return; }
-		
+
 	}
 }
 
@@ -871,7 +871,7 @@ function ManagementClubSlaveActiviy(ActivityType, RepChange) {
 
 /**
  * Triggered after player with a club slave. There's a 50% chance the club slave will go to the player's private room.
- * @returns {void} - Nothing. 
+ * @returns {void} - Nothing.
  */
 function ManagementClubSlaveVisitRoom() {
 	if ((ManagementRandomTalkCount >= 2) && (ManagementRandomActivityCount >= 2) && ManagementVisitRoom && ManagementRandomGirl.CanTalk()) {
@@ -886,8 +886,8 @@ function ManagementClubSlaveVisitRoom() {
 
 /**
  * Triggered when the player asks to have her slave collar model changed
- * @param {string} NewType - The new slave collar type to change to. 
- * @returns {void} - Nothing. 
+ * @param {string} NewType - The new slave collar type to change to.
+ * @returns {void} - Nothing.
  */
 function ManagementChangeSlaveCollarType(NewType) {
 	var Collar = InventoryGet(Player, "ItemNeck");
@@ -901,7 +901,7 @@ function ManagementChangeSlaveCollarType(NewType) {
 /**
  * Sets the given NPC's dialog based on if the player is a club slave or not. Some NPC are not available or have special dialog for club slaves.
  * @param {Character} C - Current NPC.
- * @returns {void} - Nothing. 
+ * @returns {void} - Nothing.
  */
 function ManagementClubSlaveDialog(C) {
 	if ((C != null) && (C.Stage == "0") && ManagementIsClubSlave()) C.Stage = "ClubSlave";

--- a/BondageClub/Screens/Room/MovieStudio/MovieStudio.js
+++ b/BondageClub/Screens/Room/MovieStudio/MovieStudio.js
@@ -17,25 +17,25 @@ var MovieStudioOriginalClothes = null;
  * The player can play in a movie if she doesn't have any locked restraints
  * @returns {boolean} - TRUE if the player can play in a movie
  */
-function MovieStudioCanPlayInMovie() { return !InventoryCharacterHasLockedRestraint(Player) }
+function MovieStudioCanPlayInMovie() { return !InventoryCharacterHasLockedRestraint(Player); }
 
 /**
  * Returns TRUE if the player can receive the camera as a payment
  * @returns {boolean} - TRUE if the player can get the item
  */
-function MovieStudioCanGetCamera() { return (!InventoryAvailable(Player, "Camera1", "ClothAccessory") && (MovieStudioCurrentRole == "Journalist")) }
+function MovieStudioCanGetCamera() { return (!InventoryAvailable(Player, "Camera1", "ClothAccessory") && (MovieStudioCurrentRole == "Journalist")); }
 
 /**
  * Returns TRUE if the player can receive the gavel as a payment
  * @returns {boolean} - TRUE if the player can get the item
  */
-function MovieStudioCanGetGavel() { return (!InventoryAvailable(Player, "SpankingToysGavel", "ItemHands") && (MovieStudioCurrentRole == "Mistress") && (MovieStudioActor1.TrialDone)) }
+function MovieStudioCanGetGavel() { return (!InventoryAvailable(Player, "SpankingToysGavel", "ItemHands") && (MovieStudioCurrentRole == "Mistress") && (MovieStudioActor1.TrialDone)); }
 
 /**
  * Returns TRUE if the player can receive the long duster as a payment
  * @returns {boolean} - TRUE if the player can get the item
  */
-function MovieStudioCanGetLongDuster() { return (!InventoryAvailable(Player, "SpankingToysLongDuster", "ItemHands") && (MovieStudioCurrentRole == "Maid") && (MovieStudioActor1.CanGetLongDuster)) }
+function MovieStudioCanGetLongDuster() { return (!InventoryAvailable(Player, "SpankingToysLongDuster", "ItemHands") && (MovieStudioCurrentRole == "Maid") && (MovieStudioActor1.CanGetLongDuster)); }
 
 /**
  * When the player fails the movie, we jump back to the director
@@ -65,7 +65,7 @@ function MovieStudioChangeMeter(Factor) {
 }
 
 /**
- * Process the movie meter decay over time, 
+ * Process the movie meter decay over time,
  * @returns {void} - Nothing
  */
 function MovieStudioProcessDecay() {
@@ -116,7 +116,7 @@ function MovieStudioProcessDecay() {
 			MovieStudioDirector.CurrentDialog = TextGet("InterviewDirectorSuccess" + Math.floor(Math.random() * 4).toString());
 			MovieStudioCurrentMovie = "";
 			MovieStudioCurrentScene = "";
-			MovieStudioBackground = "MovieStudio"
+			MovieStudioBackground = "MovieStudio";
 			return;
 		}
 	}
@@ -128,7 +128,7 @@ function MovieStudioProcessDecay() {
  */
 function MovieStudioLoad() {
 	if (MovieStudioOriginalClothes == null) MovieStudioOriginalClothes = Player.Appearance.slice(0);
-	if (MovieStudioDirector == null) {		
+	if (MovieStudioDirector == null) {
 		MovieStudioDirector = CharacterLoadNPC("NPC_MovieStudio_Director");
 		InventoryWear(MovieStudioDirector, "Beret1", "Hat");
 		InventoryWear(MovieStudioDirector, "SunGlasses1", "Glasses");
@@ -143,7 +143,7 @@ function MovieStudioLoad() {
  * @returns {void} - Nothing
  */
 function MovieStudioRun() {
-	
+
 	// If there's no movie going on, the player can chat with the director.
 	if (MovieStudioCurrentMovie == "") {
 		DrawCharacter(Player, 500, 0, 1);
@@ -152,13 +152,13 @@ function MovieStudioRun() {
 		DrawButton(1885, 145, 90, 90, "", "White", "Icons/Character.png", TextGet("Profile"));
 		return;
 	}
-	
+
 	// In the interview first & second scene, the player can check a drawer and a X Cross
 	if ((MovieStudioCurrentMovie == "Interview") && ((MovieStudioCurrentScene == "1") || (MovieStudioCurrentScene == "2"))) {
 		DrawCharacter(MovieStudioActor1, 250, 0, 1);
 		if (InventoryIsWorn(Player, "X-Cross", "ItemDevices")) {
 			DrawCharacter(Player, 1250, 0, 1);
-		} else {			
+		} else {
 			DrawCharacter(Player, 750, 0, 1);
 			DrawCharacter(MovieStudioActor2, 1250, 0, 1);
 		}
@@ -170,7 +170,7 @@ function MovieStudioRun() {
 		DrawCharacter(Player, 750, 0, 1);
 		DrawCharacter(MovieStudioActor2, 1250, 0, 1);
 	}
-	
+
 	// If there's a movie, we draw the progress meter on the right and the wait button
 	if (MovieStudioCurrentMovie != "") {
 		MovieStudioProcessDecay();
@@ -368,8 +368,8 @@ function MovieStudioDoActivity(Activity) {
 	if (Activity == "InterviewWearCuffs") { InventoryWear(Player, "LeatherCuffs", "ItemArms"); InventoryWear(Player, "LeatherLegCuffs", "ItemLegs"); InventoryWear(Player, "LeatherAnkleCuffs", "ItemFeet"); }
 	if (Activity == "InterviewWearCollar") InventoryWear(Player, "BordelleCollar", "ItemNeck");
 	if (Activity == "InterviewCrossRestrain") { InventoryWear(Player, "X-Cross", "ItemDevices"); MovieStudioActor2.FixedImage = "Screens/Room/MovieStudio/Empty.png"; }
-	if (Activity == "InterviewRestrainMaid") { 
-		InventoryWear(Player, "LeatherCuffs", "ItemArms"); 
+	if (Activity == "InterviewRestrainMaid") {
+		InventoryWear(Player, "LeatherCuffs", "ItemArms");
 		InventoryWear(Player, "LeatherLegCuffs", "ItemLegs");
 		InventoryWear(Player, "DusterGag", "ItemMouth");
 		InventoryRemove(Player, "ItemFeet");
@@ -385,8 +385,8 @@ function MovieStudioDoActivity(Activity) {
 	}
 	if (Activity == "InterviewDustOutfit") { InventoryWear(MovieStudioActor1, "MaidOutfit2", "Cloth"); InventoryRemove(MovieStudioActor1, "Bra"); }
 	if (Activity == "InterviewMaidStrip") { CharacterNaked(MovieStudioActor1); InventoryWear(MovieStudioActor1, "MaidHairband1", "Hat"); }
-	if (Activity == "InterviewRestrainForOral") { 
-		InventoryWear(Player, "LeatherCuffs", "ItemArms"); 
+	if (Activity == "InterviewRestrainForOral") {
+		InventoryWear(Player, "LeatherCuffs", "ItemArms");
 		InventoryWear(Player, "LeatherLegCuffs", "ItemLegs");
 		InventoryWear(Player, "LeatherAnkleCuffs", "ItemFeet");
 		InventoryRemove(Player, "ItemDevices");
@@ -399,7 +399,7 @@ function MovieStudioDoActivity(Activity) {
 		MovieStudioActor2.FixedImage = "Screens/Room/MovieStudio/XCross.png";
 	}
 	if (Activity == "InterviewMaidCuffPlayer") {
-		InventoryWear(Player, "LeatherCuffs", "ItemArms"); 
+		InventoryWear(Player, "LeatherCuffs", "ItemArms");
 		InventoryWear(Player, "LeatherLegCuffs", "ItemLegs");
 		InventoryWear(Player, "LeatherAnkleCuffs", "ItemFeet");
 		InventoryRemove(Player, "ItemDevices");
@@ -691,7 +691,7 @@ function MovieStudioDoActivity(Activity) {
 		CharacterSetFacialExpression(MovieStudioActor2, "Blush", "High", 10);
 		CharacterSetFacialExpression(MovieStudioActor2, "Eyes", "Dazed", 5);
 		CharacterSetFacialExpression(MovieStudioActor2, "Eyes2", "Dazed", 5);
-	}	
+	}
 	if (Activity == "InterviewMaidReleaseJournalist") {
 		CharacterRelease(MovieStudioActor2);
 		CharacterNaked(MovieStudioActor2);

--- a/BondageClub/Screens/Room/Nursery/Nursery.js
+++ b/BondageClub/Screens/Room/Nursery/Nursery.js
@@ -24,20 +24,20 @@ var NursuryEscapeFailMsg = null;
 var NurseryRepeatOffender = null;
 
 
-				
+
 
 // Returns TRUE if
-function NurseryPlayerIsPacified() { return (CharacterAppearanceGetCurrentValue(Player, "ItemMouth", "Name") == "PacifierGag") }
-function NurseryPlayerIsHarnessPacified() { return (CharacterAppearanceGetCurrentValue(Player, "ItemMouth", "Name") == "HarnessPacifierGag") }
-function NurseryPlayerLostBinky() { return Player.CanTalk() && !NurseryPlayerKeepsLoosingBinky }
-function NurseryPlayerLostBinkyAgain() { return Player.CanTalk() && NurseryPlayerKeepsLoosingBinky }
-function NurseryPlayerWearingBabyDress() { return (CharacterAppearanceGetCurrentValue(Player, "Cloth", "Name") == "AdultBabyDress1" || CharacterAppearanceGetCurrentValue(Player, "Cloth", "Name") == "AdultBabyDress2" || CharacterAppearanceGetCurrentValue(Player, "Cloth", "Name") == "AdultBabyDress3") }
-function NurseryPlayerReadyToAppologise() { return (NurseryPlayerBadBabyStatus <= 1) }
+function NurseryPlayerIsPacified() { return (CharacterAppearanceGetCurrentValue(Player, "ItemMouth", "Name") == "PacifierGag"); }
+function NurseryPlayerIsHarnessPacified() { return (CharacterAppearanceGetCurrentValue(Player, "ItemMouth", "Name") == "HarnessPacifierGag"); }
+function NurseryPlayerLostBinky() { return Player.CanTalk() && !NurseryPlayerKeepsLoosingBinky; }
+function NurseryPlayerLostBinkyAgain() { return Player.CanTalk() && NurseryPlayerKeepsLoosingBinky; }
+function NurseryPlayerWearingBabyDress() { return (CharacterAppearanceGetCurrentValue(Player, "Cloth", "Name") == "AdultBabyDress1" || CharacterAppearanceGetCurrentValue(Player, "Cloth", "Name") == "AdultBabyDress2" || CharacterAppearanceGetCurrentValue(Player, "Cloth", "Name") == "AdultBabyDress3"); }
+function NurseryPlayerReadyToAppologise() { return (NurseryPlayerBadBabyStatus <= 1); }
 function NurseryPlayerDiapered() {
 	return (CharacterAppearanceGetCurrentValue(Player, "Panties", "Name").toUpperCase().indexOf("DIAPER", 0) >= 0);
 }
-function NurseryPlayerReadyDiapered() { return (NurseryPlayerDiapered() && !NurseryPlayerInappropriateCloth) }
-function NurseryPlayerCanRegress() { return !InventoryGet(Player, "ItemMouth3") && !InventoryGroupIsBlocked(Player, "ItemMouth3") }
+function NurseryPlayerReadyDiapered() { return (NurseryPlayerDiapered() && !NurseryPlayerInappropriateCloth); }
+function NurseryPlayerCanRegress() { return !InventoryGet(Player, "ItemMouth3") && !InventoryGroupIsBlocked(Player, "ItemMouth3"); }
 
 
 // Loads the nursery room
@@ -98,7 +98,7 @@ function NurseryRun() {
 function NurseryClick() {
 	if (NurserySituation == null) {
 		if ((MouseX >= 500) && (MouseX < 1000) && (MouseY >= 0) && (MouseY < 1000)) CharacterSetCurrent(Player);
-		if ((MouseX >= 1000) && (MouseX < 1500) && (MouseY >= 0) && (MouseY < 1000)) NurseryLoadNurse(); 
+		if ((MouseX >= 1000) && (MouseX < 1500) && (MouseY >= 0) && (MouseY < 1000)) NurseryLoadNurse();
 		if ((MouseX >= 1885) && (MouseX < 1975) && (MouseY >= 25) && (MouseY < 115) && Player.CanWalk()) {
 			NurseryPlayerAppearance = null;
 			CommonSetScreen("Room", "MainHall");
@@ -237,7 +237,7 @@ function NurseryNPCResrained(CurrentNPC, RestraintSet) {
 
 // Random dress selection
 function NurseryRandomDressSelection() {
-	PreviousDress = RandomResultB
+	PreviousDress = RandomResultB;
 	RandomNumber = Math.floor(Math.random() * 3);
 	if (RandomNumber == 0) RandomResultB = "AdultBabyDress1";
 	if (RandomNumber == 1) RandomResultB = "AdultBabyDress2";
@@ -247,7 +247,7 @@ function NurseryRandomDressSelection() {
 
 // Random selection for dress colors
 function NurseryRandomColorSelection() {
-	PreviousDressColor = RandomResult
+	PreviousDressColor = RandomResult;
 	RandomNumber = Math.floor(Math.random() * 12);
 	if (RandomNumber == 0) RandomResult = "Default";
 	if (RandomNumber == 1) RandomResult = "#808080";
@@ -282,8 +282,8 @@ function NurseryPlayerUndress(Cost) {
 
 // When the player puts on diapers or has them put on
 function NurseryPlayerGetsDiapered(DomChange) {
-	ReputationProgress("Dominant", DomChange)
-	ReputationProgress("ABDL", 1)
+	ReputationProgress("Dominant", DomChange);
+	ReputationProgress("ABDL", 1);
 	InventoryWear(Player, "Diapers1", "Panties", "Default");
 	NurseryPlayerAdmitted();
 }
@@ -323,7 +323,7 @@ function NurseryPlayerRestrained(RestraintSet) {
 		NurseryPlayerNeedsPunishing(2);
 	}
 	if (RestraintSet == 4) {
-		if (!Player.IsRestrained()) {	
+		if (!Player.IsRestrained()) {
 			InventoryWear(Player, "AdultBabyHarness", "ItemTorso", "Default");
 			InventoryWear(Player, "MittenChain1", "ItemArms", "Default");
 			InventoryWear(Player, "PaddedMittens", "ItemHands", "Default");
@@ -333,11 +333,11 @@ function NurseryPlayerRestrained(RestraintSet) {
 		}
 	}
 	if (RestraintSet == 5) {
-		NurseryPlayerRestrained(3)
+		NurseryPlayerRestrained(3);
 		InventoryWear(Player, "LeatherBlindfold", "ItemHead", "#cccccc");
 	}
 	if (RestraintSet == 6) {
-		NurseryPlayerRestrained(3)
+		NurseryPlayerRestrained(3);
 		CharacterSetActivePose(Player, "Kneel", true);
 		InventoryWear(Player, "LeatherBelt", "ItemLegs", "#cccccc");
 		NurseryPlayerNeedsPunishing(2);
@@ -415,7 +415,7 @@ function NurseryPlayerChangeDressColor() {
 
 // Player changes dress
 function NurseryPlayerRemoveDress() {
-	InventoryRemove(Player, "Cloth")
+	InventoryRemove(Player, "Cloth");
 }
 
 // Player gives an adorable ABDL reply
@@ -424,10 +424,10 @@ function NurseryPlayerCuteRelpy() {
 	DialogRemove();
 }
 
-// Player can try to escape the nursery as an ABDL 
+// Player can try to escape the nursery as an ABDL
 function NurseryEscapeGate() {
 	if (NurseryLeaveMsg == 1 || NurseryLeaveMsg == 3) {
-		NurserySituation = "Admitted"
+		NurserySituation = "Admitted";
 		CommonSetScreen("Room", "MainHall");
 	} else {
 		// Calculate Escape score
@@ -435,10 +435,10 @@ function NurseryEscapeGate() {
 		RandomNumber = Math.floor(Math.random() * 10);
 
 		// Escape attempts effect
-		RandomNumber = RandomNumber + NurseryEscapeAttempts
+		RandomNumber = RandomNumber + NurseryEscapeAttempts;
 
 		// Evasion skill effect
-		RandomNumber = RandomNumber - SkillGetLevel(Player, "Evasion")
+		RandomNumber = RandomNumber - SkillGetLevel(Player, "Evasion");
 
 		// level of bondage effects
 		if (InventoryGet(Player, "ItemHead") != null) RandomNumber = RandomNumber + 6;
@@ -459,7 +459,7 @@ function NurseryEscapeGate() {
 		if (InventoryGet(Player, "ItemArms") == "PaddedMittensHarness") RandomNumber = RandomNumber + 2;
 		if (InventoryGet(Player, "ItemArms") == "PaddedMittensHarnessLocked") RandomNumber = RandomNumber + 2;
 		if (InventoryGet(Player, "ItemArms") == "LeatherArmbinder") RandomNumber = RandomNumber + 6;
-		
+
 		// Work out escape result
 		if (RandomNumber <= 2) {										// Player manages to open gate
 			NurseryLeaveMsg = 3;

--- a/BondageClub/Screens/Room/Pandora/Pandora.js
+++ b/BondageClub/Screens/Room/Pandora/Pandora.js
@@ -21,14 +21,14 @@ var PandoraMaxWillpower = 20;
  * NPC Dialog functions
  * @returns {boolean} - TRUE if the dialog option will be available to the player
  */
-function PandoraCanStartRecruit() { return ((CurrentCharacter.Recruit == null) || (CurrentCharacter.Recruit == 0)) }
-function PandoraCanRecruit() { return (CurrentCharacter.Recruit + (InfiltrationPerksActive("Recruiter") ? 0.25 : 0) >= CurrentCharacter.RecruitOdds) }
-function PandoraCharacterCanJoin() { return ((PandoraParty.length == 0) || (PandoraParty[0].Name != CurrentCharacter.Name)) }
-function PandoraCharacterCanLeave() { return ((PandoraParty.length == 1) && (PandoraParty[0].Name == CurrentCharacter.Name) && ((PandoraCurrentRoom.Character == null) || (PandoraCurrentRoom.Character.length <= 1))) }
-function PandoraOdds75() { return ((CurrentCharacter.RandomOdds == null) || (CurrentCharacter.RandomOdds > 0.25)) }
-function PandoraOdds50() { return ((CurrentCharacter.RandomOdds == null) || (CurrentCharacter.RandomOdds > 0.50)) }
-function PandoraOdds25() { return ((CurrentCharacter.RandomOdds == null) || (CurrentCharacter.RandomOdds > 0.75)) }
-function PandoraCostumeIs(Costume) { return (PandoraClothes == Costume) }
+function PandoraCanStartRecruit() { return ((CurrentCharacter.Recruit == null) || (CurrentCharacter.Recruit == 0)); }
+function PandoraCanRecruit() { return (CurrentCharacter.Recruit + (InfiltrationPerksActive("Recruiter") ? 0.25 : 0) >= CurrentCharacter.RecruitOdds); }
+function PandoraCharacterCanJoin() { return ((PandoraParty.length == 0) || (PandoraParty[0].Name != CurrentCharacter.Name)); }
+function PandoraCharacterCanLeave() { return ((PandoraParty.length == 1) && (PandoraParty[0].Name == CurrentCharacter.Name) && ((PandoraCurrentRoom.Character == null) || (PandoraCurrentRoom.Character.length <= 1))); }
+function PandoraOdds75() { return ((CurrentCharacter.RandomOdds == null) || (CurrentCharacter.RandomOdds > 0.25)); }
+function PandoraOdds50() { return ((CurrentCharacter.RandomOdds == null) || (CurrentCharacter.RandomOdds > 0.50)); }
+function PandoraOdds25() { return ((CurrentCharacter.RandomOdds == null) || (CurrentCharacter.RandomOdds > 0.75)); }
+function PandoraCostumeIs(Costume) { return (PandoraClothes == Costume); }
 
 /**
  * Loads the Pandora's Box screen
@@ -86,7 +86,7 @@ function PandoraRun() {
 		DrawButton(1842, 850, 90, 90, "", PandoraDirectionButtonColor("South"), "Icons/South.png", TextGet("DirectionSouth"));
 		DrawButton(1900, 735, 90, 90, "", PandoraDirectionButtonColor("East"), "Icons/East.png", TextGet("DirectionEast"));
 	}
-	
+
 	// If we must draw a message in the middle of the screen
 	if ((PandoraMessage != null) && (PandoraMessage.Timer != null) && (PandoraMessage.Text != null) && (PandoraMessage.Timer >= CommonTime())) {
 		DrawRect(500, 465, 1000, 70, "black");
@@ -128,7 +128,7 @@ function PandoraClick() {
 		return;
 	}
 
-	// Checks if we clicked on a character	
+	// Checks if we clicked on a character
 	let Pos = 690 - (PandoraCurrentRoom.Character.length + PandoraParty.length) * 230;
 	if (MouseIn(Pos, 0, 500, 1000)) return CharacterSetCurrent(Player);
 	let AllowMove = true;
@@ -189,7 +189,7 @@ function PandoraMsgBox(Text) {
 
 /**
  * Generates a random NPC for Pandora's Box missions, clear the cache if it was generated before
- * @param {string} Group - The main group for that NPC (Random, Entrance, Underground) 
+ * @param {string} Group - The main group for that NPC (Random, Entrance, Underground)
  * @param {string} Type - The NPC function within Pandora's (Guard, Mistress, Slave, Maid, etc.)
  * @param {string} Name - The name to give to that NPC, can be RANDOM for a fully random name
  * @param {boolean} AllowItem - TRUE if we allow using items on her by default
@@ -277,7 +277,7 @@ function PandoraDress(C, Type) {
  * @returns {void} - Nothing
  */
 function PandoraEnterRoom(Room, Direction) {
-	
+
 	// Shoes the incoming direction for a little while
 	if ((Direction != null) && (Direction != "")) PandoraMoveDirectionTimer = { Direction: Direction, Timer: CommonTime() + 1500 };
 
@@ -329,7 +329,7 @@ function PandoraEnterRoom(Room, Direction) {
  * @returns {void} - Nothing
  */
 function PandoraGenerateRoom(EntryRoom, DirectionFrom, RoomLevel) {
-	
+
 	// Over 100, the dungeon layout is always invalid
 	if (PandoraRoom.length >= 100) return;
 
@@ -360,7 +360,7 @@ function PandoraGenerateRoom(EntryRoom, DirectionFrom, RoomLevel) {
 			RoomBack = "Cell";
 			let DeadEndOdds = (RoomLevel - InfiltrationDifficulty) * 0.2;
 			if (RoomLevel <= 2) DeadEndOdds = 0;
-			let TunnelOdds = 0.25 + (RoomLevel * 0.1);			
+			let TunnelOdds = 0.25 + (RoomLevel * 0.1);
 			if (TunnelOdds > 0.75) TunnelOdds = 0.75;
 			if (Math.random() >= DeadEndOdds) RoomBack = (Math.random() >= TunnelOdds) ? "Fork" : "Tunnel";
 			RoomBack = RoomBack + Math.floor(Math.random() * 6);
@@ -410,7 +410,7 @@ function PandoraGenerateRoom(EntryRoom, DirectionFrom, RoomLevel) {
  * @returns {void} - Nothing
  */
 function PandoraGenerateFloor(FloorName, EntryRoom, DirectionFrom, DirectionTo) {
-	
+
 	// Always create the same entrance room
 	let Room = {};
 	Room.Character = [];
@@ -425,7 +425,7 @@ function PandoraGenerateFloor(FloorName, EntryRoom, DirectionFrom, DirectionTo) 
 	PandoraRoom.push(Room);
 	EntryRoom.Path.push(Room);
 	EntryRoom.Direction.push(DirectionTo);
-	
+
 	// Starts the room generation
 	PandoraGenerateRoom(Room, DirectionFrom, 1);
 
@@ -436,7 +436,7 @@ function PandoraGenerateFloor(FloorName, EntryRoom, DirectionFrom, DirectionTo) 
  * @returns {void} - Nothing
  */
 function PandoraBuildMainHall() {
-	
+
 	// Creates the ground entrance room with a maid
 	PandoraParty = [];
 	let Room = {};
@@ -451,7 +451,7 @@ function PandoraBuildMainHall() {
 	Room.PathMap = [];
 	let ExitRoom = { Floor: "Exit" };
 	Room.DirectionMap = [];
-	
+
 	// Generates the floors and sets the starting room, there's a min-max number of rooms based on difficulty
 	let MinRoom = 15;
 	let MaxRoom = 24;
@@ -497,7 +497,7 @@ function PandoraBuildMainHall() {
 			PandoraTargetRoom = Room;
 		}
 	}
-	
+
 }
 
 /**
@@ -645,7 +645,7 @@ function PandoraInfiltrationChange(Progress) {
  * Checks if the player can bring the NPC to her private room
  * @returns {boolean} - Returns true if the player can
  */
-function PandoraCanJoinPrivateRoom() { return (LogQuery("RentRoom", "PrivateRoom") && (PrivateCharacter.length < PrivateCharacterMax) && !LogQuery("LockOutOfPrivateRoom", "Rule")) }
+function PandoraCanJoinPrivateRoom() { return (LogQuery("RentRoom", "PrivateRoom") && (PrivateCharacter.length < PrivateCharacterMax) && !LogQuery("LockOutOfPrivateRoom", "Rule")); }
 
 /**
  * When a random NPC joins the player private room, we add that character and exits the dialog
@@ -663,14 +663,14 @@ function PandoraCharacterJoinPrivateRoom() {
  * @param {string} Type - The mission type
  * @returns {boolean} - Returns TRUE if it's the current mission
  */
-function PandoraMissionIs(Type) { return (InfiltrationMission === Type) }
+function PandoraMissionIs(Type) { return (InfiltrationMission === Type); }
 
 /**
  * Checks if the perk specified is currently selected
  * @param {string} Type - The perk type
  * @returns {boolean} - Returns TRUE if it's selected
  */
-function PandoraHasPerk(Type) { return InfiltrationPerksActive(Type) }
+function PandoraHasPerk(Type) { return InfiltrationPerksActive(Type); }
 
 /**
  * Prepares an information text based on the bribe amount provided

--- a/BondageClub/Screens/Room/Photographic/Photographic.js
+++ b/BondageClub/Screens/Room/Photographic/Photographic.js
@@ -13,9 +13,9 @@ var PhotographicSelectText = "";
  * Checks if the player is helpless (maids disabled) or not.
  * @returns {boolean} - Returns true if the player still has time remaining after asking the maids to stop helping
  */
-function PhotographicIsMaidsDisabled() { var expire = LogValue("MaidsDisabled", "Maid") - CurrentTime ; return (expire > 0 ) }
+function PhotographicIsMaidsDisabled() { var expire = LogValue("MaidsDisabled", "Maid") - CurrentTime ; return (expire > 0 ); }
 
-function PhotographicPlayerCanChangeCloth() {return Player.CanChange() && !Player.IsRestrained()}
+function PhotographicPlayerCanChangeCloth() {return Player.CanChange() && !Player.IsRestrained();}
 function PhotographicPlayerHatAvailable() {return PhotographicAppearanceAvailable(Player, "Hat");}
 function PhotographicPlayerGlovesAvailable() {return PhotographicAppearanceAvailable(Player, "Gloves");}
 function PhotographicPlayerClothAvailable() {return PhotographicAppearanceAvailable(Player, "Cloth");}
@@ -25,7 +25,7 @@ function PhotographicPlayerSocksAvailable() {return (PhotographicAppearanceAvail
 function PhotographicPlayerBraAvailable() {return (PhotographicAppearanceAvailable(Player, "Bra")&&!PhotographicAppearanceAvailable(Player, "Cloth"));}
 function PhotographicPlayerPantiesAvailable() {return (PhotographicAppearanceAvailable(Player, "Panties")&&!PhotographicAppearanceAvailable(Player, "Cloth")&&!PhotographicAppearanceAvailable(Player, "ClothLower"));}
 
-function PhotographicSubIsRestrained() {return PhotographicSub.IsRestrained()}
+function PhotographicSubIsRestrained() {return PhotographicSub.IsRestrained();}
 function PhotographicSubHatAvailable() {return PhotographicAppearanceAvailable(PhotographicSub, "Hat");}
 function PhotographicSubGlovesAvailable() {return PhotographicAppearanceAvailable(PhotographicSub, "Gloves");}
 function PhotographicSubClothAvailable() {return PhotographicAppearanceAvailable(PhotographicSub, "Cloth");}
@@ -34,14 +34,14 @@ function PhotographicSubShoesAvailable() {return PhotographicAppearanceAvailable
 function PhotographicSubSocksAvailable() {return (PhotographicAppearanceAvailable(PhotographicSub, "Socks")&&!PhotographicAppearanceAvailable(PhotographicSub, "Shoes"));}
 function PhotographicSubBraAvailable() {return (PhotographicAppearanceAvailable(PhotographicSub, "Bra")&&!PhotographicAppearanceAvailable(PhotographicSub, "Cloth"));}
 function PhotographicSubPantiesAvailable() {return (PhotographicAppearanceAvailable(PhotographicSub, "Panties")&&!PhotographicAppearanceAvailable(PhotographicSub, "Cloth")&&!PhotographicAppearanceAvailable(PhotographicSub, "ClothLower"));}
-function PhotographicSubCanAskForPhoto() {return Player.CanTalk() && !PhotographicSub.IsRestrained()}
-function PhotographicSubCanWinkForPhoto() {return !Player.CanTalk() && !PhotographicSub.IsRestrained()}
+function PhotographicSubCanAskForPhoto() {return Player.CanTalk() && !PhotographicSub.IsRestrained();}
+function PhotographicSubCanWinkForPhoto() {return !Player.CanTalk() && !PhotographicSub.IsRestrained();}
 
-function PhotographicIsRestrainedWithLock() { return (Player.IsRestrained() && (InventoryCharacterHasLockedRestraint(Player))) }
-function PhotographicIsRestrainedWithoutLock() { return (Player.IsRestrained() && !InventoryCharacterHasLockedRestraint(Player)) }
-function PhotographicIsRestrainedWithLockAndMaidsNotDisabled() { return (Player.IsRestrained() && (InventoryCharacterHasLockedRestraint(Player)) && !PhotographicIsMaidsDisabled()) }
-function PhotographicIsRestrainedWithoutLockAndMaidsNotDisabled() { return (Player.IsRestrained() && !InventoryCharacterHasLockedRestraint(Player) && !PhotographicIsMaidsDisabled()) }
-function PhotographicIsMaidsDisabledAndRestrained() { return (Player.IsRestrained() && PhotographicIsMaidsDisabled() ) }
+function PhotographicIsRestrainedWithLock() { return (Player.IsRestrained() && (InventoryCharacterHasLockedRestraint(Player))); }
+function PhotographicIsRestrainedWithoutLock() { return (Player.IsRestrained() && !InventoryCharacterHasLockedRestraint(Player)); }
+function PhotographicIsRestrainedWithLockAndMaidsNotDisabled() { return (Player.IsRestrained() && (InventoryCharacterHasLockedRestraint(Player)) && !PhotographicIsMaidsDisabled()); }
+function PhotographicIsRestrainedWithoutLockAndMaidsNotDisabled() { return (Player.IsRestrained() && !InventoryCharacterHasLockedRestraint(Player) && !PhotographicIsMaidsDisabled()); }
+function PhotographicIsMaidsDisabledAndRestrained() { return (Player.IsRestrained() && PhotographicIsMaidsDisabled() ); }
 
 function PhotographicLoad() {
 	if (PhotographicSub == null) {
@@ -79,7 +79,7 @@ function PhotographicShotThePlayerPhoto() {
 }
 
 function PhotographicPlayerClothRemove(Group) {
-	InventoryRemove(Player, Group); 
+	InventoryRemove(Player, Group);
 }
 
 function PhotographicAppearanceAvailable(C, Group) {
@@ -94,7 +94,7 @@ function PhotographicAppearanceAvailable(C, Group) {
 function PhotographicPlayerAssetAvailable(Asset, Group) {
 	for (let I = Player.Inventory.length - 1; I > -1; I--)
 		if ((Player.Inventory[I].Name == Asset) && (Player.Inventory[I].Group == Group)) {return true;}
-	return false;	
+	return false;
 }
 
 function PhotographicPlayerRelease() {
@@ -129,7 +129,7 @@ function PhotographicSubSetPose(PoseName) {
 }
 
 function PhotographicSubClothRemove(Group) {
-	InventoryRemove(PhotographicSub, Group); 
+	InventoryRemove(PhotographicSub, Group);
 }
 
 function PhotographicStartInventoryPlayer(ItemGroup) {

--- a/BondageClub/Screens/Room/Prison/Prison.js
+++ b/BondageClub/Screens/Room/Prison/Prison.js
@@ -51,8 +51,8 @@ function PrisonSubIsHandcuffedOut() {return (PrisonSubSelfCuffed && !PrisonSubBe
 function PrisonSubIsBehindBars()    {return PrisonSubBehindBars;}
 function PrisonSubIsFree()          {return (!PrisonSubBehindBars && !PrisonSubSelfCuffed);}
 function PrisonSubAskForCuff()      {return (!PrisonSubAskedCuff);}
-function PrisonSubCanStripSearch()  {return  (!PrisonSubIsStripSearch && PrisonSubBehindBars)}
-function PrisonSubCanClothBack()    {return  (PrisonSubIsStripSearch && PrisonSubBehindBars)}
+function PrisonSubCanStripSearch()  {return  (!PrisonSubIsStripSearch && PrisonSubBehindBars);}
+function PrisonSubCanClothBack()    {return  (PrisonSubIsStripSearch && PrisonSubBehindBars);}
 
 /*      Room     */
 // Loads the Prison
@@ -74,7 +74,7 @@ function PrisonLoad() {
 	}
 	PrisonPlayerAppearance = Player.Appearance.slice();
 	PrisonNextEventTimer = new Date().getTime() + (20000 * Math.random()) + (10000);
-	
+
 	if ((MaidQuartersCurrentRescue == "Prison") && !MaidQuartersCurrentRescueStarted && !PrisonSubBehindBars && MaidQuartersCurrentRescueCompleted == false) {
 		PrisonSub = CharacterLoadNPC("NPC_Prison_Sub");
 	}
@@ -90,10 +90,10 @@ function PrisonLoad() {
 function PrisonRun() {
 	if (PrisonNextEventTimer == null) PrisonNextEventTimer = new Date().getTime() + (20000 * Math.random()) + (10000);
 	if (new Date().getTime() > PrisonNextEventTimer) {
-		PrisonNextEventTimer = new Date().getTime() + (20000 * Math.random()) + (10000)
+		PrisonNextEventTimer = new Date().getTime() + (20000 * Math.random()) + (10000);
 		PrisonNextEvent = true;
 	}
-	
+
 	if ((MaidQuartersCurrentRescue == "Prison") && MaidQuartersCurrentRescueCompleted == false) {
 		//Player is Maid and NPC is Visitor
 		if (!PrisonSubBehindBars) {
@@ -146,9 +146,9 @@ function PrisonRun() {
 		} else if (PrisonNextEvent == true) {
 			PrisonNextEvent = false;
 		}
-		
+
 	} else {
-		//Player is Vistor an Maid is NPC 
+		//Player is Vistor an Maid is NPC
 		if (PrisonPlayerBehindBars) {
 			DrawCharacter(Player, 500, 50, 0.95);
 			DrawImage("Screens/Room/Prison/Cage_close.png", 0, 0);
@@ -197,7 +197,7 @@ function PrisonClick() {
 		} else if (PrisonPlayerBehindBars) {
 			CharacterSetCurrent(Player);
 			Player.CurrentDialog = TextGet("LockKey");
-		} 
+		}
 	}
 	if ((MouseX >= 1885) && (MouseX < 1975) && (MouseY >= 145) && (MouseY < 235)) InformationSheetLoadCharacter(Player);
 }
@@ -274,11 +274,11 @@ function PrisonCellRelease(C) {
 function PrisonHavySearch(C) {
 	if (!PrisonPlayerIsStriped()) {
 		PrisonMaidIsAngry = true;
-		InventoryRemove(C, "Hat"); 
-		InventoryRemove(C, "Shoes"); 
-		InventoryRemove(C, "Gloves"); 
-		InventoryRemove(C, "Cloth"); 
-		InventoryRemove(C, "ClothLower"); 
+		InventoryRemove(C, "Hat");
+		InventoryRemove(C, "Shoes");
+		InventoryRemove(C, "Gloves");
+		InventoryRemove(C, "Cloth");
+		InventoryRemove(C, "ClothLower");
 		InventoryWear(C, "MetalCuffs", "ItemArms");
 		InventoryWear(C, "LeatherBelt", "ItemLegs");
 		InventoryWear(C, "LeatherBelt", "ItemFeet");
@@ -339,7 +339,7 @@ function PrisonerClothBack(C) {
 	}
 }
 
-// Remove the Letherbelts from the Prisoner 
+// Remove the Letherbelts from the Prisoner
 function PrisonCuffsRelief() {
 	PrisonMaidIsAngry = true;
 	if (PrisonPlayerIsPanelGag() || PrisonPlayerIsLegTied() || PrisonPlayerIsFeetTied()) {
@@ -375,7 +375,7 @@ function PrisonMaidLightTorture() {
 function PrisonMaidHevyTorture() {
 	PrisonMaidIsAngry = true;
 	PrisonMaid.Stage = "PrisonerTortured";
-	var torture = Math.random() * 5
+	var torture = Math.random() * 5;
 	if (torture < 1) {
 		PrisonMaid.CurrentDialog = DialogFind(PrisonMaid, "PrisonMaidTortureWhipping");
 	} else if (torture < 2) {
@@ -457,7 +457,7 @@ function PrisonCellPlayerWimper() {
 	} else if (PrisonMaidCharacter == "Neutral" || (PrisonMaidCharacter == "Chaotic" && PrisonMaidChaotic < 0.66)) {
 		PrisonCellRelease(Player);
 	} else {
-		PrisonMaidHevyTorture();	
+		PrisonMaidHevyTorture();
 	}
 }
 
@@ -500,11 +500,11 @@ function PrisonCellSubIn() {
 
 //Strip Search the NPC
 function PrisonSubHavySearch() {
-	InventoryRemove(PrisonSub, "Hat"); 
-	InventoryRemove(PrisonSub, "Shoes"); 
-	InventoryRemove(PrisonSub, "Gloves"); 
-	InventoryRemove(PrisonSub, "Cloth"); 
-	InventoryRemove(PrisonSub, "ClothLower"); 
+	InventoryRemove(PrisonSub, "Hat");
+	InventoryRemove(PrisonSub, "Shoes");
+	InventoryRemove(PrisonSub, "Gloves");
+	InventoryRemove(PrisonSub, "Cloth");
+	InventoryRemove(PrisonSub, "ClothLower");
 	InventoryWear(PrisonSub, "MetalCuffs", "ItemArms");
 	InventoryWear(PrisonSub, "LeatherBelt", "ItemLegs");
 	InventoryWear(PrisonSub, "LeatherBelt", "ItemFeet");
@@ -809,9 +809,9 @@ function PrisonArrestConfiscatSpankingToys() {
 	PrisonSetBehavior(-1);
 	PrisonArrestEquipmentSearch();
 }
-	
+
 function PrisonArrestLeave() {
-	DialogLeave()
+	DialogLeave();
 	PrisonPlayerCatchedBadGirl = false;
 	PrisonPoliceIsPresent = false;
 	PrisonMaid.Stage = "20";

--- a/BondageClub/Screens/Room/Private/Private.js
+++ b/BondageClub/Screens/Room/Private/Private.js
@@ -25,162 +25,162 @@ var PrivateBeltList = ["LeatherChastityBelt", "SleekLeatherChastityBelt", "Studd
  * Checks if the player is caged.
  * @returns {boolean} - TRUE if the player is in the cage.
  */
-function PrivateIsCaged() { return (CurrentCharacter.Cage == null) ? false : true }
+function PrivateIsCaged() { return (CurrentCharacter.Cage == null) ? false : true; }
 /**
  * Checks if the player can get the second private room expansion.
  * @returns {boolean} - TRUE if the player has the first private room expansion, but not the second.
  */
-function PrivateCanGetSecondExtension() { return (LogQuery("Expansion", "PrivateRoom") && !LogQuery("SecondExpansion", "PrivateRoom")) }
+function PrivateCanGetSecondExtension() { return (LogQuery("Expansion", "PrivateRoom") && !LogQuery("SecondExpansion", "PrivateRoom")); }
 /**
  * Checks if the player can play with the private room vendor.
  * @returns {boolean} - TRUE if the player has every upgrade and both characters can interact.
  */
-function PrivateVendorCanPlay() { return (LogQuery("RentRoom", "PrivateRoom") && LogQuery("Wardrobe", "PrivateRoom") && LogQuery("Cage", "PrivateRoom") && LogQuery("Expansion", "PrivateRoom") && Player.CanInteract() && PrivateVendor.CanInteract()) }
+function PrivateVendorCanPlay() { return (LogQuery("RentRoom", "PrivateRoom") && LogQuery("Wardrobe", "PrivateRoom") && LogQuery("Cage", "PrivateRoom") && LogQuery("Expansion", "PrivateRoom") && Player.CanInteract() && PrivateVendor.CanInteract()); }
 /**
  * Checks if the player can change her clothes.
  * @returns {boolean} - TRUE if the player is not restrained and is more dominant than the current character.
  */
-function PrivateAllowChange() { return (!CurrentCharacter.IsRestrained() && (ReputationGet("Dominant") + 25 >= NPCTraitGet(CurrentCharacter, "Dominant"))) }
+function PrivateAllowChange() { return (!CurrentCharacter.IsRestrained() && (ReputationGet("Dominant") + 25 >= NPCTraitGet(CurrentCharacter, "Dominant"))); }
 /**
  * Checks if the player is not able to change.
  * @returns {boolean} - TRUE if the player is not restrained, but is not enough dominant to change.
  */
-function PrivateWontChange() { return (!CurrentCharacter.IsRestrained() && (ReputationGet("Dominant") + 25 < NPCTraitGet(CurrentCharacter, "Dominant"))) }
+function PrivateWontChange() { return (!CurrentCharacter.IsRestrained() && (ReputationGet("Dominant") + 25 < NPCTraitGet(CurrentCharacter, "Dominant"))); }
 /**
  * Checks if the current character is restrained.
  * @returns {boolean} - TRUE if the character is restrained.
  */
-function PrivateIsRestrained() { return (CurrentCharacter.IsRestrained()) }
+function PrivateIsRestrained() { return (CurrentCharacter.IsRestrained()); }
 /**
  * Checks if the current character can be restrained.
  * @returns {boolean} - TRUE if the character can be restrained.
  */
-function PrivateAllowRestain() { return (CurrentCharacter.AllowItem) }
+function PrivateAllowRestain() { return (CurrentCharacter.AllowItem); }
 /**
  * Checks if both characters in the current dialog can talk.
  * @returns {boolean} - TRUE if both characters are not under a gagging effect.
  */
-function PrivateNobodyGagged() { return (Player.CanTalk() && CurrentCharacter.CanTalk()) }
+function PrivateNobodyGagged() { return (Player.CanTalk() && CurrentCharacter.CanTalk()); }
 /**
  * Checks if the player can masturbate the current character.
  * @returns {boolean} - TRUE if the player is not restrained, the character is not vulva chaste and the character is naked.
  */
-function PrivateCanMasturbate() { return (CharacterIsNaked(CurrentCharacter) && !CurrentCharacter.IsVulvaChaste() && !Player.IsRestrained()) }
+function PrivateCanMasturbate() { return (CharacterIsNaked(CurrentCharacter) && !CurrentCharacter.IsVulvaChaste() && !Player.IsRestrained()); }
 /**
  * Checks if the player can fondle the current character's breasts.
  * @returns {boolean} - TRUE if the player is not restrained and the character is not breast chaste.
  */
-function PrivateCanFondle() { return (!CurrentCharacter.IsBreastChaste() && !Player.IsRestrained()) }
+function PrivateCanFondle() { return (!CurrentCharacter.IsBreastChaste() && !Player.IsRestrained()); }
 /**
  * Checks if the player can be restrained by the current character.
  * @returns {boolean} - TRUE if both characters are not restrained and the player is less dominant than the NPC.
  */
-function PrivateAllowRestrainPlayer() { return (!Player.IsRestrained() && !CurrentCharacter.IsRestrained() && (ReputationGet("Dominant") - 25 <= NPCTraitGet(CurrentCharacter, "Dominant"))) }
+function PrivateAllowRestrainPlayer() { return (!Player.IsRestrained() && !CurrentCharacter.IsRestrained() && (ReputationGet("Dominant") - 25 <= NPCTraitGet(CurrentCharacter, "Dominant"))); }
 /**
  * Checks if the player cannot be restrained by the current character.
  * @returns {boolean} - TRUE if both characters are not restrained, but the player is too dominant to be tied by the NPC.
  */
-function PrivateWontRestrainPlayer() { return (!Player.IsRestrained() && !CurrentCharacter.IsRestrained() && (ReputationGet("Dominant") - 25 > NPCTraitGet(CurrentCharacter, "Dominant"))) }
+function PrivateWontRestrainPlayer() { return (!Player.IsRestrained() && !CurrentCharacter.IsRestrained() && (ReputationGet("Dominant") - 25 > NPCTraitGet(CurrentCharacter, "Dominant"))); }
 /**
  * Checks if the player can be released by the current character.
  * @returns {boolean} - TRUE if the player is not wearing owner restraints, the player is restrained, the release timer is up or the character is owned by the player, the current character is free and the player's owner is not around.
  */
-function PrivateAllowReleasePlayer() { return (Player.IsRestrained() && !InventoryCharacterHasOwnerOnlyRestraint(Player) && CurrentCharacter.CanTalk() && CurrentCharacter.CanInteract() && ((CommonTime() > PrivateReleaseTimer) || CurrentCharacter.IsOwnedByPlayer()) && !PrivateOwnerInRoom()) }
+function PrivateAllowReleasePlayer() { return (Player.IsRestrained() && !InventoryCharacterHasOwnerOnlyRestraint(Player) && CurrentCharacter.CanTalk() && CurrentCharacter.CanInteract() && ((CommonTime() > PrivateReleaseTimer) || CurrentCharacter.IsOwnedByPlayer()) && !PrivateOwnerInRoom()); }
 /**
  * Checks if the player cannot be released by the current character due to time/character restrictions.
  * @returns {boolean} - TRUE if the player is restrained, but cannot be released due to the character not being owned by the player or the release timer not being expired yet.
  */
-function PrivateWontReleasePlayer() { return (Player.IsRestrained() && !InventoryCharacterHasOwnerOnlyRestraint(Player) && CurrentCharacter.CanTalk() && CurrentCharacter.CanInteract() && !((CommonTime() > PrivateReleaseTimer) || CurrentCharacter.IsOwnedByPlayer()) && !PrivateOwnerInRoom()) }
+function PrivateWontReleasePlayer() { return (Player.IsRestrained() && !InventoryCharacterHasOwnerOnlyRestraint(Player) && CurrentCharacter.CanTalk() && CurrentCharacter.CanInteract() && !((CommonTime() > PrivateReleaseTimer) || CurrentCharacter.IsOwnedByPlayer()) && !PrivateOwnerInRoom()); }
 /**
  * Checks if the player cannot be released by the current character due to her owner being around.
  * @returns {boolean} - TRUE if the player is restrained, but cannot be released due to her owner being in the room.
  */
-function PrivateWontReleasePlayerOwner() { return (Player.IsRestrained() && !InventoryCharacterHasOwnerOnlyRestraint(Player) && CurrentCharacter.CanTalk() && CurrentCharacter.CanInteract() && PrivateOwnerInRoom()) }
+function PrivateWontReleasePlayerOwner() { return (Player.IsRestrained() && !InventoryCharacterHasOwnerOnlyRestraint(Player) && CurrentCharacter.CanTalk() && CurrentCharacter.CanInteract() && PrivateOwnerInRoom()); }
 /**
  * Checks if the player cannot be released by the current character due to worn owner only restraint(s).
  * @returns {boolean} - TRUE if the player is restrained, but is wearing owner-only restraints.
  */
-function PrivateWontReleasePlayerOwnerOnly() { return (Player.IsRestrained() && InventoryCharacterHasOwnerOnlyRestraint(Player) && CurrentCharacter.CanTalk() && CurrentCharacter.CanInteract()) }
+function PrivateWontReleasePlayerOwnerOnly() { return (Player.IsRestrained() && InventoryCharacterHasOwnerOnlyRestraint(Player) && CurrentCharacter.CanTalk() && CurrentCharacter.CanInteract()); }
 /**
  * Checks if the NPC will kneel willingly while not gagged.
  * @returns {boolean} - TRUE if the player is more dominant than the NPC or if the player owns the NPC.
  */
-function PrivateWillKneel() { return (CurrentCharacter.CanKneel() && CurrentCharacter.CanTalk() && !CurrentCharacter.IsKneeling() && ((ReputationGet("Dominant") > NPCTraitGet(CurrentCharacter, "Dominant")) || CurrentCharacter.IsOwnedByPlayer())) }
+function PrivateWillKneel() { return (CurrentCharacter.CanKneel() && CurrentCharacter.CanTalk() && !CurrentCharacter.IsKneeling() && ((ReputationGet("Dominant") > NPCTraitGet(CurrentCharacter, "Dominant")) || CurrentCharacter.IsOwnedByPlayer())); }
 /**
  * Checks if the NPC will kneel willingly while gagged.
  * @returns {boolean} - TRUE if the player is more dominant than the NPC or if the player owns the NPC.
  */
-function PrivateWillKneelGagged() { return (CurrentCharacter.CanKneel() && !CurrentCharacter.CanTalk() && !CurrentCharacter.IsKneeling() && ((ReputationGet("Dominant") > NPCTraitGet(CurrentCharacter, "Dominant")) || CurrentCharacter.IsOwnedByPlayer())) }
+function PrivateWillKneelGagged() { return (CurrentCharacter.CanKneel() && !CurrentCharacter.CanTalk() && !CurrentCharacter.IsKneeling() && ((ReputationGet("Dominant") > NPCTraitGet(CurrentCharacter, "Dominant")) || CurrentCharacter.IsOwnedByPlayer())); }
 /**
  * Checks if the NPC will not kneel willingly.
  * @returns {boolean} - TRUE if the player is less dominant than the NPC and if the player does owns the NPC.
  */
-function PrivateWontKneel() { return (CurrentCharacter.CanKneel() && !CurrentCharacter.IsKneeling() && (ReputationGet("Dominant") <= NPCTraitGet(CurrentCharacter, "Dominant")) && !CurrentCharacter.IsOwnedByPlayer()) }
+function PrivateWontKneel() { return (CurrentCharacter.CanKneel() && !CurrentCharacter.IsKneeling() && (ReputationGet("Dominant") <= NPCTraitGet(CurrentCharacter, "Dominant")) && !CurrentCharacter.IsOwnedByPlayer()); }
 /**
  * Checks if the NPC cannot kneel.
  * @returns {boolean} - TRUE if the NPC cannot kneel.
  */
-function PrivateCannotKneel() { return (!CurrentCharacter.CanKneel() && !CurrentCharacter.IsKneeling()) }
+function PrivateCannotKneel() { return (!CurrentCharacter.CanKneel() && !CurrentCharacter.IsKneeling()); }
 /**
  * Checks if the NPC can stand.
  * @returns {boolean} - TRUE if the NPC can stand.
  */
-function PrivateCanStandUp() { return (CurrentCharacter.CanKneel() && CurrentCharacter.CanTalk() && CurrentCharacter.IsKneeling()) }
+function PrivateCanStandUp() { return (CurrentCharacter.CanKneel() && CurrentCharacter.CanTalk() && CurrentCharacter.IsKneeling()); }
 /**
  * Checks if the NPC can stand while gagged.
  * @returns {boolean} - TRUE if the NPC can stand.
  */
-function PrivateCanStandUpGagged() { return (CurrentCharacter.CanKneel() && !CurrentCharacter.CanTalk() && CurrentCharacter.IsKneeling()) }
+function PrivateCanStandUpGagged() { return (CurrentCharacter.CanKneel() && !CurrentCharacter.CanTalk() && CurrentCharacter.IsKneeling()); }
 /**
  * Checks if the NPC cannot stand up.
  * @returns {boolean} - TRUE if the NPC is not able to stand.
  */
-function PrivateCannotStandUp() { return (!CurrentCharacter.CanKneel() && CurrentCharacter.IsKneeling()) }
+function PrivateCannotStandUp() { return (!CurrentCharacter.CanKneel() && CurrentCharacter.IsKneeling()); }
 /**
  * Checks if the character would take the player as a sub.
  * @returns {boolean} - TRUE if the character is willing to own the player.
  */
-function PrivateWouldTakePlayerAsSub() { return (!PrivatePlayerIsOwned() && !PrivateIsCaged() && !CurrentCharacter.IsKneeling() && !CurrentCharacter.IsRestrained() && (NPCTraitGet(CurrentCharacter, "Dominant") >= -50) && (CurrentCharacter.Love >= 50) && (ReputationGet("Dominant") + 50 <= NPCTraitGet(CurrentCharacter, "Dominant")) && (CurrentTime >= CheatFactor("SkipTrialPeriod", 0) * NPCEventGet(CurrentCharacter, "PrivateRoomEntry") + NPCLongEventDelay(CurrentCharacter))) }
+function PrivateWouldTakePlayerAsSub() { return (!PrivatePlayerIsOwned() && !PrivateIsCaged() && !CurrentCharacter.IsKneeling() && !CurrentCharacter.IsRestrained() && (NPCTraitGet(CurrentCharacter, "Dominant") >= -50) && (CurrentCharacter.Love >= 50) && (ReputationGet("Dominant") + 50 <= NPCTraitGet(CurrentCharacter, "Dominant")) && (CurrentTime >= CheatFactor("SkipTrialPeriod", 0) * NPCEventGet(CurrentCharacter, "PrivateRoomEntry") + NPCLongEventDelay(CurrentCharacter))); }
 /**
  * Checks if the character will not take the player as a sub.
  * @returns {boolean} - TRUE if the character is not willing to own the player.
  */
-function PrivateWontTakePlayerAsSub() { return (!PrivatePlayerIsOwned() && !PrivateIsCaged() && !CurrentCharacter.IsKneeling() && !CurrentCharacter.IsRestrained() && (NPCTraitGet(CurrentCharacter, "Dominant") >= -50) && ((ReputationGet("Dominant") + 50 > NPCTraitGet(CurrentCharacter, "Dominant")) || (CurrentCharacter.Love < 50))) }
+function PrivateWontTakePlayerAsSub() { return (!PrivatePlayerIsOwned() && !PrivateIsCaged() && !CurrentCharacter.IsKneeling() && !CurrentCharacter.IsRestrained() && (NPCTraitGet(CurrentCharacter, "Dominant") >= -50) && ((ReputationGet("Dominant") + 50 > NPCTraitGet(CurrentCharacter, "Dominant")) || (CurrentCharacter.Love < 50))); }
 /**
  * Checks if the character would take the player has a sub, but the wait time is not over.
  * @returns {boolean} - TRUE if some time is still needed before the NPC can own the player.
  */
-function PrivateNeedTimeToTakePlayerAsSub() { return (!PrivatePlayerIsOwned() && !PrivateIsCaged() && !CurrentCharacter.IsKneeling() && !CurrentCharacter.IsRestrained() && (NPCTraitGet(CurrentCharacter, "Dominant") >= -50) && (CurrentCharacter.Love >= 50) && (ReputationGet("Dominant") + 50 <= NPCTraitGet(CurrentCharacter, "Dominant")) && (CurrentTime < CheatFactor("SkipTrialPeriod", 0) * NPCEventGet(CurrentCharacter, "PrivateRoomEntry") + NPCLongEventDelay(CurrentCharacter))) }
+function PrivateNeedTimeToTakePlayerAsSub() { return (!PrivatePlayerIsOwned() && !PrivateIsCaged() && !CurrentCharacter.IsKneeling() && !CurrentCharacter.IsRestrained() && (NPCTraitGet(CurrentCharacter, "Dominant") >= -50) && (CurrentCharacter.Love >= 50) && (ReputationGet("Dominant") + 50 <= NPCTraitGet(CurrentCharacter, "Dominant")) && (CurrentTime < CheatFactor("SkipTrialPeriod", 0) * NPCEventGet(CurrentCharacter, "PrivateRoomEntry") + NPCLongEventDelay(CurrentCharacter))); }
 /**
  * Checks if the character would never own the player.
  * @returns {boolean} - TRUE if the character is too submissive to own the player.
  */
-function PrivateNeverTakePlayerAsSub() { return (NPCTraitGet(CurrentCharacter, "Dominant") < -50) }
+function PrivateNeverTakePlayerAsSub() { return (NPCTraitGet(CurrentCharacter, "Dominant") < -50); }
 /**
  * Checks if the character is currently on a trial.
  * @returns {boolean} - TRUE if the trial is in progress.
  */
-function PrivateTrialInProgress() { return ((Player.Owner == "") && (CurrentTime < CheatFactor("SkipTrialPeriod", 0) * NPCEventGet(CurrentCharacter, "EndSubTrial")) && (NPCEventGet(CurrentCharacter, "EndSubTrial") > 0)) }
+function PrivateTrialInProgress() { return ((Player.Owner == "") && (CurrentTime < CheatFactor("SkipTrialPeriod", 0) * NPCEventGet(CurrentCharacter, "EndSubTrial")) && (NPCEventGet(CurrentCharacter, "EndSubTrial") > 0)); }
 /**
  * Checks if the trial period is over and the character likes the player enough.
  * @returns {boolean} - TRUE if the trial period is over and the character loves the player enough.
  */
-function PrivateTrialDoneEnoughLove() { return ((Player.Owner == "") && (CurrentTime >= CheatFactor("SkipTrialPeriod", 0) * NPCEventGet(CurrentCharacter, "EndSubTrial")) && (NPCEventGet(CurrentCharacter, "EndSubTrial") > 0) && (CurrentCharacter.Love >= 90)) }
+function PrivateTrialDoneEnoughLove() { return ((Player.Owner == "") && (CurrentTime >= CheatFactor("SkipTrialPeriod", 0) * NPCEventGet(CurrentCharacter, "EndSubTrial")) && (NPCEventGet(CurrentCharacter, "EndSubTrial") > 0) && (CurrentCharacter.Love >= 90)); }
 /**
  * Checks if the trial period is over, but the character does not like the player enough.
  * @returns {boolean} - TRUE if the trial period is over, but the character does not like the player enough.
  */
-function PrivateTrialDoneNotEnoughLove() { return ((Player.Owner == "") && (CurrentTime >= CheatFactor("SkipTrialPeriod", 0) * NPCEventGet(CurrentCharacter, "EndSubTrial")) && (NPCEventGet(CurrentCharacter, "EndSubTrial") > 0) && (CurrentCharacter.Love < 90)) }
+function PrivateTrialDoneNotEnoughLove() { return ((Player.Owner == "") && (CurrentTime >= CheatFactor("SkipTrialPeriod", 0) * NPCEventGet(CurrentCharacter, "EndSubTrial")) && (NPCEventGet(CurrentCharacter, "EndSubTrial") > 0) && (CurrentCharacter.Love < 90)); }
 /**
  * Checks if the player can cancel an active trial with the current NPC.
  * @returns {boolean} - TRUE if the player can cancel the trial.
  */
-function PrivateTrialCanCancel() { return ((Player.Owner == "") && NPCEventGet(CurrentCharacter, "EndSubTrial") > 0) }
+function PrivateTrialCanCancel() { return ((Player.Owner == "") && NPCEventGet(CurrentCharacter, "EndSubTrial") > 0); }
 /**
  * Checks if the current NPC will forgive the player for refusing to play.
  * @returns {boolean} - TRUE if the NPC forgives the player.
  */
-function PrivateWillForgive() { return (NPCEventGet(CurrentCharacter, "RefusedActivity") < CurrentTime - 60000) }
+function PrivateWillForgive() { return (NPCEventGet(CurrentCharacter, "RefusedActivity") < CurrentTime - 60000); }
 /**
  * Checks if the player can ask to be uncollared.
  * @returns {boolean} - TRUE if the NPC will allow the player to be uncollared.
@@ -188,7 +188,7 @@ function PrivateWillForgive() { return (NPCEventGet(CurrentCharacter, "RefusedAc
 function PrivateCanAskUncollar() { return (DialogIsOwner() && (NPCEventGet(CurrentCharacter, "PlayerCollaring") > 0) && (CurrentTime >= CheatFactor("SkipTrialPeriod", 0) * NPCEventGet(CurrentCharacter, "PlayerCollaring") + NPCLongEventDelay(CurrentCharacter))); }
 /**
  * Checks if the player cannot ask to be uncollared.
- * @returns {boolean} - TRUE if the player cannot ask to be uncollared. 
+ * @returns {boolean} - TRUE if the player cannot ask to be uncollared.
  */
 function PrivateCannotAskUncollar() { return (DialogIsOwner() && (NPCEventGet(CurrentCharacter, "PlayerCollaring") > 0) && (CurrentTime < CheatFactor("SkipTrialPeriod", 0) * NPCEventGet(CurrentCharacter, "PlayerCollaring") + NPCLongEventDelay(CurrentCharacter))); }
 /**
@@ -200,127 +200,127 @@ function PrivateIsMistress() { return ((CurrentCharacter.Title != null) && (Curr
  * Checks if the NPC is willing to take the player as her owner.
  * @returns {boolean} - TRUE if the player can own the NPC
  */
-function PrivateWouldTakePlayerAsDom() { return (!Player.IsKneeling() && !Player.IsRestrained() && !CurrentCharacter.IsRestrained() && !CurrentCharacter.IsOwned() && (NPCTraitGet(CurrentCharacter, "Dominant") <= 50) && (CurrentCharacter.Love >= 50) && (ReputationGet("Dominant") - 50 >= NPCTraitGet(CurrentCharacter, "Dominant")) && (CurrentTime >= CheatFactor("SkipTrialPeriod", 0) * NPCEventGet(CurrentCharacter, "PrivateRoomEntry") + NPCLongEventDelay(CurrentCharacter))) }
+function PrivateWouldTakePlayerAsDom() { return (!Player.IsKneeling() && !Player.IsRestrained() && !CurrentCharacter.IsRestrained() && !CurrentCharacter.IsOwned() && (NPCTraitGet(CurrentCharacter, "Dominant") <= 50) && (CurrentCharacter.Love >= 50) && (ReputationGet("Dominant") - 50 >= NPCTraitGet(CurrentCharacter, "Dominant")) && (CurrentTime >= CheatFactor("SkipTrialPeriod", 0) * NPCEventGet(CurrentCharacter, "PrivateRoomEntry") + NPCLongEventDelay(CurrentCharacter))); }
 /**
  * Checks if the NPC is not willing to take the player as her owner
  * @returns {boolean} - TRUE if the player cannot own the NPC
  */
-function PrivateWontTakePlayerAsDom() { return (!Player.IsKneeling() && !Player.IsRestrained() && !CurrentCharacter.IsRestrained() && !CurrentCharacter.IsOwned() && (NPCTraitGet(CurrentCharacter, "Dominant") <= 50) && ((CurrentCharacter.Love < 50) || (ReputationGet("Dominant") - 50 < NPCTraitGet(CurrentCharacter, "Dominant")))) }
+function PrivateWontTakePlayerAsDom() { return (!Player.IsKneeling() && !Player.IsRestrained() && !CurrentCharacter.IsRestrained() && !CurrentCharacter.IsOwned() && (NPCTraitGet(CurrentCharacter, "Dominant") <= 50) && ((CurrentCharacter.Love < 50) || (ReputationGet("Dominant") - 50 < NPCTraitGet(CurrentCharacter, "Dominant")))); }
 /**
  * Checks if the NPC is willing to be own, but the waiting period is not over.
  * @returns {boolean} - TRUE if the NPC can be own, but more time is needed.
  */
-function PrivateNeedTimeToTakePlayerAsDom() { return (!Player.IsKneeling() && !Player.IsRestrained() && !CurrentCharacter.IsRestrained() && !CurrentCharacter.IsOwned() && (NPCTraitGet(CurrentCharacter, "Dominant") <= 50) && (CurrentCharacter.Love >= 50) && (ReputationGet("Dominant") - 50 >= NPCTraitGet(CurrentCharacter, "Dominant")) && (CurrentTime < CheatFactor("SkipTrialPeriod", 0) * NPCEventGet(CurrentCharacter, "PrivateRoomEntry") + NPCLongEventDelay(CurrentCharacter))) }
+function PrivateNeedTimeToTakePlayerAsDom() { return (!Player.IsKneeling() && !Player.IsRestrained() && !CurrentCharacter.IsRestrained() && !CurrentCharacter.IsOwned() && (NPCTraitGet(CurrentCharacter, "Dominant") <= 50) && (CurrentCharacter.Love >= 50) && (ReputationGet("Dominant") - 50 >= NPCTraitGet(CurrentCharacter, "Dominant")) && (CurrentTime < CheatFactor("SkipTrialPeriod", 0) * NPCEventGet(CurrentCharacter, "PrivateRoomEntry") + NPCLongEventDelay(CurrentCharacter))); }
 /**
  * Checks if the NPC would never take the player as an owner
  * @returns {boolean} - TRUE if the character has a dominant reputation above 50
  */
-function PrivateNeverTakePlayerAsDom() { return (!CurrentCharacter.IsRestrained() && NPCTraitGet(CurrentCharacter, "Dominant") > 50) }
+function PrivateNeverTakePlayerAsDom() { return (!CurrentCharacter.IsRestrained() && NPCTraitGet(CurrentCharacter, "Dominant") > 50); }
 /**
  * Checks if the NPC is happy.
  * @returns {boolean} - TRUE if the love value is above 30.
  */
-function PrivateIsHappy() { return (CurrentCharacter.Love > 30) }
+function PrivateIsHappy() { return (CurrentCharacter.Love > 30); }
 /**
  * Checks if the NPC is unhappy
  * @returns {boolean} - TRUE if the love value is below -30.
  */
-function PrivateIsUnhappy() { return (CurrentCharacter.Love < -30) }
+function PrivateIsUnhappy() { return (CurrentCharacter.Love < -30); }
 /**
  * Checks if the NPC is in a neutral mood.
  * @returns {boolean} - TRUE if the love value is between -30 and 30
  */
-function PrivateIsNeutral() { return ((CurrentCharacter.Love >= -30) && (CurrentCharacter.Love <= 30)) }
+function PrivateIsNeutral() { return ((CurrentCharacter.Love >= -30) && (CurrentCharacter.Love <= 30)); }
 /**
  * Checks if the lover NPC is happy.
  * @returns {boolean} - TRUE if the NPC is a lover and the love value is above 30
  */
-function PrivateIsLoverHappy() { return ((CurrentCharacter.Love > 30) && CurrentCharacter.IsLoverPrivate()) }
+function PrivateIsLoverHappy() { return ((CurrentCharacter.Love > 30) && CurrentCharacter.IsLoverPrivate()); }
 /**
  * Checks if the lover NPC is unhappy.
  * @returns {boolean} - TRUE if the NPC is a lover and the love value is below -30
  */
-function PrivateIsLoverUnhappy() { return ((CurrentCharacter.Love < -30) && CurrentCharacter.IsLoverPrivate()) }
+function PrivateIsLoverUnhappy() { return ((CurrentCharacter.Love < -30) && CurrentCharacter.IsLoverPrivate()); }
 /**
  * Checks if the lover NPC is in a neutral mood.
  * @returns {boolean} - TRUE if the NPC is a lover and the love value is between -30 and 30
  */
-function PrivateIsLoverNeutral() { return ((CurrentCharacter.Love >= -30) && (CurrentCharacter.Love <= 30) && CurrentCharacter.IsLoverPrivate()) }
+function PrivateIsLoverNeutral() { return ((CurrentCharacter.Love >= -30) && (CurrentCharacter.Love <= 30) && CurrentCharacter.IsLoverPrivate()); }
 /**
  * Checks if the sub trial for the NPC is over.
  * @returns {boolean} - TRUE if the trial period is over.
  */
-function PrivateSubTrialInProgress() { return ((NPCEventGet(CurrentCharacter, "EndDomTrial") > 0) && (CurrentTime < CheatFactor("SkipTrialPeriod", 0) * NPCEventGet(CurrentCharacter, "EndDomTrial"))) }
+function PrivateSubTrialInProgress() { return ((NPCEventGet(CurrentCharacter, "EndDomTrial") > 0) && (CurrentTime < CheatFactor("SkipTrialPeriod", 0) * NPCEventGet(CurrentCharacter, "EndDomTrial"))); }
 /**
  * Checks if the NPC is willing to be fully collared after the trial.
  * @returns {boolean} - TRUE if the NPC is willing to be fully collared after the trial.
  */
-function PrivateSubTrialOverWilling() { return ((NPCEventGet(CurrentCharacter, "EndDomTrial") > 0) && (CurrentTime >= CheatFactor("SkipTrialPeriod", 0) * NPCEventGet(CurrentCharacter, "EndDomTrial")) && (CurrentCharacter.Love >= 90)) }
+function PrivateSubTrialOverWilling() { return ((NPCEventGet(CurrentCharacter, "EndDomTrial") > 0) && (CurrentTime >= CheatFactor("SkipTrialPeriod", 0) * NPCEventGet(CurrentCharacter, "EndDomTrial")) && (CurrentCharacter.Love >= 90)); }
 /**
  * Checks if the NPC is not willing to be fully collared after the trial.
  * @returns {boolean} - TRUE if the NPC is not willing to be fully collared after the trial.
  */
-function PrivateSubTrialOverUnwilling() { return ((NPCEventGet(CurrentCharacter, "EndDomTrial") > 0) && (CurrentTime >= CheatFactor("SkipTrialPeriod", 0) * NPCEventGet(CurrentCharacter, "EndDomTrial")) && (CurrentCharacter.Love < 90)) }
+function PrivateSubTrialOverUnwilling() { return ((NPCEventGet(CurrentCharacter, "EndDomTrial") > 0) && (CurrentTime >= CheatFactor("SkipTrialPeriod", 0) * NPCEventGet(CurrentCharacter, "EndDomTrial")) && (CurrentCharacter.Love < 90)); }
 /**
  * Checks if the player can be pet by a NPC.
  * @returns {boolean} - TRUE if the player is restrained by a petsuit and the NPC is free.
  */
-function PrivateCanPet() { return ((CurrentCharacter.Love >= 0) && !CurrentCharacter.IsRestrained() && (InventoryGet(Player, "ItemArms") != null) && (InventoryGet(Player, "ItemArms").Asset.Name == "BitchSuit")) }
+function PrivateCanPet() { return ((CurrentCharacter.Love >= 0) && !CurrentCharacter.IsRestrained() && (InventoryGet(Player, "ItemArms") != null) && (InventoryGet(Player, "ItemArms").Asset.Name == "BitchSuit")); }
 /**
  * Checks if the player can sell her slave.
  * @returns {boolean} - TRUE if the player is free and the slave is not a bondage college NPC.
  */
-function PrivateCanSellSlave() { return (!Player.IsRestrained() && (CurrentCharacter.Love >= 0) && (CurrentCharacter.Name != "Amanda") && (CurrentCharacter.Name != "Sarah") && (CurrentCharacter.Name != "Sophie") && (CurrentCharacter.Name != "Jennifer") && (CurrentCharacter.Name != "Sidney") && (NPCEventGet(CurrentCharacter, "NPCCollaring") > 0)) }
+function PrivateCanSellSlave() { return (!Player.IsRestrained() && (CurrentCharacter.Love >= 0) && (CurrentCharacter.Name != "Amanda") && (CurrentCharacter.Name != "Sarah") && (CurrentCharacter.Name != "Sophie") && (CurrentCharacter.Name != "Jennifer") && (CurrentCharacter.Name != "Sidney") && (NPCEventGet(CurrentCharacter, "NPCCollaring") > 0)); }
 /**
  * Checks if the player cannot sell her slave.
  * @returns {boolean} - TRUE if the player is free and the slave is not a bondage college NPC, but the current love value is negative.
  */
-function PrivateCannotSellSlave() { return (!Player.IsRestrained() && (CurrentCharacter.Love < 0) && (CurrentCharacter.Name != "Amanda") && (CurrentCharacter.Name != "Sarah") && (CurrentCharacter.Name != "Sophie") && (CurrentCharacter.Name != "Jennifer") && (CurrentCharacter.Name != "Sidney") && (NPCEventGet(CurrentCharacter, "NPCCollaring") > 0)) }
+function PrivateCannotSellSlave() { return (!Player.IsRestrained() && (CurrentCharacter.Love < 0) && (CurrentCharacter.Name != "Amanda") && (CurrentCharacter.Name != "Sarah") && (CurrentCharacter.Name != "Sophie") && (CurrentCharacter.Name != "Jennifer") && (CurrentCharacter.Name != "Sidney") && (NPCEventGet(CurrentCharacter, "NPCCollaring") > 0)); }
 /**
  * Checks if the player can get the college outfit.
  * @returns {boolean} - TRUE if the player does not have the college outfit and the current NPC is a bondage college NPC.
  */
-function PrivateCanGetCollegeClothes() { return (!InventoryAvailable(Player, "CollegeOutfit1", "Cloth") && ((CurrentCharacter.Name == "Amanda") || (CurrentCharacter.Name == "Sarah") || (CurrentCharacter.Name == "Jennifer") || (CurrentCharacter.Name == "Sidney"))) }
+function PrivateCanGetCollegeClothes() { return (!InventoryAvailable(Player, "CollegeOutfit1", "Cloth") && ((CurrentCharacter.Name == "Amanda") || (CurrentCharacter.Name == "Sarah") || (CurrentCharacter.Name == "Jennifer") || (CurrentCharacter.Name == "Sidney"))); }
 /**
  * Checks if the current NPC is a lover of the player.
  * @returns {boolean} - TRUE if the NPC is a lover of the player.
  */
-function PrivateIsLover() { return CurrentCharacter.IsLoverPrivate() }
+function PrivateIsLover() { return CurrentCharacter.IsLoverPrivate(); }
 /**
  * Checks if the NPC will take the player as a lover.
  * @returns {boolean} - TRUE if the player can have one more lover, the NPC loves the player enough and the event delay has expired.
  */
-function PrivateWillTakePlayerAsLover() { return (((CurrentCharacter.Lover == null) || (CurrentCharacter.Lover == "")) && (Player.Lovership.length < 5) && (CurrentCharacter.Love >= 50) && (CurrentTime >= CheatFactor("SkipTrialPeriod", 0) * NPCEventGet(CurrentCharacter, "PrivateRoomEntry") + NPCLongLoverEventDelay(CurrentCharacter))) }
+function PrivateWillTakePlayerAsLover() { return (((CurrentCharacter.Lover == null) || (CurrentCharacter.Lover == "")) && (Player.Lovership.length < 5) && (CurrentCharacter.Love >= 50) && (CurrentTime >= CheatFactor("SkipTrialPeriod", 0) * NPCEventGet(CurrentCharacter, "PrivateRoomEntry") + NPCLongLoverEventDelay(CurrentCharacter))); }
 /**
  * Checks if the NPC will not take the player as a lover.
  * @returns {boolean} - TRUE if the player cannot have one more lover, the NPC does not love the player enough, or the event delay has not expired yet.
  */
-function PrivateWontTakePlayerAsLover() { return (((CurrentCharacter.Lover == null) || (CurrentCharacter.Lover == "")) && (Player.Lovership.length < 5) && ((CurrentCharacter.Love < 50) || (CurrentTime < CheatFactor("SkipTrialPeriod", 0) * NPCEventGet(CurrentCharacter, "PrivateRoomEntry") + NPCLongLoverEventDelay(CurrentCharacter)))) }
+function PrivateWontTakePlayerAsLover() { return (((CurrentCharacter.Lover == null) || (CurrentCharacter.Lover == "")) && (Player.Lovership.length < 5) && ((CurrentCharacter.Love < 50) || (CurrentTime < CheatFactor("SkipTrialPeriod", 0) * NPCEventGet(CurrentCharacter, "PrivateRoomEntry") + NPCLongLoverEventDelay(CurrentCharacter)))); }
 /**
  * Checks if the NPC will not take the player as a lover because she is already dating someone.
  * @returns {boolean} - TRUE if the NPC is already dating something.
  */
-function PrivateWontTakePlayerAsLoverAlreadyDating() { return ((CurrentCharacter.Lover != null) && (CurrentCharacter.Lover != "") && (CurrentCharacter.Lover != Player.Name) && (Player.Lovership.length < 5)) }
+function PrivateWontTakePlayerAsLoverAlreadyDating() { return ((CurrentCharacter.Lover != null) && (CurrentCharacter.Lover != "") && (CurrentCharacter.Lover != Player.Name) && (Player.Lovership.length < 5)); }
 /**
  * Checks if the NPC will not take the player as a lover because the player reached the lover limit.
  * @returns {boolean} - TRUE if the NPC is free, but the player has 5 lovers.
  */
-function PrivateWontTakePlayerAsLoverPlayerDating() { return (((CurrentCharacter.Lover == null) || (CurrentCharacter.Lover == "")) && (Player.Lovership.length >= 5)) }
+function PrivateWontTakePlayerAsLoverPlayerDating() { return (((CurrentCharacter.Lover == null) || (CurrentCharacter.Lover == "")) && (Player.Lovership.length >= 5)); }
 /**
  * Checks if it's possible for the player to turn the tables against her NPC owner
  * @returns {boolean} - TRUE if turning the tables is possible
  */
-function PrivatePlayerCanTurnTables() { return (!Player.IsRestrained() && (ReputationGet("Dominant") - 50 >= NPCTraitGet(CurrentCharacter, "Dominant")) && (NPCEventGet(CurrentCharacter, "PlayerCollaring") > 0)) }
+function PrivatePlayerCanTurnTables() { return (!Player.IsRestrained() && (ReputationGet("Dominant") - 50 >= NPCTraitGet(CurrentCharacter, "Dominant")) && (NPCEventGet(CurrentCharacter, "PlayerCollaring") > 0)); }
 /**
  * Checks if it's possible for the submissive to turn the tables against her player owner
  * @returns {boolean} - TRUE if turning the tables is possible
  */
-function PrivateSubCanTurnTables() { return (!Player.IsRestrained() && !CurrentCharacter.IsRestrained() && !Player.IsOwned() && !PrivateOwnerInRoom() && (ReputationGet("Dominant") + 50 <= NPCTraitGet(CurrentCharacter, "Dominant")) && (NPCEventGet(CurrentCharacter, "NPCCollaring") > 0)) }
+function PrivateSubCanTurnTables() { return (!Player.IsRestrained() && !CurrentCharacter.IsRestrained() && !Player.IsOwned() && !PrivateOwnerInRoom() && (ReputationGet("Dominant") + 50 <= NPCTraitGet(CurrentCharacter, "Dominant")) && (NPCEventGet(CurrentCharacter, "NPCCollaring") > 0)); }
 /**
  * Checks if it's possible to use cheats on an NPC
  * @returns {boolean} - TRUE if we allow NPC cheats
  */
-function PrivateNPCAllowCheat() { return (CheatFactor("ChangeNPCTrait", 0) == 0) }
+function PrivateNPCAllowCheat() { return (CheatFactor("ChangeNPCTrait", 0) == 0); }
 
 /**
  * Loads the private room screen and the vendor NPC.
@@ -368,7 +368,7 @@ function PrivateDrawCharacter() {
 
 			// If the character is sent to the asylum, she won't show in the room but her slot is still taken
 			if (NPCEventGet(PrivateCharacter[C], "AsylumSent") <= CurrentTime) {
-		
+
 				// Draw the NPC and the cage if needed
 				if (PrivateCharacter[C].Cage != null) DrawImage("Screens/Room/Private/CageBack.png", X + (C - PrivateCharacterOffset) * 470, 0);
 				DrawCharacter(PrivateCharacter[C], X + (C - PrivateCharacterOffset) * 470, 0, 1);
@@ -457,14 +457,14 @@ function PrivateRun() {
  * @returns {void} - Nothing.
  */
 function PrivateClickCharacterButton() {
-	
+
 	// Defines the character position in the private screen
 	var X = 1000 - ((PrivateCharacter.length - PrivateCharacterOffset) * 250);
 	if (X < 0) X = 0;
 
 	// For each character, we check if the player clicked on the cage or information button
 	for (let C = PrivateCharacterOffset; (C < PrivateCharacter.length && C < PrivateCharacterOffset + 4); C++) {
-		
+
 		// The information sheet button is always available
 		if ((MouseX >= X + 85 + (C - PrivateCharacterOffset) * 470) && (MouseX <= X + 175 + (C - PrivateCharacterOffset) * 470))
 			InformationSheetLoadCharacter(PrivateCharacter[C]);
@@ -620,9 +620,9 @@ function PrivateClick() {
 			PrivateBackground = Name;
 			ServerSend("AccountUpdate", { VisualSettings: Player.VisualSettings });
 		});
-		
+
 	}
-	
+
 	if ((MouseX <= 1885) && (MouseY < 900) && LogQuery("RentRoom", "PrivateRoom") && (Player.Cage == null)) PrivateClickCharacter();
 	if ((MouseX <= 1885) && (MouseY >= 900) && LogQuery("RentRoom", "PrivateRoom")) PrivateClickCharacterButton();
 
@@ -692,11 +692,11 @@ function PrivateLoadCharacter(C) {
 		if (PrivateCharacter[C].Title != null) N.Title = PrivateCharacter[C].Title;
 		if (PrivateCharacter[C].AssetFamily != null) N.AssetFamily = PrivateCharacter[C].AssetFamily;
 		if (PrivateCharacter[C].Appearance != null) {
-			const updateValid = ServerAppearanceLoadFromBundle(N, PrivateCharacter[C].AssetFamily, PrivateCharacter[C].Appearance)
+			const updateValid = ServerAppearanceLoadFromBundle(N, PrivateCharacter[C].AssetFamily, PrivateCharacter[C].Appearance);
 			updateRequired = updateRequired || !updateValid;
 		}
 		if (PrivateCharacter[C].AppearanceFull != null) {
-			const updateValid = ServerAppearanceLoadFromBundle(N, PrivateCharacter[C].AssetFamily, PrivateCharacter[C].AppearanceFull, null, true)
+			const updateValid = ServerAppearanceLoadFromBundle(N, PrivateCharacter[C].AssetFamily, PrivateCharacter[C].AppearanceFull, null, true);
 			updateRequired = updateRequired || !updateValid;
 		}
 		if (PrivateCharacter[C].Trait != null) N.Trait = PrivateCharacter[C].Trait.slice();
@@ -726,7 +726,7 @@ function PrivateLoadCharacter(C) {
 
 /**
  * Triggered when a new character is added to the player's private room.
- * @param {object} Template - The base of the character, includes the name and appearance. 
+ * @param {object} Template - The base of the character, includes the name and appearance.
  * @param {string} Archetype - The type of character such as maid or mistress.
  * @param {boolean} CustomData - Whether or not the character has non-random traits.
  * @returns {void} - Nothing.
@@ -771,7 +771,7 @@ function PrivateKickOut() {
 	PrivateCharacter.splice(ID, 1);
 	ServerPrivateCharacterSync();
 	for (let P = 1; P < PrivateCharacter.length; P++)
-		if (PrivateCharacter[P] != null) 
+		if (PrivateCharacter[P] != null)
 			PrivateCharacter[P].AccountName = "NPC_Private_Custom" + P.toString();
 	DialogLeave();
 }
@@ -858,7 +858,7 @@ function PrivateRelationDecay() {
 
 /**
  * Triggered when the player starts a submissive trial with an NPC
- * @param {number} ChangeRep - Amount of dominant reputation to lose. 
+ * @param {number} ChangeRep - Amount of dominant reputation to lose.
  * @returns {void} - Nothing.
  */
 function PrivateStartTrial(ChangeRep) {
@@ -871,7 +871,7 @@ function PrivateStartTrial(ChangeRep) {
 
 /**
  * Triggered when the player stops a submissive trial with an NPC
- * @param {number} ChangeRep - Amount of dominant reputation to gain/lose. 
+ * @param {number} ChangeRep - Amount of dominant reputation to gain/lose.
  * @returns {void} - Nothing.
  */
 function PrivateStopTrial(ChangeRep) {
@@ -896,7 +896,7 @@ function PrivateShowTrialHours() {
 function PrivatePlayerIsOwned() {
 	if (Player.Owner != "") return true;
 	for (let C = 0; C < PrivateCharacter.length; C++)
-		if (typeof PrivateCharacter[C].IsOwner === 'function') 
+		if (typeof PrivateCharacter[C].IsOwner === 'function')
 			if (PrivateCharacter[C].IsOwner())
 				return true;
 	return false;
@@ -1087,7 +1087,7 @@ function PrivateBlockChange(Minutes) {
  * @returns {void} - Nothing.
  */
 function PrivateSelectPunishment() {
-	
+
 	// Release the player first
 	if (Player.IsRestrained() || !Player.CanTalk()) {
 		CharacterRelease(Player);
@@ -1103,7 +1103,7 @@ function PrivateSelectPunishment() {
 		CurrentCharacter.CurrentDialog = DialogFind(CurrentCharacter, "PunishStripBeforeIntro");
 		return;
 	}
-	
+
 	// Finds a valid punishment for the player
 	while (true) {
 
@@ -1412,7 +1412,7 @@ function PrivateSubTurnTablesStart() {
  * @returns {void} - Nothing.
  */
 function PrivateSubTurnTablesDone() {
-	
+
 	// Clears the submissive ownership
 	NPCEventDelete(CurrentCharacter, "EndSubTrial");
 	NPCEventDelete(CurrentCharacter, "NPCCollaring");

--- a/BondageClub/Screens/Room/Sarah/Sarah.js
+++ b/BondageClub/Screens/Room/Sarah/Sarah.js
@@ -19,42 +19,42 @@ var SophieOrgasmGameCount = 0;
 var SophieOrgasmGamePleasure = 0;
 
 // Returns TRUE if a dialog condition matches
-function SarahStatusIs(QueryStatus) { return (QueryStatus == SarahStatus) }
-function SarahAmandaStatusIs(QueryStatus) { return (QueryStatus == AmandaStatus) }
-function SarahCanKissLover() { return (Player.CanTalk() && Sarah.CanTalk() && (Player.Lover == "NPC-Sarah")) }
-function SarahCanKissNotLover() { return (Player.CanTalk() && Sarah.CanTalk() && (Player.Lover != "NPC-Sarah")) }
-function SarahCanSpankOwner() { return (Player.CanInteract() && (Sarah.Owner == Player.Name)) }
-function SarahCanSpankNotOwner() { return (Player.CanInteract() && (Sarah.Owner != Player.Name)) }
-function SarahCanReleaseToClub() { return (!SophieInside && !DialogIsRestrained("CurrentCharacter")) }
-function SarahCanInviteToRoomFriend() { return (Player.CanWalk() && Sarah.CanWalk() && !SophieInside && (Sarah.Owner != Player.Name) && (PrivateCharacter.length < PrivateCharacterMax) && LogQuery("RentRoom", "PrivateRoom") && !LogQuery("LockOutOfPrivateRoom", "Rule")) }
-function SarahCanInviteToRoomSlave() { return (Player.CanWalk() && Sarah.CanWalk() && !SophieInside && (Sarah.Owner == Player.Name) && (PrivateCharacter.length < PrivateCharacterMax) && LogQuery("RentRoom", "PrivateRoom") && !LogQuery("LockOutOfPrivateRoom", "Rule")) }
-function SarahCanInviteAmandaToRoom() { return (Player.CanWalk() && Amanda.CanWalk() && !SophieInside && (PrivateCharacter.length < PrivateCharacterMax) && (!SarahInside || (Amanda.Owner == Player.Name)) && LogQuery("RentRoom", "PrivateRoom") && !LogQuery("LockOutOfPrivateRoom", "Rule")) }
-function SarahCanInviteAmandaToRoomRefuse() { return (Player.CanWalk() && Amanda.CanWalk() && !SophieInside && (PrivateCharacter.length < PrivateCharacterMax) && SarahInside && (Amanda.Owner != Player.Name) && LogQuery("RentRoom", "PrivateRoom") && !LogQuery("LockOutOfPrivateRoom", "Rule")) }
-function SarahCanInviteSophieToRoom() { return (Player.CanWalk() && Sophie.CanWalk() && (PrivateCharacter.length < PrivateCharacterMax)) }
-function SarahCanInviteSophieToRoomAccept() { return (Player.CanWalk() && Sophie.CanWalk() && (PrivateCharacter.length < PrivateCharacterMax) && (SophieUpsetCount >= 0) && (SophieUpsetCount <= 2)) }
-function SarahCanInviteSophieToRoomRefuse() { return (Player.CanWalk() && Sophie.CanWalk() && (PrivateCharacter.length < PrivateCharacterMax) && ((SophieUpsetCount < 0) || (SophieUpsetCount > 2))) }
-function SarahCanKickAmandaOut() { return (Amanda.CanWalk() && (Player.Owner != "NPC-Amanda") && (!SarahInside || (Amanda.Owner == Player.Name))) }
-function SarahCanKickAmandaOutRefuse() { return (Amanda.CanWalk() && (Player.Owner != "NPC-Amanda") && SarahInside && (Amanda.Owner != Player.Name)) }
-function SarahShackled() { return (SarahInside && (Sarah != null) && (InventoryGet(Sarah, "ItemArms") != null) && (InventoryGet(Sarah, "ItemArms").Asset.Name == "FourLimbsShackles")) }
-function SarahAmandaHasStrapon() { return (Player.CanInteract() && AmandaInside && (Amanda != null) && (InventoryGet(Amanda, "ItemPelvis") != null) && (InventoryGet(Amanda, "ItemPelvis").Asset.Name == "StraponPanties")) }
-function SarahAmandaHasNoStrapon() { return (Player.CanInteract() && AmandaInside && (Amanda != null) && !Amanda.IsVulvaChaste()) }
-function SarahKnowAmandaInRoom() { return (SarahInside && AmandaInside && (Sarah != null) && (Amanda != null) && !Sarah.CanInteract() && (!Sarah.IsBlind() || Amanda.CanTalk())) }
-function SarahAmandaCanKiss() { return (AmandaInside && (Amanda != null) && Player.CanTalk() && Amanda.CanTalk() && (Player.Lover == "NPC-Amanda")) }
-function SarahIsClubSlave() { return ((InventoryGet(Player, "ItemNeck") != null) && (InventoryGet(Player, "ItemNeck").Asset.Name == "ClubSlaveCollar")) }
-function SarahCanKissSophie() { return (Player.CanTalk() && Sophie.CanTalk()) }
-function SarahCanFightSophie() { return (!SophieFightDone && Player.CanInteract()) }
-function SarahSophiePunishmentStageIs(Stage) { return (SophiePunishmentStage == parseInt(Stage)) }
-function SarahSophieLikesPlayer() { return ((SophieUpsetCount >= 0) && (SophieUpsetCount <= 2)) }
-function SarahCanStrip() { return (!Sarah.IsRestrained() && !Sarah.IsNaked()) }
+function SarahStatusIs(QueryStatus) { return (QueryStatus == SarahStatus); }
+function SarahAmandaStatusIs(QueryStatus) { return (QueryStatus == AmandaStatus); }
+function SarahCanKissLover() { return (Player.CanTalk() && Sarah.CanTalk() && (Player.Lover == "NPC-Sarah")); }
+function SarahCanKissNotLover() { return (Player.CanTalk() && Sarah.CanTalk() && (Player.Lover != "NPC-Sarah")); }
+function SarahCanSpankOwner() { return (Player.CanInteract() && (Sarah.Owner == Player.Name)); }
+function SarahCanSpankNotOwner() { return (Player.CanInteract() && (Sarah.Owner != Player.Name)); }
+function SarahCanReleaseToClub() { return (!SophieInside && !DialogIsRestrained("CurrentCharacter")); }
+function SarahCanInviteToRoomFriend() { return (Player.CanWalk() && Sarah.CanWalk() && !SophieInside && (Sarah.Owner != Player.Name) && (PrivateCharacter.length < PrivateCharacterMax) && LogQuery("RentRoom", "PrivateRoom") && !LogQuery("LockOutOfPrivateRoom", "Rule")); }
+function SarahCanInviteToRoomSlave() { return (Player.CanWalk() && Sarah.CanWalk() && !SophieInside && (Sarah.Owner == Player.Name) && (PrivateCharacter.length < PrivateCharacterMax) && LogQuery("RentRoom", "PrivateRoom") && !LogQuery("LockOutOfPrivateRoom", "Rule")); }
+function SarahCanInviteAmandaToRoom() { return (Player.CanWalk() && Amanda.CanWalk() && !SophieInside && (PrivateCharacter.length < PrivateCharacterMax) && (!SarahInside || (Amanda.Owner == Player.Name)) && LogQuery("RentRoom", "PrivateRoom") && !LogQuery("LockOutOfPrivateRoom", "Rule")); }
+function SarahCanInviteAmandaToRoomRefuse() { return (Player.CanWalk() && Amanda.CanWalk() && !SophieInside && (PrivateCharacter.length < PrivateCharacterMax) && SarahInside && (Amanda.Owner != Player.Name) && LogQuery("RentRoom", "PrivateRoom") && !LogQuery("LockOutOfPrivateRoom", "Rule")); }
+function SarahCanInviteSophieToRoom() { return (Player.CanWalk() && Sophie.CanWalk() && (PrivateCharacter.length < PrivateCharacterMax)); }
+function SarahCanInviteSophieToRoomAccept() { return (Player.CanWalk() && Sophie.CanWalk() && (PrivateCharacter.length < PrivateCharacterMax) && (SophieUpsetCount >= 0) && (SophieUpsetCount <= 2)); }
+function SarahCanInviteSophieToRoomRefuse() { return (Player.CanWalk() && Sophie.CanWalk() && (PrivateCharacter.length < PrivateCharacterMax) && ((SophieUpsetCount < 0) || (SophieUpsetCount > 2))); }
+function SarahCanKickAmandaOut() { return (Amanda.CanWalk() && (Player.Owner != "NPC-Amanda") && (!SarahInside || (Amanda.Owner == Player.Name))); }
+function SarahCanKickAmandaOutRefuse() { return (Amanda.CanWalk() && (Player.Owner != "NPC-Amanda") && SarahInside && (Amanda.Owner != Player.Name)); }
+function SarahShackled() { return (SarahInside && (Sarah != null) && (InventoryGet(Sarah, "ItemArms") != null) && (InventoryGet(Sarah, "ItemArms").Asset.Name == "FourLimbsShackles")); }
+function SarahAmandaHasStrapon() { return (Player.CanInteract() && AmandaInside && (Amanda != null) && (InventoryGet(Amanda, "ItemPelvis") != null) && (InventoryGet(Amanda, "ItemPelvis").Asset.Name == "StraponPanties")); }
+function SarahAmandaHasNoStrapon() { return (Player.CanInteract() && AmandaInside && (Amanda != null) && !Amanda.IsVulvaChaste()); }
+function SarahKnowAmandaInRoom() { return (SarahInside && AmandaInside && (Sarah != null) && (Amanda != null) && !Sarah.CanInteract() && (!Sarah.IsBlind() || Amanda.CanTalk())); }
+function SarahAmandaCanKiss() { return (AmandaInside && (Amanda != null) && Player.CanTalk() && Amanda.CanTalk() && (Player.Lover == "NPC-Amanda")); }
+function SarahIsClubSlave() { return ((InventoryGet(Player, "ItemNeck") != null) && (InventoryGet(Player, "ItemNeck").Asset.Name == "ClubSlaveCollar")); }
+function SarahCanKissSophie() { return (Player.CanTalk() && Sophie.CanTalk()); }
+function SarahCanFightSophie() { return (!SophieFightDone && Player.CanInteract()); }
+function SarahSophiePunishmentStageIs(Stage) { return (SophiePunishmentStage == parseInt(Stage)); }
+function SarahSophieLikesPlayer() { return ((SophieUpsetCount >= 0) && (SophieUpsetCount <= 2)); }
+function SarahCanStrip() { return (!Sarah.IsRestrained() && !Sarah.IsNaked()); }
 
 // Returns TRUE to know if the girls are inside the room
-function SarahIsInside() { return (SarahInside && (Sarah != null)) }
-function SarahAmandaIsInside() { return (AmandaInside && (Amanda != null)) }
-function SarahAndAmandaAreInside() { return (SarahIsInside() && SarahAmandaIsInside()) }
-function SarahOrAmandaAreInside() { return (SarahIsInside() || SarahAmandaIsInside()) }
-function SarahIsPlayerSlave() { return ((Sarah != null) && (Sarah.Owner == Player.Name)) }
-function SarahAmandaIsPlayerSlave() { return ((Amanda != null) && (Amanda.Owner == Player.Name)) }
-function SarahAmandaAndSarahArePlayerSlave() { return (SarahAmandaIsPlayerSlave() && SarahIsPlayerSlave()) }
+function SarahIsInside() { return (SarahInside && (Sarah != null)); }
+function SarahAmandaIsInside() { return (AmandaInside && (Amanda != null)); }
+function SarahAndAmandaAreInside() { return (SarahIsInside() && SarahAmandaIsInside()); }
+function SarahOrAmandaAreInside() { return (SarahIsInside() || SarahAmandaIsInside()); }
+function SarahIsPlayerSlave() { return ((Sarah != null) && (Sarah.Owner == Player.Name)); }
+function SarahAmandaIsPlayerSlave() { return ((Amanda != null) && (Amanda.Owner == Player.Name)); }
+function SarahAmandaAndSarahArePlayerSlave() { return (SarahAmandaIsPlayerSlave() && SarahIsPlayerSlave()); }
 
 // Returns the correct label for Sarah's room
 function SarahRoomLabel() {
@@ -67,7 +67,7 @@ function SarahRoomLabel() {
 
 // Sets Sarah and Amanda status
 function SarahSetStatus() {
-	
+
 	// Sarah status depends on Bondage College imported data
 	if (LogQuery("BondageCollege", "Import")) SarahStatus = "SchoolMate";
 	if (LogQuery("SarahLover", "NPC-Sarah") && (Player.Lover == "NPC-Sarah")) SarahStatus = "Lover";
@@ -76,7 +76,7 @@ function SarahSetStatus() {
 	if (LogQuery("SarahCollaredWithCurfew", "NPC-Sarah")) SarahStatus = "Curfew";
 	if (LogQuery("SarahWillBePunished", "NPC-SarahIntro")) SarahStatus = "WillBePunished";
 	if (LogQuery("SarahCameWithPlayer", "NPC-SarahIntro")) SarahStatus = "CameWithPlayer";
-	
+
 	// Amanda status depends on Bondage College imported data
 	if (LogQuery("BondageCollege", "Import")) AmandaStatus = "SchoolMate";
 	if (LogQuery("AmandaLover", "NPC-Amanda") && (Player.Lover == "NPC-Amanda")) AmandaStatus = "Lover";
@@ -85,7 +85,7 @@ function SarahSetStatus() {
 	if (LogQuery("AmandaCollaredWithCurfew", "NPC-Amanda")) AmandaStatus = "Curfew";
 	if (LogQuery("AmandaMistress", "NPC-Amanda") && (Player.Owner == "NPC-Amanda")) AmandaStatus = "Owner";
 	if (LogQuery("AmandaMistress", "NPC-Amanda") && (Player.Owner != "NPC-Amanda")) AmandaStatus = "ExOwner";
-	
+
 	// They are not accessible if they already are in the private room
 	for (let P = 1; P < PrivateCharacter.length; P++) {
 		if (PrivateCharacter[P].Name.trim() == "Sarah") { SarahStatus = "InPrivateRoom"; SarahInside = false; }
@@ -96,7 +96,7 @@ function SarahSetStatus() {
 
 // Loads the Sarah room
 function SarahLoad() {
-	
+
 	// Add the player if we need too
 	if (SarahCharacter.length == 0)
 		SarahCharacter.push(Player);
@@ -139,7 +139,7 @@ function SarahLoad() {
 			CharacterSetActivePose(Sarah, "Kneel", true);
 			AmandaIntroTime = CurrentTime + 400000;
 			SarahCharacter.push(Sarah);
-			
+
 		}
 	}
 
@@ -184,7 +184,7 @@ function SarahLoad() {
 		Sophie.Name = "Mistress Sophie";
 		Sophie.AllowItem = false;
 		CharacterNaked(Sophie);
-		InventoryRemove(Sophie, "Nipples");		
+		InventoryRemove(Sophie, "Nipples");
 		InventoryWear(Sophie, "Stockings4", "Socks", "#222222");
 		InventoryWear(Sophie, "Corset3", "Bra", "#222222");
 		InventoryWear(Sophie, "Panties13", "Panties", "#222222");
@@ -209,7 +209,7 @@ function SarahLoad() {
 
 // Loads the Amanda character
 function AmandaLoad() {
-	
+
 	// If we must show the intro scene
 	if (!AmandaIntroDone) {
 		if (CurrentCharacter != null) DialogLeave();
@@ -223,7 +223,7 @@ function AmandaLoad() {
 
 // Loads the Sophie character
 function SophieLoad() {
-	
+
 	// If we must show the intro scene
 	if (!SophieIntroDone) {
 		if (CurrentCharacter != null) DialogLeave();
@@ -237,7 +237,7 @@ function SophieLoad() {
 
 // Check to load new characters
 function SarahLoadNewCharacter() {
-	
+
 	// Amanda can be loaded if Sarah isn't there or after a while with Sarah.  She must not be in the player room.
 	if (!AmandaInside && (AmandaStatus != "InPrivateRoom") && ((AmandaIntroTime <= CurrentTime) && (AmandaIntroTime > 0))) AmandaLoad();
 	if (!AmandaInside && (AmandaStatus != "InPrivateRoom") && !AmandaIntroDone && !SarahInside) AmandaLoad();
@@ -246,7 +246,7 @@ function SarahLoadNewCharacter() {
 	if (!SophieInside && (SophieStatus != "InPrivateRoom") && (SophieIntroTime <= 0) && ((AmandaIntroTime <= CurrentTime) && (AmandaIntroTime > 0)) && (AmandaStatus == "InPrivateRoom")) SophieLoad();
 	if (!SophieInside && (SophieStatus != "InPrivateRoom") && ((SophieIntroTime <= CurrentTime) && (SophieIntroTime > 0))) SophieLoad();
 	if (!SophieInside && (SophieStatus != "InPrivateRoom") && !SophieIntroDone && !AmandaInside && !SarahInside) SophieLoad();
-	
+
 }
 
 // Make sure the background is proper
@@ -328,7 +328,7 @@ function SarahTransferToRoom() {
 	CharacterRelease(Sarah);
 	InventoryWear(Sarah, "CollegeOutfit1", "Cloth");
 	InventoryWear(Sarah, "Socks4", "Socks", "#AAAAAA");
-	InventoryWear(Sarah, "Shoes2", "Shoes", "#222222");	
+	InventoryWear(Sarah, "Shoes2", "Shoes", "#222222");
 	InventoryAdd(Player, "StuddedBlindfold", "ItemHead");
 	CommonSetScreen("Room", "Private");
 	PrivateAddCharacter(Sarah, null, true);
@@ -432,11 +432,11 @@ function SarahRestrainedBySophie(Phase, DomRep) {
 	if (DomRep > 0) SarahUpsetSophie(DomRep);
 	if (SophieUpsetCount <= 4) {
 		if (Phase == 0) { InventoryRemove(Player, "ItemArms"); InventoryWear(Player, "LeatherCuffs", "ItemArms"); }
-		if (Phase == 1) { 
-			InventoryRemove(Player, "ItemFeet"); 
-			InventoryRemove(Player, "ItemLegs"); 
-			InventoryWear(Player, "LeatherBelt", "ItemFeet"); 
-			InventoryWear(Player, "LeatherBelt", "ItemLegs"); 
+		if (Phase == 1) {
+			InventoryRemove(Player, "ItemFeet");
+			InventoryRemove(Player, "ItemLegs");
+			InventoryWear(Player, "LeatherBelt", "ItemFeet");
+			InventoryWear(Player, "LeatherBelt", "ItemLegs");
 		}
 		if (Phase == 2) SarahSophiePreparePunishCharacter(Player);
 	}
@@ -475,7 +475,7 @@ function SarahSophiePunishGirls() {
 	// Sets the correct stage & dialog
 	if ((SophiePunishmentStage % 2 == 0) && !SarahInside && !AmandaInside) SophiePunishmentStage++;
 	Sophie.CurrentDialog = DialogFind(Sophie, "PlayerPunishmentStage" + SophiePunishmentStage.toString());
-	
+
 }
 
 // When Sophie frees Sarah because she's already owned
@@ -535,7 +535,7 @@ function SarahTransferSophieToRoom(Love) {
 
 // When we need to set Sophie intro
 function SarahSophieSetPunishmentIntro(DomRep) {
-	SarahSophiePunishEvent("", DomRep)
+	SarahSophiePunishEvent("", DomRep);
 	if (Sophie.Stage == "201") {
 		Sophie.Stage = "200";
 		SophiePunishmentStage++;
@@ -599,7 +599,7 @@ function SarahSophiePunishEvent(EventType, DomRep) {
 
 // When the player plays Sophie Orgasm Game
 function SarahSophieOrgasmGame(Factor) {
-	
+
 	// Increments the game parameters
 	SophieOrgasmGameCount++;
 	SophieOrgasmGamePleasure = SophieOrgasmGamePleasure + parseInt(Factor);
@@ -623,7 +623,7 @@ function SarahSophieOrgasmGame(Factor) {
 		Sophie.Stage = "280";
 		return;
 	}
-	
+
 }
 
 // When Sophie releases all the characters but Sarah
@@ -652,7 +652,7 @@ function SarahPlayerPunishGirls() {
 }
 
 // Returns TRUE if the current slave(s) are naked and without restrains
-function SarahSlaveNakedWithoutRestrains(C) { 
+function SarahSlaveNakedWithoutRestrains(C) {
 	if (C == null) {
 		if (SarahAndAmandaAreInside()) return SarahSlaveNakedWithoutRestrains(Sarah) && SarahSlaveNakedWithoutRestrains(Amanda);
 		else if (SarahIsInside()) return SarahSlaveNakedWithoutRestrains(Sarah);

--- a/BondageClub/Screens/Room/Shibari/Shibari.js
+++ b/BondageClub/Screens/Room/Shibari/Shibari.js
@@ -29,7 +29,7 @@ function ShibariAllowTeacherStrip() { return (ShibariAllowTeacherItem && !Shibar
  * Checks if the player can be restrained by the Shibari dojo teacher.
  * @returns {boolean} - Returns TRUE if the player can be restrained by the teacher.
  */
-function ShibariAllowPlayerBondage() { return !Player.IsRestrained() && !ShibariTeacher.IsRestrained() }
+function ShibariAllowPlayerBondage() { return !Player.IsRestrained() && !ShibariTeacher.IsRestrained(); }
 /**
  * Checks if the player can spank the Shibari dojo teacher.
  * @returns {boolean} - Returns TRUE if the player can spank the teacher.
@@ -40,23 +40,23 @@ function ShibariAllowSpank() { return (((CurrentCharacter.ID == ShibariTeacher.I
  * @param {string} ScenarioName - Name of the scenario to check for.
  * @returns {boolean} - Returns TRUE if the given scenario is active.
  */
-function ShibariIsRescueScenario(ScenarioName) { return (ShibariRescueScenario == ScenarioName) }
+function ShibariIsRescueScenario(ScenarioName) { return (ShibariRescueScenario == ScenarioName); }
 /**
  * Checks if the Shibari dojo teacher is restrained.
  * @returns {boolean} - Returns TRUE if the teacher is restrained.
  */
-function ShibariIsTeacherRestrained() { return (ShibariTeacher.IsRestrained() || !ShibariTeacher.CanTalk()) }
+function ShibariIsTeacherRestrained() { return (ShibariTeacher.IsRestrained() || !ShibariTeacher.CanTalk()); }
 /**
  * Checks if the player can be trained in a given skill type.
  * @param {string} SkillType - Name of the skill to check for.
  * @returns {boolean} - Returns TRUE if the player can receive a training.
  */
-function ShibariCanTrainSkill(SkillType) { return (SkillGetLevelReal(Player, SkillType) < 10) }
+function ShibariCanTrainSkill(SkillType) { return (SkillGetLevelReal(Player, SkillType) < 10); }
 /**
  * Checks if the player can pay for a training.
  * @returns {boolean} - Returns TRUE if the player can pay for the requested training.
  */
-function ShibariCanPayForTraining() { return (Player.Money >= ShibariTrainingPrice) }
+function ShibariCanPayForTraining() { return (Player.Money >= ShibariTrainingPrice); }
 
 /**
  * Puts a character in a random bondage position.
@@ -65,7 +65,7 @@ function ShibariCanPayForTraining() { return (Player.Money >= ShibariTrainingPri
  * @returns {void} - Nothing
  */
 function ShibariRandomBondage(C, Level) {
-	
+
 	// For NPCs, we give the items
 	if (C.ID != 0) {
 		InventoryAdd(C, "HempRope", "ItemArms");
@@ -74,10 +74,10 @@ function ShibariRandomBondage(C, Level) {
 		InventoryAdd(C, "HempRopeHarness", "ItemTorso");
 		InventoryAdd(C, "BambooGag", "ItemMouth");
 	}
-	
+
 	// At a level of 0, we pick a random level, over zero, we apply restrains
 	if (Level >= 0) {
-		
+
 		// Wears more item with higher levels
 		if (Level >= 1) InventoryWear(C, "HempRope", "ItemArms", "Default", (Level - 1) * 3);
 		if (Level >= 2) InventoryWear(C, "HempRope", "ItemLegs", "Default", (Level - 1) * 3);
@@ -88,7 +88,7 @@ function ShibariRandomBondage(C, Level) {
 			else if (Math.random() > 0.5) InventoryGet(C, "ItemTorso").Property = { Type: "Harness", Difficulty: 0, Effect: [] };
 		}
 		if (Level >= 4) InventoryWear(C, "BambooGag", "ItemMouth");
-		
+
 		// At 3 or more, there's a random chance of a more complicated bondage
 		if (Level >= 3) {
 			Level = Math.floor(Math.random() * 4);
@@ -111,7 +111,7 @@ function ShibariRandomBondage(C, Level) {
  * @returns {void} - Nothing
  */
 function ShibariLoad() {
-	
+
 	// Default load
 	if (ShibariPlayerAppearance == null) ShibariPlayerAppearance = Player.Appearance.slice();
 	if (ShibariTeacher == null) {
@@ -124,7 +124,7 @@ function ShibariLoad() {
 		CharacterNaked(ShibariStudent);
 		ShibariRandomBondage(ShibariStudent, 4);
 	}
-	
+
 	// Rescue mission load
 	if ((MaidQuartersCurrentRescue == "ShibariDojo") && !MaidQuartersCurrentRescueStarted) {
 		MaidQuartersCurrentRescueStarted = true;

--- a/BondageClub/Screens/Room/Shop/Shop.js
+++ b/BondageClub/Screens/Room/Shop/Shop.js
@@ -35,25 +35,25 @@ var ShopSellExceptions = [
 	{ Name: "LeatherCuffs", Group: "ItemArms" },
 ];
 
-/** 
+/**
  * Checks if the vendor is restrained
  * @returns {boolean} - Returns TRUE if the vendor is restrained or gagged
  */
-function ShopIsVendorRestrained() { return (ShopVendor.IsRestrained() || !ShopVendor.CanTalk()) }
-/** 
+function ShopIsVendorRestrained() { return (ShopVendor.IsRestrained() || !ShopVendor.CanTalk()); }
+/**
  * Checks if the current rescue scenario corresponds to the given one
  * @param {string} ScenarioName - Name of the rescue scenario to check for
  * @returns {boolean} - Returns TRUE if the current rescue scenario is the given one
  */
-function ShopIsRescueScenario(ScenarioName) { return (ShopRescueScenario == ScenarioName) }
-/** 
+function ShopIsRescueScenario(ScenarioName) { return (ShopRescueScenario == ScenarioName); }
+/**
  * Activates the mode which allows the player to buy the items that appear in the inventory screen
  * @returns {void} - Nothing
  */
 function ShopSetBuyMode() {
 	ShopBuyMode = true;
 }
-/** 
+/**
  * Activates the mode which allows the player to sell the items that appear in the inventory screen
  * @returns {void} - Nothing
  */
@@ -95,7 +95,7 @@ function ShopLoad() {
  * @returns {void} - Nothing
  */
 function ShopRun() {
-	
+
 	// Draw both characters
 	DrawCharacter(Player, 0, 0, 1);
 	DrawCharacter(ShopVendor, 500, 0, 1);
@@ -132,7 +132,7 @@ function ShopRun() {
 }
 
 /**
- * Checks if an asset is from the focus group and if it can be bought/sold. An asset can be bought/sold if it has a value greater than 
+ * Checks if an asset is from the focus group and if it can be bought/sold. An asset can be bought/sold if it has a value greater than
  * 0. (0 is a default item, -1 is a non-purchasable item)
  * @param {Asset} Asset - The asset to check for availability
  * @returns {boolean} - Returns TRUE if the item is purchasable and part of the focus group.
@@ -172,7 +172,7 @@ function ShopSelectAssetMissing() {
  * @returns {void} - Nothing
  */
 function ShopClick() {
-	
+
 	// Out of shopping mode, the player can click on herself, the vendor or exit
 	if (!ShopStarted) {
 		if ((MouseX >= 0) && (MouseX < 500) && (MouseY >= 0) && (MouseY < 1000)) CharacterSetCurrent(Player);
@@ -221,7 +221,7 @@ function ShopClick() {
 			CharacterSetCurrent(ShopVendor);
 			ShopVendor.CurrentDialog = TextGet("MoreShopping");
 		}
-		
+
 		// If the user wants to get the next 12 items
 		if ((MouseX >= 1770) && (MouseX <= 1860) && (MouseY >= 25) && (MouseY < 115)) {
 			ShopItemOffset = ShopItemOffset + 12;
@@ -302,7 +302,7 @@ function ShopSellItem(asset) {
  * Builds the array of items the player can buy in the current category.
  * @returns {void} - Nothing
  */
-function ShopCartBuild() { 
+function ShopCartBuild() {
 	ShopCart = [];
 	for (let A = 0; A < Asset.length; A++)
 		if (ShopSelectAsset(Asset[A]))
@@ -311,7 +311,7 @@ function ShopCartBuild() {
 
 /**
  * If selling items, checks whether the player owns any items in the specified groups that can be sold
- * @param {string} groupList - The list of groups to check, with separator "|" 
+ * @param {string} groupList - The list of groups to check, with separator "|"
  * @returns {boolean} - If TRUE the player is either buying items or owns at least one item in one of the groups
  */
 function ShopCanShow(groupList) {
@@ -416,8 +416,8 @@ function ShopJobRestrain() {
 	ShopCustomer = CharacterLoadNPC("NPC_Shop_Customer");
 	ShopCustomer.AllowItem = false;
 	ShopCustomer.Stage = ShopDemoItemGroup + "0";
-	if (Math.random() >= 0.5) ShopCustomer.WillRelease = function () { return true };
-	else ShopCustomer.WillRelease = function () { return false };
+	if (Math.random() >= 0.5) ShopCustomer.WillRelease = function () { return true; };
+	else ShopCustomer.WillRelease = function () { return false; };
 
 }
 

--- a/BondageClub/Screens/Room/SlaveMarket/SlaveMarket.js
+++ b/BondageClub/Screens/Room/SlaveMarket/SlaveMarket.js
@@ -10,22 +10,22 @@ var SlaveMarketBuyer = null;
  * Checks if an auction can be started.
  * @returns {boolean} - Returns TRUE if the player has room in her private room and is dominant enough to participate in an auction
  */
-function SlaveMarketCanStartAuction() { return ((ReputationGet("Dominant") >= -50) && ManagementCanTransferToRoom()) }
+function SlaveMarketCanStartAuction() { return ((ReputationGet("Dominant") >= -50) && ManagementCanTransferToRoom()); }
 /**
  * Checks if an auction cannot be started due to being too submissive.
  * @returns {boolean} - Returns TRUE if the player is not dominant enough to participate in an auction
  */
-function SlaveMarketCannotStartAuctionSubmissive() { return (ReputationGet("Dominant") < -50) }
+function SlaveMarketCannotStartAuctionSubmissive() { return (ReputationGet("Dominant") < -50); }
 /**
  * Checks if an auction cannot be started due to lack of space in the player's private room
  * @returns {boolean} - Returns TRUE if the player is dominant enough to participate in an auction, but does not have space in her private room
  */
-function SlaveMarketCannotStartAuctionRoom() { return ((ReputationGet("Dominant") >= -50) && !ManagementCanTransferToRoom()) }
+function SlaveMarketCannotStartAuctionRoom() { return ((ReputationGet("Dominant") >= -50) && !ManagementCanTransferToRoom()); }
 /**
  * Checks if the player can be auctioned.  Must not be owned, must be submissive, must not be restrained, must have space in room and must not have been auctioned in the last seven days
  * @returns {boolean} - Returns TRUE if the player can be auctioned
  */
-function SlaveMarketCanBeAuctioned() { return (!Player.IsOwned() && !PrivateOwnerInRoom() && !Player.IsRestrained() && !Player.IsChaste() && (ReputationGet("Dominant") < 0) && !LogQuery("Auctioned", "SlaveMarket") && ManagementCanTransferToRoom()) }
+function SlaveMarketCanBeAuctioned() { return (!Player.IsOwned() && !PrivateOwnerInRoom() && !Player.IsRestrained() && !Player.IsChaste() && (ReputationGet("Dominant") < 0) && !LogQuery("Auctioned", "SlaveMarket") && ManagementCanTransferToRoom()); }
 
 /**
  * Loads the Slave Market room, generates the Mistress and slave
@@ -181,7 +181,7 @@ function SlaveMarketPlayerAuctionEnd() {
 	LogAdd("Auctioned", "SlaveMarket", CurrentTime + 604800000);
 	CharacterChangeMoney(Player, PlayerAuctionBidAmount / 2);
 	CommonSetScreen("Room", "SlaveMarket");
-	SlaveMarketBuyer.AllowItem = false;	
+	SlaveMarketBuyer.AllowItem = false;
 	SlaveMarketBuyer.Appearance = PlayerAuctionCustomer[PlayerAuctionBidCurrent].Appearance.slice(0);
 	SlaveMarketBuyer.Archetype = PlayerAuctionCustomer[PlayerAuctionBidCurrent].Archetype;
 	CharacterRefresh(SlaveMarketBuyer);

--- a/BondageClub/Screens/Room/Stable/Stable.js
+++ b/BondageClub/Screens/Room/Stable/Stable.js
@@ -25,8 +25,8 @@ var StableExamPoint = 0;
 //General Room function
 ////////////////////////////////////////////////////////////////////////////////////////////
 // functions for Dialogs
-function StablePlayerIsDressOff() {return StablePlayerDressOff;} 
-function StablePlayerIsCollared() {return StableCharacterAppearanceGroupAvailable(Player, "ItemNeck")}
+function StablePlayerIsDressOff() {return StablePlayerDressOff;}
+function StablePlayerIsCollared() {return StableCharacterAppearanceGroupAvailable(Player, "ItemNeck");}
 function StablePlayerOtherPony()  {return StableTrainer.Stage == "StableTrainingOtherPoniesBack" || StableTrainer.Stage == "StableTrainingEnd";}
 function StablePlayerIsolation()  {return StableTrainer.Stage == "StableTrainingIsolationBack";}
 function StableTrainingExercisesAvailable() {return (StableTrainerTrainingExercises > 0);}
@@ -36,7 +36,7 @@ function StablePlayerAllowedTrainerExamen() {return (!StablePlayerIsExamTrainer 
 function StablePlayerDisallowedTrainerExamen() {return (!StablePlayerIsExamTrainer && StablePlayerIsTrainer && (SkillGetLevel(Player, "Dressage") < 6));}
 
 //BadGirlClub
-function StableCanHideDice() {return (LogQuery("Joined", "BadGirl") && LogQuery("Stolen", "BadGirl") && !LogQuery("Hide", "BadGirl"))}
+function StableCanHideDice() {return (LogQuery("Joined", "BadGirl") && LogQuery("Stolen", "BadGirl") && !LogQuery("Hide", "BadGirl"));}
 
 
 // Loads the stable characters with many restrains
@@ -54,7 +54,7 @@ function StableLoad() {
 		ItemsToEarn.push({Name: "HarnessPonyBits", Group: "ItemMouth"});
 		InventoryAddMany(Player, ItemsToEarn);
 	}
-	
+
 	// Default load
 	if (StableTrainer == null) {
 		StableTrainer = CharacterLoadNPC("NPC_Stable_Trainer");
@@ -328,7 +328,7 @@ function StablePlayerTrainingHurdles(Behavior) {
 	StablePlayerTrainingLessons += 2;
 }
 
-function StablePlayerTrainingHurdlesEnd() {	
+function StablePlayerTrainingHurdlesEnd() {
 	CommonSetScreen("Room", "Stable");
 	CharacterSetCurrent(StableTrainer);
 	if (MiniGameVictory) {
@@ -636,11 +636,11 @@ function StablePlayerExamHurdles() {
 	MiniGameStart("HorseWalk", "Hurdle", "StablePlayerExamHurdlesEnd");
 }
 
-function StablePlayerExamHurdlesEnd() {	
+function StablePlayerExamHurdlesEnd() {
 	CommonSetScreen("Room", "Stable");
 	CharacterSetCurrent(StableTrainer);
 	if (MiniGameVictory) {
-		StableExamPoint++
+		StableExamPoint++;
 		StableTrainer.CurrentDialog = DialogFind(StableTrainer, "StableExamRaceIntro");
 		StableTrainer.Stage = "StableExamRace";
 	} else {
@@ -777,7 +777,7 @@ function StablePonyTrainingHurdles() {
 	StableTrainerTrainingExercises -= 2;
 }
 
-function StablePonyTrainingHurdlesEnd() {	
+function StablePonyTrainingHurdlesEnd() {
 	CommonSetScreen("Room", "Stable");
 	CharacterSetCurrent(StablePony);
 	if (MiniGameVictory) {
@@ -870,7 +870,7 @@ function StablePlayerTExamHurdles() {
 	MiniGameStart("HorseWalk", "HurdleTraining", "StablePlayerTExamHurdlesEnd");
 }
 
-function StablePlayerTExamHurdlesEnd() {	
+function StablePlayerTExamHurdlesEnd() {
 	CommonSetScreen("Room", "Stable");
 	CharacterSetCurrent(StableTrainer);
 	if (MiniGameVictory) {
@@ -908,7 +908,7 @@ var StableSecondProgressAuto = 0;
 var StableProgressClick = 0;
 var StableProgressLastKeyPress = 0;
 var StableProgressItem = '';
-var StableProgressFinished = false; 
+var StableProgressFinished = false;
 var StableProgressCharacter = null;
 var StableProgressSecondCharacter = null;
 var StableProgressEndStage = 0;
@@ -920,7 +920,7 @@ var StableProgressOperation = null;
 var StableProgressStruggleCount = null;
 
 function StableGenericProgressStart(Timer, S, S2, Item, Background, Character, SecondCharacter, Stage, CurrentDialog, CancelStage, CancelCurrentDialog, Behavior, ProgressOperation) {
-	DialogLeave()
+	DialogLeave();
 	if (Timer < 1) Timer = 1;
 	//Charakter
 	StableProgressAuto = TimerRunInterval * (0.1333 + (S * 0.1333)) / (Timer * CheatFactor("DoubleItemSpeed", 0.5));
@@ -931,7 +931,7 @@ function StableGenericProgressStart(Timer, S, S2, Item, Background, Character, S
 	StableSecondProgressAuto = TimerRunInterval * (0.1333 + (S2 * 0.1333)) / (Timer * CheatFactor("DoubleItemSpeed", 0.5));
 	if (S2 < 0) { StableSecondProgressAuto = StableSecondProgressAuto / 2; }
 	StableSecondProgress = 0;
-	
+
 	StableBackground = Background;
 	StableProgressItem = Item;
 	StableProgress = 0;
@@ -994,24 +994,24 @@ function StableGenericDrawProgress() {
 		if (StableProgress >= 100) {
 			StableGenericFinished();
 		} else if (StableSecondProgress >= 100) {
-			StableGenericCancel(); 
+			StableGenericCancel();
 		}
 	}
 }
 
 function StableGenericFinished() {
 	StableProgressFinished = true;
-	StableGenericProgressEnd()
+	StableGenericProgressEnd();
 }
 
 function StableGenericCancel() {
 	StableProgressFinished = false;
-	StableGenericProgressEnd()
+	StableGenericProgressEnd();
 }
 
 function StableGenericProgressEnd() {
 	StableProgress = -1;
-	StableBackground = "HorseStable"
+	StableBackground = "HorseStable";
 	CharacterSetCurrent(StableProgressCharacter);
 	if (StableProgressFinished) {
 		StableProgressCharacter.Stage = StableProgressEndStage;


### PR DESCRIPTION
This PR has no functional effect, it only:
- Removes spaces and tabs on end of lines, where they have no effect (trailing whitespace)
- Add semicolons to where they should be

To keep this cleanup small, this part only focuses on files in `Screens/Room/`.