### PR TITLE
Bugfix: Locks breaking gag effects

### DIFF
--- a/BondageClub/Assets/Female3DCG/Female3DCGExtended.js
+++ b/BondageClub/Assets/Female3DCG/Female3DCGExtended.js
@@ -323,11 +323,17 @@ var AssetFemale3DCGExtended = {
 				Options: [
 					{
 						Name: "Normal",
-						Property: { Type: null },
+						Property: {
+							Type: null,
+							Effect: ["BlockMouth", "GagNormal"],
+						},
 					},
 					{
 						Name: "Tight",
-						Property: { Type: "Tight" },
+						Property: {
+							Type: "Tight",
+							Effect: ["BlockMouth", "GagNormal"],
+						},
 					},
 				],
 				Dialog: {
@@ -343,15 +349,24 @@ var AssetFemale3DCGExtended = {
 				Options: [
 					{
 						Name: "Normal",
-						Property: { Type: null },
+						Property: {
+							Type: null,
+							Effect: ["BlockMouth", "GagMedium"],
+						},
 					},
 					{
 						Name: "Shiny",
-						Property: { Type: "Shiny" },
+						Property: {
+							Type: "Shiny",
+							Effect: ["BlockMouth", "GagMedium"],
+						},
 					},
 					{
 						Name: "Tight",
-						Property: { Type: "Tight" },
+						Property: {
+							Type: "Tight",
+							Effect: ["BlockMouth", "GagMedium"],
+						},
 					},
 				],
 				Dialog: {
@@ -418,15 +433,24 @@ var AssetFemale3DCGExtended = {
 				Options: [
 					{
 						Name: "NoCup",
-						Property: { Type: null },
+						Property: {
+							Type: null,
+							Effect: ["BlockMouth", "GagEasy"],
+						},
 					},
 					{
 						Name: "Tip",
-						Property: { Type: null },
+						Property: {
+							Type: null,
+							Effect: ["BlockMouth", "GagEasy"],
+						},
 					},
 					{
 						Name: "Cup",
-						Property: { Type: "Cup" },
+						Property: {
+							Type: "Cup",
+							Effect: ["BlockMouth", "GagEasy"],
+						},
 					},
 				],
 				Dialog: {


### PR DESCRIPTION
## Summary

As part of #2388, I removed the `Property.Effect` arrays from a few gags where it was duplicating the asset's base `Effect` array. However, this causes the gag effects to stop working when a gag is locked, as locking it adds a `Property.Effect` array to the item which contains no gag effects. This reinstates the removed effects, and also adds effect arrays to the cupholder gag, which apparently has always suffered from this problem without anyone noticing.

## Steps to reproduce

For one of the modified gags (ball gag, wiffle gag, cupholder gag):
1. Equip the gag - note that the gag effect is properly applied
2. Optionally, change the gag's type
3. Lock the gag
4. Note that the gag no longer applies a gag effect in chat