### PR TITLE
Extended Options Validation Fix

### DIFF
--- a/BondageClub/Scripts/ExtendedItem.js
+++ b/BondageClub/Scripts/ExtendedItem.js
@@ -372,7 +372,7 @@ function ExtendedItemSelfProofRequirementCheck(C, Prerequisite) {
 
 	// Remove the item temporarily for prerequisite-checking
 	let CurrentItem = InventoryGet(C, C.FocusGroup.Name);
-	InventoryRemove(C, C.FocusGroup.Name);
+	InventoryRemove(C, C.FocusGroup.Name, false);
 
 	if (!InventoryAllow(C, Prerequisite, true)) {
 		Allowed = false;
@@ -382,7 +382,7 @@ function ExtendedItemSelfProofRequirementCheck(C, Prerequisite) {
 	let DifficultyFactor = CurrentItem.Difficulty - CurrentItem.Asset.Difficulty;
 	CharacterAppearanceSetItem(C, C.FocusGroup.Name, CurrentItem.Asset, CurrentItem.Color, DifficultyFactor, null, false);
 	InventoryGet(C, C.FocusGroup.Name).Property = CurrentItem.Property;
-	CharacterRefresh(C);
+	CharacterRefresh(C, false);
 	DialogFocusItem = InventoryGet(C, C.FocusGroup.Name);
 
 	return Allowed;


### PR DESCRIPTION
The extended item's self-blocking validation no longer pushes the temporary removal and reapplication of the item to the server.
This fixes a rare bug when two players are in the extended item options at the same time for an item with SelfBlockCheck options, e.g. Hemp Rope on arms. When one player tried to select an option while the other is still in the screen, their selection was incorrectly changed to the default option. The second player didn't get this change and was desynced.
This was also resetting the options' prerequisites memoization, causing it to unnecessarily re-check prerequisites every draw cycle.