### PR TITLE
Fixed Dungeoneer reputation

### DIFF
--- a/BondageClub/Screens/MiniGame/KinkyDungeon/KinkyDungeon.js
+++ b/BondageClub/Screens/MiniGame/KinkyDungeon/KinkyDungeon.js
@@ -230,6 +230,9 @@ function KinkyDungeonClick() {
  */
 function KinkyDungeonExit() {
 	CommonDynamicFunction(MiniGameReturnFunction + "()");
+	
+	if (MiniGameKinkyDungeonLevel > ReputationGet("Gaming"))
+		DialogSetReputation("Gaming", MiniGameKinkyDungeonLevel);
 
 	if (CurrentScreen == "ChatRoom" && KinkyDungeonState != "Menu" && (MiniGameKinkyDungeonLevel > 1 || KinkyDungeonState == "Lose")) {
 		let Message = "KinkyDungeonExit";

--- a/BondageClub/Screens/MiniGame/KinkyDungeon/KinkyDungeon.js
+++ b/BondageClub/Screens/MiniGame/KinkyDungeon/KinkyDungeon.js
@@ -3,6 +3,7 @@ var KinkyDungeonBackground = "BrickWall";
 var KinkyDungeonPlayer = null;
 var KinkyDungeonState = "Menu";
 
+var KinkyDungeonRep = 0; // Variable to store max level to avoid losing it if the server doesnt take the rep update
 
 var KinkyDungeonKeybindings = null;
 var KinkyDungeonKeybindingsTemp = null;
@@ -231,8 +232,10 @@ function KinkyDungeonClick() {
 function KinkyDungeonExit() {
 	CommonDynamicFunction(MiniGameReturnFunction + "()");
 	
-	if (MiniGameKinkyDungeonLevel > ReputationGet("Gaming"))
-		DialogSetReputation("Gaming", MiniGameKinkyDungeonLevel);
+	if (MiniGameKinkyDungeonLevel > Math.max(KinkyDungeonRep, ReputationGet("Gaming")) || Math.max(KinkyDungeonRep, ReputationGet("Gaming")) > KinkyDungeonMaxLevel) {
+		KinkyDungeonRep = Math.max(KinkyDungeonRep, MiniGameKinkyDungeonLevel);
+		DialogSetReputation("Gaming", KinkyDungeonRep);
+	}
 
 	if (CurrentScreen == "ChatRoom" && KinkyDungeonState != "Menu" && (MiniGameKinkyDungeonLevel > 1 || KinkyDungeonState == "Lose")) {
 		let Message = "KinkyDungeonExit";

--- a/BondageClub/Screens/MiniGame/KinkyDungeon/KinkyDungeonGame.js
+++ b/BondageClub/Screens/MiniGame/KinkyDungeon/KinkyDungeonGame.js
@@ -76,6 +76,8 @@ var KinkyDungeonDoorCloseTimer = 0;
 var KinkyDungeonLastMoveDirection = null;
 var KinkyDungeonTargetingSpell = null;
 
+var KinkyDungeonMaxLevel = 10; // Game stops when you reach this level
+
 function KinkyDungeonSetCheckPoint() {
 	MiniGameKinkyDungeonCheckpoint = Math.floor(MiniGameKinkyDungeonLevel / 10);
 }
@@ -892,7 +894,7 @@ function KinkyDungeonAdvanceTime(delta) {
 
 		KinkyDungeonSendActionMessage(10, TextGet("ClimbDown"), "#ffffff", 1);
 
-		if (MiniGameKinkyDungeonCheckpoint >= 1) {
+		if (MiniGameKinkyDungeonLevel >= KinkyDungeonMaxLevel) {
 			KinkyDungeonState = "End";
 			MiniGameVictory = true;
 		} else

--- a/BondageClub/Screens/Room/Arcade/Arcade.js
+++ b/BondageClub/Screens/Room/Arcade/Arcade.js
@@ -178,7 +178,7 @@ function ArcadeKinkyDungeonStart(PlayerLevel) {
 function ArcadeKinkyDungeonEnd() {
 	CommonSetScreen("Room", "Arcade");
 
-	if (MiniGameVictory) {
-		ReputationChange("Gaming", Math.max(ReputationGet("Gaming"), MiniGameKinkyDungeonCheckpoint));
-	}
+	//if (MiniGameVictory) {
+	
+	//}
 }


### PR DESCRIPTION
Dungeoneer is supposed to give the max level youve been to, but it instead just increases each level currently. This update fixes that and also adds a bit of cheat prevention (if it's higher than the max level it resets). This is to reset people's scores that are currently at 100 without theoretically penalizing anyone in the future because it is impossible to go above a certain level.