### PR TITLE
Bugfix: WebGL alpha blending

### DIFF
--- a/BondageClub/Scripts/GLDraw.js
+++ b/BondageClub/Scripts/GLDraw.js
@@ -279,7 +279,7 @@ function GLDrawImage(url, gl, dstX, dstY, offsetX, color, fullAlpha, alphaMasks,
 	gl.useProgram(program);
 
 	gl.enable(gl.BLEND);
-	gl.blendFuncSeparate(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA, gl.SRC_ALPHA, gl.DST_ALPHA);
+	gl.blendFuncSeparate(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA, gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
 
 	gl.bindBuffer(gl.ARRAY_BUFFER, program.position_buffer);
 	gl.enableVertexAttribArray(program.a_position);


### PR DESCRIPTION
## Summary

This fixes an issue with alpha blending where source and destination alpha channels were not being interpolated properly when drawing an image with semi-transparent pixels onto a canvas. This could result in visual artifacts being displayed on some setups (see before/after comparison for this change below).

| Before fix | After Fix |
| --- | --- |
| ![alpha-before](https://user-images.githubusercontent.com/62729616/117960897-67144980-b315-11eb-96f2-74da2f33b823.png) | ![alpha-after](https://user-images.githubusercontent.com/62729616/117960916-6bd8fd80-b315-11eb-825a-5585a02e9709.png) |

