### PR TITLE
Bugfix: Ensures pose refresh on loading wardrobe outfit

### DIFF
--- a/BondageClub/Screens/Character/Wardrobe/Wardrobe.js
+++ b/BondageClub/Screens/Character/Wardrobe/Wardrobe.js
@@ -251,6 +251,7 @@ function WardrobeFastLoad(C, W, Update) {
 				}
 			});
 		}
+		CharacterLoadPose(C);
 		CharacterLoadCanvas(C);
 		if (Update == null || Update) {
 			if (C.ID == 0 && C.OnlineID != null) ServerPlayerAppearanceSync();


### PR DESCRIPTION
## Summary

This fixes an issue with the appearance screen that's probably been around for a while where the character's pose would not be refreshed after loading a wardrobe outfit. This would result in visual issues with clothing items that set poses (e.g. the pencil skirt) as the player's pose inside the wardrobe would not get updated. In addition, if the player was inside their private room, their pose would remain broken on leaving the appearance screen.

## Steps to reproduce

This fixes a few issues:

1. Enter the appearance screen from anywhere (player pose should be the default pose)
2. Load an outfit which includes the pencil skirt
3. Note that the player's pose does not update

And in the player's private room:

1. Enter the wardrobe screen
2. Note that an outfit which includes the pencil skirt is not rendered properly (the pose is incorrect)
3. Load an outfit which includes the pencil skirt
4. Exit the wardrobe
5. Note that on leaving the wardrobe, the player's pose has not been updated (they are rendered with legs apart, but pencil skirt on)