### PR TITLE
Bugfix: Better null safety on combination padlock extended menu

### DIFF
--- a/BondageClub/Screens/Inventory/ItemMisc/CombinationPadlock/CombinationPadlock.js
+++ b/BondageClub/Screens/Inventory/ItemMisc/CombinationPadlock/CombinationPadlock.js
@@ -91,14 +91,17 @@ function InventoryItemMiscCombinationPadlockDraw() {
 		document.getElementById("NewCombinationNumber").type = playerBlind ? "password" : "text";
 	}
 
-	const LockMemberNumber = playerBlind ? "?" : DialogFocusSourceItem.Property.LockMemberNumber.toString();
 	DrawText(
 		DialogFindPlayer(DialogFocusItem.Asset.Group.Name + DialogFocusItem.Asset.Name + "Intro"), 1500, 400, "white",
 		"gray",
 	);
-	if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property != null) &&
-		(DialogFocusSourceItem.Property.LockMemberNumber != null))
+	const Property = DialogFocusSourceItem && DialogFocusSourceItem.Property;
+	let LockMemberNumber;
+	if (playerBlind) LockMemberNumber = "?";
+	else LockMemberNumber = Property && Property.LockMemberNumber && Property.LockMemberNumber.toString();
+	if (LockMemberNumber != null) {
 		DrawText(DialogFindPlayer("LockMemberNumber") + " " + LockMemberNumber, 1500, 500, "white", "gray");
+	}
 
 	const additionalInfo = [];
 	if (playerBlind) additionalInfo.push("ControlsBlind");


### PR DESCRIPTION
## Summary

I'm not entirely sure on what caused the original problem (possibly a badly consoled-on combination lock), but if a combination padlocked item has no `LockMemberNumber` property, then it will cause an error in the combination padlock's extended item menu. This PR adds better null-safety to the extended item menu to catch this.