### PR TITLE
Bugfix: Re-enables `DarkFactor` inside minigames

### DIFF
--- a/BondageClub/Screens/MiniGame/KinkyDungeon/KinkyDungeon.js
+++ b/BondageClub/Screens/MiniGame/KinkyDungeon/KinkyDungeon.js
@@ -24,6 +24,7 @@ var KinkyDungeonRootDirectory = "Screens/MiniGame/KinkyDungeon/";
  */
 function KinkyDungeonLoad() {
 
+	CurrentDarkFactor = 0;
 	if (!KinkyDungeonGameRunning) {
 		if (!KinkyDungeonPlayer)
       KinkyDungeonPlayer = CharacterLoadNPC("NPC_Avatar");
@@ -70,6 +71,7 @@ function KinkyDungeonDeviousDungeonAvailable() {
  * @returns {void} - Nothing
  */
 function KinkyDungeonRun() {
+	DrawImage("Backgrounds/BrickWall.jpg", 0, 0);
 
 	// Draw the characters
 	DrawCharacter(KinkyDungeonPlayer, 0, 0, 1);

--- a/BondageClub/Scripts/Drawing.js
+++ b/BondageClub/Scripts/Drawing.js
@@ -1183,7 +1183,7 @@ function DrawProcess() {
 
 		let customBG = DrawGetCustomBackground();
 
-		if (customBG != "" && (CurrentModule != "Character" && CurrentModule != "MiniGame") && (B != "Sheet")) {
+		if (customBG != "" && (CurrentModule != "Character") && (B != "Sheet")) {
 			B = customBG;
 			if (DarkFactor == 0)
 				DarkFactor = CharacterGetDarkFactor(Player, true);

--- a/BondageClub/Scripts/Drawing.js
+++ b/BondageClub/Scripts/Drawing.js
@@ -1175,7 +1175,7 @@ function DrawProcess() {
 
 	if ((B != null) && (B != "")) {
 		let DarkFactor = 1.0;
-		if ((CurrentModule != "Character" && CurrentModule != "MiniGame") && (B != "Sheet")) {
+		if ((CurrentModule != "Character") && (B != "Sheet")) {
 			DarkFactor = CharacterGetDarkFactor(Player) * CurrentDarkFactor;
 			if (DarkFactor == 1 && (CurrentCharacter != null || ShopStarted) && !CommonPhotoMode) DarkFactor = 0.5;
 		}


### PR DESCRIPTION
# Summary

#2163 modified `Drawing.js` so that `DarkFactor` was no longer applied inside minigames. This resulted in a few visual issues in some minigames, for example the Asylum Therapy minigame, where the instruction text is shown against an almost-white background, making it almost impossible to read (see image below). This removes the minigame check, which fixes the issue for the Asylum Therapy and any other minigames that were trying to set `DarkFactor` to something other than 1.

I assume that the minigame check was added to support the Kinky Dungeon minigame (although that hadn't yet been fully introduced at the time of the above PR). That said, I've checked this change inside the Kinky Dungeon minigame, and have not seen any issues as a result. @Ada18980 - do you foresee this causing any problems with the Kinky Dungeon minigame?

![Asylum](https://cdn.discordapp.com/attachments/554378725916147722/839099434058645504/unknown.png)