### PR TITLE
Revert to Default Bugfix

### DIFF
--- a/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
+++ b/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
@@ -2438,7 +2438,7 @@ function ChatRoomSyncItem(data) {
 			ChatRoomAllowCharacterUpdate = false;
 			if (item) {
 				CharacterAppearanceSetItem(
-					ChatRoomCharacter[C], data.Item.Group, item.Asset, item.Color, item.Difficulty);
+					ChatRoomCharacter[C], data.Item.Group, item.Asset, item.Color, item.Difficulty, null, false);
 				InventoryGet(ChatRoomCharacter[C], data.Item.Group).Property = item.Property;
 			} else {
 				InventoryRemove(ChatRoomCharacter[C], data.Item.Group);


### PR DESCRIPTION
There was a rare bug where if two players opened an extended item's options screen at the same time, then one of them selected a new option, it was incorrectly changed to the default option. The other player did not receive this update and was desynced. This only seemed to happen for items where the default/first option was not the null type (i.e. arm ropes, chains and cuffs).