### PR TITLE
Improvement: `ItemBoots` is now shown in the `Spread` pose by default

### DIFF
--- a/BondageClub/Assets/Female3DCG/Female3DCG.js
+++ b/BondageClub/Assets/Female3DCG/Female3DCG.js
@@ -4347,7 +4347,6 @@ var PoseFemale3DCG = [
 	{
 		Name: "Spread",
 		Category: "BodyLower",
-		Hide: ["ItemBoots"],
 		MovePosition: [{ Group: "Pussy", X: 0, Y: -5 }, { Group: "ItemVulva", X: 0, Y: -5 }, { Group: "ItemButt", X: 0, Y: -5 }, { Group: "TailStraps", X: 0, Y: -5 }, { Group: "ItemVulvaPiercings", X: 0, Y: -5 }]
 	},
 	{


### PR DESCRIPTION
## Summary

> ⚠️ Depends on, _but does not include_ #2421 & #2422. Merging without these two PRs will result in bugs.

This removes the `Hide` entry for the `Spread` pose, meaning that by default items from the `ItemBoots` group will now be shown in the pose by default. Along with the changes in #2421 & #2422, this should enable the `Spread` pose for the Futuristic Heels, whilst not causing incompatibilities with the alpha masks of other boots.