### PR TITLE
Notification Popup fix

### DIFF
--- a/BondageClub/Scripts/Notification.js
+++ b/BondageClub/Scripts/Notification.js
@@ -153,7 +153,7 @@ class NotificationEventHandler {
 			this.raisedCount = 0;
 
 			if (this.settings.AlertType === NotificationAlertType.POPUP) {
-				this.popup.close();
+				if (this.popup) this.popup.close();
 			}
 			else if (this.settings.AlertType === NotificationAlertType.TITLEPREFIX) {
 				NotificationTitleUpdate();


### PR DESCRIPTION
A fix to ensure the screen doesn't freeze if a popup doesn't exist when the reset occurs.