### PR TITLE
Feature: Modular item `Effect` support

### DIFF
--- a/BondageClub/Scripts/Asset.js
+++ b/BondageClub/Scripts/Asset.js
@@ -193,9 +193,18 @@ function AssetBuildExtended(A, ExtendedConfig) {
 				TypedItemRegister(A, AssetConfig.Config);
 				break;
 		}
+		A.Archetype = AssetConfig.Archetype;
 	}
 }
 
+/**
+ * Finds the extended item configuration for the provided group and asset name, if any exists
+ * @param {ExtendedItemConfig} ExtendedConfig - The full extended item configuration object
+ * @param {string} GroupName - The name of the asset group to find extended configuration for
+ * @param {string} AssetName - The name of the asset to find extended configuration fo
+ * @returns {ExtendedItemAssetConfig | undefined} - The extended asset configuration object for the specified asset, if
+ * any exists, or undefined otherwise
+ */
 function AssetFindExtendedConfig(ExtendedConfig, GroupName, AssetName) {
 	const GroupConfig = ExtendedConfig[GroupName] || {};
 	return GroupConfig[AssetName];

--- a/BondageClub/Scripts/ModularItem.js
+++ b/BondageClub/Scripts/ModularItem.js
@@ -418,6 +418,7 @@ function ModularItemMergeModuleValues({ asset, modules }, moduleValues) {
 		Property = Property || {};
 		mergedProperty.Difficulty += (Property.Difficulty || 0);
 		if (Property.Block) CommonArrayConcatDedupe(mergedProperty.Block, Property.Block);
+		if (Property.Effect) CommonArrayConcatDedupe(mergedProperty.Effect, Property.Effect);
 		if (Property.Hide) CommonArrayConcatDedupe(mergedProperty.Hide, Property.Hide);
 		if (Property.HideItem) CommonArrayConcatDedupe(mergedProperty.HideItem, Property.HideItem);
 		return mergedProperty;
@@ -425,6 +426,7 @@ function ModularItemMergeModuleValues({ asset, modules }, moduleValues) {
 		Type: ModularItemConstructType(modules, moduleValues),
 		Difficulty: asset.Difficulty,
 		Block: asset.Block || [],
+		Effect: asset.Effect || [],
 		Hide: asset.Hide || [],
 		HideItem: asset.HideItem || [],
 	});
@@ -457,6 +459,8 @@ function ModularItemSetType(module, index, data) {
 	const C = CharacterGetCurrent();
 	DialogFocusItem = InventoryGet(C, C.FocusGroup.Name);
 	const option = module.Options[index];
+
+	// Make a final requirement check before actually modifying the item
 	const requirementMessage = ModularItemRequirementMessageCheck(option);
 	if (requirementMessage) {
 		DialogExtendedMessage = requirementMessage;
@@ -464,6 +468,7 @@ function ModularItemSetType(module, index, data) {
 	}
 
 	const currentModuleValues = ModularItemParseCurrent(data);
+
 	const moduleIndex = data.modules.indexOf(module);
 	let changed = false;
 	const newModuleValues = currentModuleValues.map((value, i) => {
@@ -475,8 +480,26 @@ function ModularItemSetType(module, index, data) {
 	});
 
 	if (changed) {
+		// Take a snapshot of the property values that are applied by the current type
+		const currentProperty = ModularItemMergeModuleValues(data, currentModuleValues);
+
+		// Create a shallow copy of the old property, and remove any module-defined keys from it (should only leave any
+		// lock-related keys behind)
+		const newProperty = Object.assign({}, DialogFocusItem.Property);
+		for (const key of Object.keys(currentProperty)) {
+			delete newProperty[key];
+		}
+
+		// Assign the new property data
+		DialogFocusItem.Property = Object.assign(newProperty, ModularItemMergeModuleValues(data, newModuleValues));
+
+		// Reinstate the Lock effect if there's a lock
+		if (newProperty.LockedBy && !(newProperty.Effect || []).includes("Lock")) {
+			newProperty.Effect = (newProperty.Effect || []);
+			newProperty.Effect.push("Lock");
+		}
+
 		const groupName = data.asset.Group.Name;
-		Object.assign(DialogFocusItem.Property, ModularItemMergeModuleValues(data, newModuleValues));
 		CharacterRefresh(C);
 		ChatRoomCharacterItemUpdate(C, groupName);
 

--- a/BondageClub/Scripts/ModularItem.js
+++ b/BondageClub/Scripts/ModularItem.js
@@ -425,10 +425,10 @@ function ModularItemMergeModuleValues({ asset, modules }, moduleValues) {
 	}, {
 		Type: ModularItemConstructType(modules, moduleValues),
 		Difficulty: asset.Difficulty,
-		Block: asset.Block || [],
-		Effect: asset.Effect || [],
-		Hide: asset.Hide || [],
-		HideItem: asset.HideItem || [],
+		Block: Array.isArray(asset.Block) ? asset.Block.slice() : [],
+		Effect: Array.isArray(asset.Effect) ? asset.Effect.slice() : [],
+		Hide: Array.isArray(asset.Hide) ? asset.Hide.slice() : [],
+		HideItem: Array.isArray(asset.HideItem) ? asset.HideItem.slice() : [],
 	});
 }
 

--- a/BondageClub/Scripts/Typedef.d.ts
+++ b/BondageClub/Scripts/Typedef.d.ts
@@ -202,6 +202,7 @@ interface Asset {
 	FixedPosition: boolean;
 	Layer: AssetLayer[];
 	ColorableLayerCount: number;
+	Archetype?: string;
 }
 
 /** An ItemBundle is a minified version of the normal Item */

--- a/BondageClub/Tools/Node/AssetCheck_Types.js
+++ b/BondageClub/Tools/Node/AssetCheck_Types.js
@@ -130,7 +130,8 @@ const AssetType = {
 	MirrorExpression: "String",
 	FixedPosition: "Boolean",
 	CustomBlindBackground: "Object",
-	Layer: "[Object]"
+	Layer: "[Object]",
+	Archetype: "String",
 };
 
 const AssetLayerType = {


### PR DESCRIPTION
## Summary

This PR does a couple of things:
* Adds support to modular items for the `Effect` property (which wasn't supported until now, since no items needed it). This supports a request from @Ada18980 to extend the Kigurumi Mask's functionality
* Adds an `Archetype` property to assets, which is automatically populated for items which have an extended archetype - this is primarily a convenience property, but may be useful to scripters, or to support Ada's Kinky Dungeon functionality
* Fixes an issue with the modular item script where module changes were unintentionally getting assigned directly to the underlying asset's `Block`, `Hide` and `HideItem` arrays