### PR TITLE
Bugfix: `HideForPose`/`HideAs` compatibility issue

### DIFF
--- a/BondageClub/Screens/Character/Appearance/Appearance.js
+++ b/BondageClub/Screens/Character/Appearance/Appearance.js
@@ -372,8 +372,10 @@ function CharacterAppearanceVisible(C, AssetName, GroupName, Recursive = true) {
 	if (!C.DrawAppearance) C.DrawAppearance = C.Appearance;
 
 	const assetToCheck = AssetGet(C.AssetFamily, GroupName, AssetName);
-	const Pose = CommonDrawResolveAssetPose(C, assetToCheck);
-	if (Pose && assetToCheck.HideForPose.includes(Pose)) return false;
+	if (assetToCheck) {
+		const Pose = CommonDrawResolveAssetPose(C, assetToCheck);
+		if (Pose && assetToCheck.HideForPose.includes(Pose)) return false;
+	}
 
 	for (const item of C.DrawAppearance) {
 		if (CharacterAppearanceItemIsHidden(item.Asset.Name, item.Asset.Group.Name)) continue;


### PR DESCRIPTION
## Summmary

This fixes an issue introduced by the change to the `HideForPose` property in #2422 where items using the `HideAs` property would result in an error being thrown as the `ItemHidden` group no longer exists.

## Steps to reproduce

1. Equip an armbinder
2. Select one of the strap variations from the extended menu
3. Note that the menu does not exit properly, and an error is thrown in the console