### PR TITLE
"Hide others' Messages" applies to Hide Names sensory deprivation option

### DIFF
--- a/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
+++ b/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
@@ -1805,7 +1805,6 @@ function ChatRoomMessage(data) {
 			// Prepares the HTML tags
 			if (data.Type != null) {
 				const HideOthersMessages = Player.ImmersionSettings.SenseDepMessages
-					&& (Player.GameplaySettings.SensDepChatLog === "SensDepExtreme" || Player.GameplaySettings.SensDepChatLog === "SensDepTotal")
 					&& PreferenceIsPlayerInSensDep()
 					&& SenderCharacter.ID !== 0
 					&& Player.GetDeafLevel() >= 4;


### PR DESCRIPTION
Figured there was no reason to block it out.

It still does not affect Light because in Light the player cannot enter total sensory deprivation due to the IsInSenseDep function.