### PR TITLE
Bugfix: Ensures items get removed with timer locks

### DIFF
--- a/BondageClub/Scripts/Timer.js
+++ b/BondageClub/Scripts/Timer.js
@@ -55,7 +55,8 @@ function TimerInventoryRemove() {
 			for (let A = 0; A < Character[C].Appearance.length; A++)
 				if ((Character[C].Appearance[A].Property != null) && (Character[C].Appearance[A].Property.RemoveTimer != null))
 					if ((typeof Character[C].Appearance[A].Property.RemoveTimer == "number") && (Character[C].Appearance[A].Property.RemoveTimer <= CurrentTime)) {
-						var LockName = Character[C].Appearance[A].Property.LockedBy;
+						const LockName = Character[C].Appearance[A].Property.LockedBy;
+						const ShouldRemoveItem = Character[C].Appearance[A].Property.RemoveItem;
 
 						// Remove any lock or timer
 						ValidationDeleteLock(Character[C].Appearance[A].Property, false);
@@ -71,7 +72,7 @@ function TimerInventoryRemove() {
 						}
 
 						// If we must remove the linked item from the character or the facial expression
-						if ((Character[C].Appearance[A].Property.RemoveItem != null) && Character[C].Appearance[A].Property.RemoveItem && (Character[C].Appearance[A].Asset.Group.Category != null) && (Character[C].Appearance[A].Asset.Group.Category == "Item"))
+						if (ShouldRemoveItem && Character[C].Appearance[A].Asset.Group.Category === "Item")
 							InventoryRemove(Character[C], Character[C].Appearance[A].Asset.Group.Name);
 						else if (Character[C].Appearance[A].Asset.Group.AllowExpression != null)
 							CharacterSetFacialExpression(Character[C], Character[C].Appearance[A].Asset.Group.Name, null);


### PR DESCRIPTION
## Summary

The fix in #2341 meant that more properties were being removed from locked items on unlock than previously, including the `RemoveItem` property, which was later used in `Timer.js` to detect whether the locked item should be removed as well in the case of timer locks with a "Remove item when the lock timer runs out" checkbox, meaning that these locks would no longer remove the item upon expiry. This fixes that so that the redundant properties still get removed, but so does the item if the `RemoveItem` property was set.

## Steps to reproduce

1. Equip a lockable item and lock it with a Mistress, Lover or Owner Padlock
2. Inspect the lock and check the "Remove item when the lock timer runs out" checkbox
3. Wait for the lock timer to run out
4. Note that the lock gets removed, but the item does not