### PR TITLE
If a leashing player disconnects, the leash is broken

### DIFF
--- a/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
+++ b/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
@@ -1714,6 +1714,8 @@ function ChatRoomMessage(data) {
 				MsgEnterLeave = " ChatMessageEnterLeave";
 			if ((data.Type != "Chat" && data.Type != "Whisper" && data.Type != "Emote"))
 				MsgNonDialogue = " ChatMessageNonDialogue";
+			
+			if (msg.startsWith("ServerDisconnect") && SenderCharacter.MemberNumber == ChatRoomLeashPlayer) ChatRoomLeashPlayer = null;
 
 			// Replace actions by the content of the dictionary
 			if (data.Type && ((data.Type == "Action") || (data.Type == "ServerMessage"))) {


### PR DESCRIPTION
This makes it so that if the player receives a message that her leasher disconnected, the leash will break and the player will be able to leave the room again. This is to prevent cases where the player is stuck for no discernable reason.