### PR TITLE
Prevent players that are leashed from leaving

### DIFF
--- a/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
+++ b/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
@@ -1330,6 +1330,11 @@ function ChatRoomAttemptStandMinigameEnd() {
  * @returns {boolean} - Returns TRUE if the player can leave the current chat room.
  */
 function ChatRoomCanLeave() {
+	if (ChatRoomLeashPlayer != null) {
+		if (ChatRoomCanBeLeashed(Player)) {
+			return false;
+		} else ChatRoomLeashPlayer = null;		
+	}
 	if (!Player.CanWalk()) return false; // Cannot leave if cannot walk
 	if (!ChatRoomData.Locked || ChatRoomPlayerIsAdmin()) return true; // Can leave if the room isn't locked or is an administrator
 	for (let C = 0; C < ChatRoomCharacter.length; C++)


### PR DESCRIPTION
Since the current behavior is that if you are leashed, you keep getting dragged to whatever room the leashing player takes you to, this prevents the player from manually breaking the leash connection except by removing the leash. 

Tested to make sure leashing itself wasn't broken, and also verified the functionality and that it can be escaped by no longer being leashable.