### PR TITLE
Refactor/Bugfix: Password lock refactors & UI improvements

### DIFF
--- a/BondageClub/Screens/Inventory/ItemMisc/PasswordPadlock/PasswordPadlock.js
+++ b/BondageClub/Screens/Inventory/ItemMisc/PasswordPadlock/PasswordPadlock.js
@@ -1,77 +1,98 @@
 "use strict";
 
+const InventoryItemMiscPasswordPadlockPasswordRegex = /^[A-Z]+$/;
+
 // Loads the item extension properties
 function InventoryItemMiscPasswordPadlockLoad() {
-	var C = CharacterGetCurrent();
-	if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property == null)) DialogFocusSourceItem.Property = {};
-	if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property != null) && (DialogFocusSourceItem.Property.Password == null)) DialogFocusSourceItem.Property.Password = "PASSWORD";
-	if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property != null) && (DialogFocusSourceItem.Property.Hint == null)) DialogFocusSourceItem.Property.Hint = "Take a guess...";
-	if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property != null) && (DialogFocusSourceItem.Property.LockSet == null)) DialogFocusSourceItem.Property.LockSet = false;
+	const C = CharacterGetCurrent();
+
+	if (DialogFocusSourceItem == null) return;
+
+	if (DialogFocusSourceItem.Property == null) DialogFocusSourceItem.Property = {};
+	const Property = DialogFocusSourceItem.Property;
+
+	if (Property.Password == null) Property.Password = "PASSWORD";
+	if (Property.Hint == null) Property.Hint = "Take a guess...";
+	if (Property.LockSet == null) Property.LockSet = false;
 
 	// Only create the inputs if the zone isn't blocked
 	if (!InventoryGroupIsBlocked(C, C.FocusGroup.Name)) {
-		if (DialogFocusSourceItem.Property && (DialogFocusSourceItem.Property.LockSet ||
-		(DialogFocusSourceItem.Property.LockMemberNumber && DialogFocusSourceItem.Property.LockMemberNumber != Player.MemberNumber))) {
+		if (InventoryItemMiscPasswordPadlockIsSet()) {
 			// Normal lock interface
 			ElementCreateInput("Password", "text", "", "8");
 			// the current code is shown for owners, lovers and the member whose number is on the padlock
-			if (DialogFocusSourceItem != null && ((Player.MemberNumber == DialogFocusSourceItem.Property.LockMemberNumber)
-				|| C.IsOwnedByPlayer() || C.IsLoverOfPlayer())) document.getElementById("Password").placeholder = DialogFocusSourceItem.Property.Password;
+			if (Player.MemberNumber == Property.LockMemberNumber ||
+				C.IsOwnedByPlayer() ||
+				C.IsLoverOfPlayer()
+			) {
+				document.getElementById("Password").placeholder = Property.Password;
+			}
 		} else {
 			// Set a password and hint
 			ElementCreateInput("SetHint", "text", "", "140");
 			ElementCreateInput("SetPassword", "text", "", "8");
 			// the current code is shown for owners, lovers and the member whose number is on the padlock
-			document.getElementById("SetPassword").placeholder = DialogFocusSourceItem.Property.Password;
-			document.getElementById("SetHint").placeholder = DialogFocusSourceItem.Property.Hint;
+			document.getElementById("SetPassword").placeholder = Property.Password;
+			document.getElementById("SetHint").placeholder = Property.Hint;
 		}
-
-
 	}
 }
 
 // Draw the extension screen
 function InventoryItemMiscPasswordPadlockDraw() {
-	var C = CharacterGetCurrent();
+	if (!DialogFocusSourceItem) return;
+	const { Property } = DialogFocusSourceItem;
+	const C = CharacterGetCurrent();
+
 	DrawAssetPreview(1387, 225, DialogFocusItem.Asset);
-	if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property != null) && (DialogFocusSourceItem.Property.LockMemberNumber != null))
-		DrawText(DialogFindPlayer("LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 600, "white", "gray");
+
+	if (Property && Property.LockMemberNumber != null) {
+		DrawText(
+			DialogFindPlayer("LockMemberNumber") + " " + Property.LockMemberNumber.toString(),
+			1500, 600, "white", "gray",
+		);
+	}
 
 	if (InventoryGroupIsBlocked(C, C.FocusGroup.Name)) {
 		// If the zone is blocked, just display some text informing the player that they can't access the lock
 		DrawText(DialogFindPlayer("LockZoneBlocked"), 1500, 800, "white", "gray");
 	} else {
-		if (DialogFocusSourceItem.Property && (DialogFocusSourceItem.Property.LockSet ||
-		(DialogFocusSourceItem.Property.LockMemberNumber && DialogFocusSourceItem.Property.LockMemberNumber != Player.MemberNumber))) {
-			// Normal lock interface
-			if (DialogFocusSourceItem && DialogFocusSourceItem.Property && DialogFocusSourceItem.Property.Hint)
-				DrawTextWrap("\"" + DialogFocusSourceItem.Property.Hint + "\"", 1000, 640, 1000, 120, null, null, 2);
-			MainCanvas.textAlign = "right";
-			DrawText(DialogFindPlayer("PasswordPadlockOld"), 1490, 805, "white", "gray");
-			ElementPosition("Password", 1640, 805, 250);
-			MainCanvas.textAlign = "center";
-			DrawButton(1370, 871, 250, 64, DialogFindPlayer("PasswordPadlockEnter"), "White", "");
-			if (PreferenceMessage != "") DrawText(DialogFindPlayer(PreferenceMessage), 1500, 963, "Red", "Black");
-		} else {
-			ElementPosition("SetHint", 1643, 700, 550);
-			ElementPosition("SetPassword", 1491, 770, 250);
-			MainCanvas.textAlign = "left";
-			DrawText(DialogFindPlayer("PasswordPadlockSetHint"), 1100, 703, "white", "gray");
-			DrawText(DialogFindPlayer("PasswordPadlockSetPassword"), 1100, 773, "white", "gray");
-			MainCanvas.textAlign = "center";
-			DrawButton(1360, 871, 250, 64, DialogFindPlayer("PasswordPadlockChangePassword"), "White", "");
-			if (PreferenceMessage != "") DrawText(DialogFindPlayer(PreferenceMessage), 1500, 963, "Red", "Black");
+		InventoryItemMiscPasswordPadlockDrawControls();
+	}
+}
+
+function InventoryItemMiscPasswordPadlockDrawControls() {
+	const { Property } = DialogFocusSourceItem;
+
+	if (InventoryItemMiscPasswordPadlockIsSet()) {
+		// Normal lock interface
+		if (Property && Property.Hint) {
+			DrawTextWrap("\"" + Property.Hint + "\"", 1000, 640, 1000, 120, null, null, 2);
 		}
+		MainCanvas.textAlign = "right";
+		DrawText(DialogFindPlayer("PasswordPadlockOld"), 1350, 810, "white", "gray");
+		ElementPosition("Password", 1643, 805, 550);
+		MainCanvas.textAlign = "center";
+		DrawButton(1360, 871, 250, 64, DialogFindPlayer("PasswordPadlockEnter"), "White", "");
+		if (PreferenceMessage != "") DrawText(DialogFindPlayer(PreferenceMessage), 1500, 963, "Red", "Black");
+	} else {
+		ElementPosition("SetHint", 1643, 700, 550);
+		ElementPosition("SetPassword", 1643, 770, 550);
+		MainCanvas.textAlign = "left";
+		DrawText(DialogFindPlayer("PasswordPadlockSetHint"), 1100, 705, "white", "gray");
+		DrawText(DialogFindPlayer("PasswordPadlockSetPassword"), 1100, 775, "white", "gray");
+		MainCanvas.textAlign = "center";
+		DrawButton(1360, 871, 250, 64, DialogFindPlayer("PasswordPadlockChangePassword"), "White", "");
+		if (PreferenceMessage != "") DrawText(DialogFindPlayer(PreferenceMessage), 1500, 963, "Red", "Black");
 	}
 }
 
 function InventoryItemMiscPasswordPadlockUnlock(C, Item) {
-	delete Item.Property.Password;
-	delete Item.Property.LockSet;
-	delete Item.Property.Hint;
 	for (let A = 0; A < C.Appearance.length; A++) {
-		if (C.Appearance[A].Asset.Group.Name == C.FocusGroup.Name)
+		if (C.Appearance[A].Asset.Group.Name == C.FocusGroup.Name) {
 			C.Appearance[A] = Item;
+			break;
+		}
 	}
 	InventoryUnlock(C, C.FocusGroup.Name);
 	ChatRoomPublishAction(C, Item, null, true, "ActionUnlock");
@@ -79,75 +100,69 @@ function InventoryItemMiscPasswordPadlockUnlock(C, Item) {
 
 // Catches the item extension clicks
 function InventoryItemMiscPasswordPadlockClick() {
-	var C = CharacterGetCurrent();
-	var Item = InventoryGet(C, C.FocusGroup.Name);
-
-	if ((MouseX >= 1360) && (MouseX <= 1950) && !InventoryGroupIsBlocked(C, C.FocusGroup.Name)) {
-
-
-		if (DialogFocusSourceItem.Property && (DialogFocusSourceItem.Property.LockSet ||
-		(DialogFocusSourceItem.Property.LockMemberNumber && DialogFocusSourceItem.Property.LockMemberNumber != Player.MemberNumber))) {
-
-				// Opens the padlock
-				if (MouseIn(1360, 871, 250, 64)) {
-					if (ElementValue("Password").toUpperCase() == DialogFocusSourceItem.Property.Password) {
-						InventoryItemMiscPasswordPadlockUnlock(C, DialogFocusSourceItem);
-						InventoryItemMiscPasswordPadlockExit();
-					}
-
-					// Send fail message if online
-					else if (CurrentScreen == "ChatRoom") {
-						let Dictionary = [];
-						Dictionary.push({Tag: "SourceCharacter", Text: Player.Name, MemberNumber: Player.MemberNumber});
-						Dictionary.push({Tag: "DestinationCharacter", Text: C.Name, MemberNumber: C.MemberNumber});
-						Dictionary.push({Tag: "FocusAssetGroup", AssetGroupName: C.FocusGroup.Name});
-						Dictionary.push({Tag: "Password", Text: ElementValue("Password")});
-						ChatRoomPublishCustomAction("PasswordFail", true, Dictionary);
-						InventoryItemMiscPasswordPadlockExit();
-					}
-					else { PreferenceMessage = "PasswordPadlockError"; }
-				}
-
-		} else {
-				if (MouseIn(1360, 871, 250, 64)) {
-					var pw = ElementValue("SetPassword").toUpperCase();
-					var hint =  ElementValue("SetHint");
-					var E = /^[A-Z]+$/;
-					// We only accept code made of letters
-					if (pw == "" || pw.match(E)) {
-						DialogFocusSourceItem.Property.LockSet = true;
-						if (pw != "") {
-							DialogFocusSourceItem.Property.Password = pw;
-						}
-						if (hint != "") {
-							DialogFocusSourceItem.Property.Hint = hint;
-						}
-						for (let A = 0; A < C.Appearance.length; A++) {
-							if (C.Appearance[A].Asset.Group.Name == C.FocusGroup.Name)
-								C.Appearance[A] = DialogFocusSourceItem;
-						}
-						if (CurrentScreen == "ChatRoom") {
-							let Dictionary = [];
-							Dictionary.push({Tag: "SourceCharacter", Text: Player.Name, MemberNumber: Player.MemberNumber});
-							Dictionary.push({Tag: "DestinationCharacter", Text: C.Name, MemberNumber: C.MemberNumber});
-							Dictionary.push({Tag: "FocusAssetGroup", AssetGroupName: C.FocusGroup.Name});
-							ChatRoomPublishCustomAction("PasswordChangeSuccess", true, Dictionary);
-							InventoryItemMiscPasswordPadlockExit();
-						}
-						else {
-							CharacterRefresh(C);
-							InventoryItemMiscPasswordPadlockExit();
-						}
-					}
-					else { PreferenceMessage = "PasswordPadlockErrorInput"; }
-
-				}
-		}
+	// Exits the screen
+	if (MouseIn(1885, 25, 90, 90)) {
+		return InventoryItemMiscPasswordPadlockExit();
 	}
 
-	// Exits the screen
-	if ((MouseX >= 1885) && (MouseX <= 1975) && (MouseY >= 25) && (MouseY <= 110)) {
-		InventoryItemMiscPasswordPadlockExit();
+	const C = CharacterGetCurrent();
+	if (InventoryGroupIsBlocked(C, C.FocusGroup.Name)) return;
+
+	InventoryItemMiscPasswordPadlockControlsClick(InventoryItemMiscPasswordPadlockExit);
+}
+
+function InventoryItemMiscPasswordPadlockControlsClick(ExitCallback) {
+	if (!DialogFocusSourceItem) return;
+	const { Property } = DialogFocusSourceItem;
+	const C = CharacterGetCurrent();
+
+	if (InventoryItemMiscPasswordPadlockIsSet() && MouseIn(1360, 871, 250, 64)) {
+		// Opens the padlock
+		if (ElementValue("Password").toUpperCase() == Property.Password) {
+			InventoryItemMiscPasswordPadlockUnlock(C, DialogFocusSourceItem);
+			ExitCallback();
+		}
+
+		// Send fail message if online
+		else if (CurrentScreen == "ChatRoom") {
+			const Dictionary = [
+				{ Tag: "SourceCharacter", Text: Player.Name, MemberNumber: Player.MemberNumber },
+				{ Tag: "DestinationCharacter", Text: C.Name, MemberNumber: C.MemberNumber },
+				{ Tag: "FocusAssetGroup", AssetGroupName: C.FocusGroup.Name },
+				{ Tag: "Password", Text: ElementValue("Password") },
+			];
+			ChatRoomPublishCustomAction("PasswordFail", true, Dictionary);
+			ExitCallback();
+		} else { PreferenceMessage = "PasswordPadlockError"; }
+	} else if (MouseIn(1360, 871, 250, 64)) {
+		const pw = ElementValue("SetPassword").toUpperCase();
+		const hint = ElementValue("SetHint");
+		// We only accept code made of letters
+		if (pw === "" || pw.match(InventoryItemMiscPasswordPadlockPasswordRegex)) {
+			Property.LockSet = true;
+			if (pw !== "") Property.Password = pw;
+			if (hint !== "") Property.Hint = hint;
+
+			for (let A = 0; A < C.Appearance.length; A++) {
+				if (C.Appearance[A].Asset.Group.Name == C.FocusGroup.Name) {
+					C.Appearance[A] = DialogFocusSourceItem;
+					break;
+				}
+			}
+
+			if (CurrentScreen == "ChatRoom") {
+				const Dictionary = [
+					{ Tag: "SourceCharacter", Text: Player.Name, MemberNumber: Player.MemberNumber },
+					{ Tag: "DestinationCharacter", Text: C.Name, MemberNumber: C.MemberNumber },
+					{ Tag: "FocusAssetGroup", AssetGroupName: C.FocusGroup.Name },
+				];
+				ChatRoomPublishCustomAction("PasswordChangeSuccess", true, Dictionary);
+				ExitCallback();
+			} else {
+				CharacterRefresh(C);
+				ExitCallback();
+			}
+		} else { PreferenceMessage = "PasswordPadlockErrorInput"; }
 	}
 }
 
@@ -157,5 +172,16 @@ function InventoryItemMiscPasswordPadlockExit() {
 	ElementRemove("SetHint");
 	PreferenceMessage = "";
 	DialogFocusItem = null;
-	if (DialogInventory != null) DialogMenuButtonBuild((Player.FocusGroup != null) ? Player : CurrentCharacter);
+	if (DialogInventory != null) DialogMenuButtonBuild(CharacterGetCurrent());
+}
+
+function InventoryItemMiscPasswordPadlockIsSet() {
+	if (!DialogFocusSourceItem || !DialogFocusSourceItem.Property) {
+		return false;
+	} else if (DialogFocusSourceItem.Property.LockSet) {
+		return true;
+	} else {
+		const { LockMemberNumber } = DialogFocusSourceItem.Property;
+		return LockMemberNumber != null && LockMemberNumber !== Player.MemberNumber;
+	}
 }

--- a/BondageClub/Screens/Inventory/ItemMisc/SafewordPadlock/SafewordPadlock.js
+++ b/BondageClub/Screens/Inventory/ItemMisc/SafewordPadlock/SafewordPadlock.js
@@ -1,7 +1,5 @@
 "use strict";
 
-const InventoryItemMiscSafewordPadlockPasswordRegex = /^[A-Z]+$/;
-
 // Loads the item extension properties
 function InventoryItemMiscSafewordPadlockLoad() {
 	const C = CharacterGetCurrent();
@@ -15,7 +13,7 @@ function InventoryItemMiscSafewordPadlockLoad() {
 	if (Property.Hint == null) Property.Hint = "Say the magic word...";
 	if (Property.LockSet == null) Property.LockSet = false;
 
-	if (InventoryItemMiscSafewordPadlockIsSet()) {
+	if (InventoryItemMiscPasswordPadlockIsSet()) {
 		// Normal lock interface
 		ElementCreateInput("Password", "text", "", "8");
 		// the current code is shown for owners, lovers and the member whose number is on the padlock
@@ -40,7 +38,7 @@ function InventoryItemMiscSafewordPadlockLoad() {
 // Draw the extension screen
 function InventoryItemMiscSafewordPadlockDraw() {
 	if (!DialogFocusSourceItem) return;
-	const Property = DialogFocusSourceItem.Property;
+	const { Property } = DialogFocusSourceItem;
 
 	DrawAssetPreview(1387, 225, DialogFocusItem.Asset);
 
@@ -51,38 +49,7 @@ function InventoryItemMiscSafewordPadlockDraw() {
 		);
 	}
 
-	if (InventoryItemMiscSafewordPadlockIsSet()) {
-		// Normal lock interface
-		if (Property.Hint) {
-			DrawTextWrap("\"" + Property.Hint + "\"", 1000, 640, 1000, 120, null, null, 2);
-		}
-		MainCanvas.textAlign = "right";
-		DrawText(DialogFindPlayer("PasswordPadlockOld"), 1350, 810, "white", "gray");
-		ElementPosition("Password", 1643, 805, 550);
-		MainCanvas.textAlign = "center";
-		DrawButton(1360, 871, 250, 64, DialogFindPlayer("PasswordPadlockEnter"), "White", "");
-		if (PreferenceMessage != "") DrawText(DialogFindPlayer(PreferenceMessage), 1500, 963, "Red", "Black");
-	} else {
-		ElementPosition("SetHint", 1643, 700, 550);
-		ElementPosition("SetPassword", 1643, 770, 550);
-		MainCanvas.textAlign = "left";
-		DrawText(DialogFindPlayer("PasswordPadlockSetHint"), 1100, 703, "white", "gray");
-		DrawText(DialogFindPlayer("PasswordPadlockSetPassword"), 1100, 773, "white", "gray");
-		MainCanvas.textAlign = "center";
-		DrawButton(1360, 871, 250, 64, DialogFindPlayer("PasswordPadlockChangePassword"), "White", "");
-		if (PreferenceMessage != "") DrawText(DialogFindPlayer(PreferenceMessage), 1500, 963, "Red", "Black");
-	}
-}
-
-function InventoryItemMiscSafewordPadlockUnlock(C, Item) {
-	for (let A = 0; A < C.Appearance.length; A++) {
-		if (C.Appearance[A].Asset.Group.Name == C.FocusGroup.Name) {
-			C.Appearance[A] = Item;
-			break;
-		}
-	}
-	InventoryUnlock(C, C.FocusGroup.Name);
-	ChatRoomPublishAction(C, Item, null, true, "ActionUnlock");
+	InventoryItemMiscPasswordPadlockDrawControls();
 }
 
 // Catches the item extension clicks
@@ -92,80 +59,9 @@ function InventoryItemMiscSafewordPadlockClick() {
 		return InventoryItemMiscSafewordPadlockExit();
 	}
 
-	if (!DialogFocusSourceItem) return;
-	const Property = DialogFocusSourceItem.Property;
-
-	const C = CharacterGetCurrent();
-
-	if (InventoryItemMiscSafewordPadlockIsSet()) {
-		// Opens the padlock
-		if (MouseIn(1360, 871, 250, 64)) {
-			if (ElementValue("Password").toUpperCase() == Property.Password) {
-				InventoryItemMiscSafewordPadlockUnlock(C, DialogFocusSourceItem);
-				InventoryItemMiscSafewordPadlockExit();
-			}
-
-			// Send fail message if online
-			else if (CurrentScreen == "ChatRoom") {
-				let Dictionary = [];
-				Dictionary.push({ Tag: "SourceCharacter", Text: Player.Name, MemberNumber: Player.MemberNumber });
-				Dictionary.push({ Tag: "DestinationCharacter", Text: C.Name, MemberNumber: C.MemberNumber });
-				Dictionary.push({ Tag: "FocusAssetGroup", AssetGroupName: C.FocusGroup.Name });
-				Dictionary.push({ Tag: "Password", Text: ElementValue("Password") });
-				ChatRoomPublishCustomAction("PasswordFail", true, Dictionary);
-				InventoryItemMiscSafewordPadlockExit();
-			} else { PreferenceMessage = "SafewordPadlockError"; }
-		}
-
-	} else {
-		if (MouseIn(1360, 871, 250, 64)) {
-			const pw = ElementValue("SetPassword").toUpperCase();
-			const hint = ElementValue("SetHint");
-			// We only accept code made of letters
-			if (pw == "" || pw.match(InventoryItemMiscSafewordPadlockPasswordRegex)) {
-				Property.LockSet = true;
-				if (pw != "") {
-					Property.Password = pw;
-				}
-				if (hint != "") {
-					Property.Hint = hint;
-				}
-				for (let A = 0; A < C.Appearance.length; A++) {
-					if (C.Appearance[A].Asset.Group.Name == C.FocusGroup.Name)
-						C.Appearance[A] = DialogFocusSourceItem;
-				}
-				if (CurrentScreen == "ChatRoom") {
-					let Dictionary = [];
-					Dictionary.push({ Tag: "SourceCharacter", Text: Player.Name, MemberNumber: Player.MemberNumber });
-					Dictionary.push({ Tag: "DestinationCharacter", Text: C.Name, MemberNumber: C.MemberNumber });
-					Dictionary.push({ Tag: "FocusAssetGroup", AssetGroupName: C.FocusGroup.Name });
-					ChatRoomPublishCustomAction("PasswordChangeSuccess", true, Dictionary);
-					InventoryItemMiscSafewordPadlockExit();
-				} else {
-					CharacterRefresh(C);
-					InventoryItemMiscSafewordPadlockExit();
-				}
-			} else { PreferenceMessage = "SafewordPadlockErrorInput"; }
-		}
-	}
+	InventoryItemMiscPasswordPadlockControlsClick(InventoryItemMiscSafewordPadlockExit);
 }
 
 function InventoryItemMiscSafewordPadlockExit() {
-	ElementRemove("Password");
-	ElementRemove("SetPassword");
-	ElementRemove("SetHint");
-	PreferenceMessage = "";
-	DialogFocusItem = null;
-	if (DialogInventory != null) DialogMenuButtonBuild((Player.FocusGroup != null) ? Player : CurrentCharacter);
-}
-
-function InventoryItemMiscSafewordPadlockIsSet() {
-	if (!DialogFocusSourceItem || !DialogFocusSourceItem.Property) {
-		return false;
-	} else if (DialogFocusSourceItem.Property.LockSet) {
-		return true;
-	} else {
-		const { LockMemberNumber } = DialogFocusSourceItem.Property;
-		return LockMemberNumber != null && LockMemberNumber !== Player.MemberNumber;
-	}
+	InventoryItemMiscPasswordPadlockExit();
 }

--- a/BondageClub/Screens/Inventory/ItemMisc/SafewordPadlock/SafewordPadlock.js
+++ b/BondageClub/Screens/Inventory/ItemMisc/SafewordPadlock/SafewordPadlock.js
@@ -2,12 +2,11 @@
 
 // Loads the item extension properties
 function InventoryItemMiscSafewordPadlockLoad() {
-	const C = CharacterGetCurrent();
+	if (!DialogFocusItem || !DialogFocusSourceItem) return InventoryItemMiscSafewordPadlockExit();
 
-	if (DialogFocusSourceItem == null) return;
-
-	if (DialogFocusSourceItem.Property == null) DialogFocusSourceItem.Property = {};
+	if (!DialogFocusSourceItem.Property) DialogFocusSourceItem.Property = {};
 	const Property = DialogFocusSourceItem.Property;
+	const C = CharacterGetCurrent();
 
 	if (Property.Password == null) Property.Password = "PLEASE";
 	if (Property.Hint == null) Property.Hint = "Say the magic word...";
@@ -18,7 +17,8 @@ function InventoryItemMiscSafewordPadlockLoad() {
 		ElementCreateInput("Password", "text", "", "8");
 		// the current code is shown for owners, lovers and the member whose number is on the padlock
 		// It is also shown for the person who is bound by it
-		if (C.ID == 0 ||
+		if (
+			C.ID === 0 ||
 			Player.MemberNumber === Property.LockMemberNumber ||
 			C.IsOwnedByPlayer() ||
 			C.IsLoverOfPlayer()
@@ -38,7 +38,7 @@ function InventoryItemMiscSafewordPadlockLoad() {
 // Draw the extension screen
 function InventoryItemMiscSafewordPadlockDraw() {
 	if (!DialogFocusSourceItem) return;
-	const { Property } = DialogFocusSourceItem;
+	const Property = DialogFocusSourceItem.Property;
 
 	DrawAssetPreview(1387, 225, DialogFocusItem.Asset);
 

--- a/BondageClub/Screens/Inventory/ItemMisc/SafewordPadlock/SafewordPadlock.js
+++ b/BondageClub/Screens/Inventory/ItemMisc/SafewordPadlock/SafewordPadlock.js
@@ -1,55 +1,70 @@
 "use strict";
 
+const InventoryItemMiscSafewordPadlockPasswordRegex = /^[A-Z]+$/;
+
 // Loads the item extension properties
 function InventoryItemMiscSafewordPadlockLoad() {
-	var C = CharacterGetCurrent();
-	if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property == null)) DialogFocusSourceItem.Property = {};
-	if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property != null) && (DialogFocusSourceItem.Property.Password == null)) DialogFocusSourceItem.Property.Password = "PLEASE";
-	if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property != null) && (DialogFocusSourceItem.Property.Hint == null)) DialogFocusSourceItem.Property.Hint = "Say the magic word...";
-	if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property != null) && (DialogFocusSourceItem.Property.LockSet == null)) DialogFocusSourceItem.Property.LockSet = false;
+	const C = CharacterGetCurrent();
 
-	if (DialogFocusSourceItem.Property && (DialogFocusSourceItem.Property.LockSet ||
-	(DialogFocusSourceItem.Property.LockMemberNumber && DialogFocusSourceItem.Property.LockMemberNumber != Player.MemberNumber))) {
+	if (DialogFocusSourceItem == null) return;
+
+	if (DialogFocusSourceItem.Property == null) DialogFocusSourceItem.Property = {};
+	const Property = DialogFocusSourceItem.Property;
+
+	if (Property.Password == null) Property.Password = "PLEASE";
+	if (Property.Hint == null) Property.Hint = "Say the magic word...";
+	if (Property.LockSet == null) Property.LockSet = false;
+
+	if (InventoryItemMiscSafewordPadlockIsSet()) {
 		// Normal lock interface
 		ElementCreateInput("Password", "text", "", "8");
 		// the current code is shown for owners, lovers and the member whose number is on the padlock
 		// It is also shown for the person who is bound by it
-		if (DialogFocusSourceItem != null && (C.ID == 0 || (Player.MemberNumber == DialogFocusSourceItem.Property.LockMemberNumber)
-			|| C.IsOwnedByPlayer() || C.IsLoverOfPlayer())) document.getElementById("Password").placeholder = DialogFocusSourceItem.Property.Password;
+		if (C.ID == 0 ||
+			Player.MemberNumber === Property.LockMemberNumber ||
+			C.IsOwnedByPlayer() ||
+			C.IsLoverOfPlayer()
+		) {
+			document.getElementById("Password").placeholder = Property.Password;
+		}
 	} else {
 		// Set a password and hint
 		ElementCreateInput("SetHint", "text", "", "140");
 		ElementCreateInput("SetPassword", "text", "", "8");
 		// the current code is shown for owners, lovers and the member whose number is on the padlock
-		document.getElementById("SetPassword").placeholder = DialogFocusSourceItem.Property.Password;
-		document.getElementById("SetHint").placeholder = DialogFocusSourceItem.Property.Hint;
+		document.getElementById("SetPassword").placeholder = Property.Password;
+		document.getElementById("SetHint").placeholder = Property.Hint;
 	}
-
 }
 
 // Draw the extension screen
 function InventoryItemMiscSafewordPadlockDraw() {
-	var C = CharacterGetCurrent();
+	if (!DialogFocusSourceItem) return;
+	const Property = DialogFocusSourceItem.Property;
+
 	DrawAssetPreview(1387, 225, DialogFocusItem.Asset);
 
-	if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property != null) && (DialogFocusSourceItem.Property.LockMemberNumber != null))
-		DrawText(DialogFindPlayer("LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 600, "white", "gray");
+	if (Property && Property.LockMemberNumber != null) {
+		DrawText(
+			DialogFindPlayer("LockMemberNumber") + " " + Property.LockMemberNumber.toString(),
+			1500, 600, "white", "gray",
+		);
+	}
 
-
-	if (DialogFocusSourceItem.Property && (DialogFocusSourceItem.Property.LockSet ||
-	(DialogFocusSourceItem.Property.LockMemberNumber && DialogFocusSourceItem.Property.LockMemberNumber != Player.MemberNumber))) {
+	if (InventoryItemMiscSafewordPadlockIsSet()) {
 		// Normal lock interface
-		if (DialogFocusSourceItem && DialogFocusSourceItem.Property && DialogFocusSourceItem.Property.Hint)
-			DrawTextWrap("\"" + DialogFocusSourceItem.Property.Hint + "\"", 1000, 640, 1000, 120, null, null, 2);
+		if (Property.Hint) {
+			DrawTextWrap("\"" + Property.Hint + "\"", 1000, 640, 1000, 120, null, null, 2);
+		}
 		MainCanvas.textAlign = "right";
-		DrawText(DialogFindPlayer("PasswordPadlockOld"), 1490, 805, "white", "gray");
-		ElementPosition("Password", 1640, 805, 250);
+		DrawText(DialogFindPlayer("PasswordPadlockOld"), 1350, 810, "white", "gray");
+		ElementPosition("Password", 1643, 805, 550);
 		MainCanvas.textAlign = "center";
-		DrawButton(1370, 871, 250, 64, DialogFindPlayer("PasswordPadlockEnter"), "White", "");
+		DrawButton(1360, 871, 250, 64, DialogFindPlayer("PasswordPadlockEnter"), "White", "");
 		if (PreferenceMessage != "") DrawText(DialogFindPlayer(PreferenceMessage), 1500, 963, "Red", "Black");
 	} else {
 		ElementPosition("SetHint", 1643, 700, 550);
-		ElementPosition("SetPassword", 1491, 770, 250);
+		ElementPosition("SetPassword", 1643, 770, 550);
 		MainCanvas.textAlign = "left";
 		DrawText(DialogFindPlayer("PasswordPadlockSetHint"), 1100, 703, "white", "gray");
 		DrawText(DialogFindPlayer("PasswordPadlockSetPassword"), 1100, 773, "white", "gray");
@@ -60,12 +75,11 @@ function InventoryItemMiscSafewordPadlockDraw() {
 }
 
 function InventoryItemMiscSafewordPadlockUnlock(C, Item) {
-	delete Item.Property.Password;
-	delete Item.Property.LockSet;
-	delete Item.Property.Hint;
 	for (let A = 0; A < C.Appearance.length; A++) {
-		if (C.Appearance[A].Asset.Group.Name == C.FocusGroup.Name)
+		if (C.Appearance[A].Asset.Group.Name == C.FocusGroup.Name) {
 			C.Appearance[A] = Item;
+			break;
+		}
 	}
 	InventoryUnlock(C, C.FocusGroup.Name);
 	ChatRoomPublishAction(C, Item, null, true, "ActionUnlock");
@@ -73,75 +87,66 @@ function InventoryItemMiscSafewordPadlockUnlock(C, Item) {
 
 // Catches the item extension clicks
 function InventoryItemMiscSafewordPadlockClick() {
-	var C = CharacterGetCurrent();
-	var Item = InventoryGet(C, C.FocusGroup.Name);
-
-	if ((MouseX >= 1360) && (MouseX <= 1950)) {
-
-
-		if (DialogFocusSourceItem.Property && (DialogFocusSourceItem.Property.LockSet ||
-		(DialogFocusSourceItem.Property.LockMemberNumber && DialogFocusSourceItem.Property.LockMemberNumber != Player.MemberNumber))) {
-
-				// Opens the padlock
-				if (MouseIn(1360, 871, 250, 64)) {
-					if (ElementValue("Password").toUpperCase() == DialogFocusSourceItem.Property.Password) {
-						InventoryItemMiscSafewordPadlockUnlock(C, DialogFocusSourceItem);
-						InventoryItemMiscSafewordPadlockExit();
-					}
-
-					// Send fail message if online
-					else if (CurrentScreen == "ChatRoom") {
-						let Dictionary = [];
-						Dictionary.push({Tag: "SourceCharacter", Text: Player.Name, MemberNumber: Player.MemberNumber});
-						Dictionary.push({Tag: "DestinationCharacter", Text: C.Name, MemberNumber: C.MemberNumber});
-						Dictionary.push({Tag: "FocusAssetGroup", AssetGroupName: C.FocusGroup.Name});
-						Dictionary.push({Tag: "Password", Text: ElementValue("Password")});
-						ChatRoomPublishCustomAction("PasswordFail", true, Dictionary);
-						InventoryItemMiscSafewordPadlockExit();
-					}
-					else { PreferenceMessage = "SafewordPadlockError"; }
-				}
-
-		} else {
-				if (MouseIn(1360, 871, 250, 64)) {
-					var pw = ElementValue("SetPassword").toUpperCase();
-					var hint =  ElementValue("SetHint");
-					var E = /^[A-Z]+$/;
-					// We only accept code made of letters
-					if (pw == "" || pw.match(E)) {
-						DialogFocusSourceItem.Property.LockSet = true;
-						if (pw != "") {
-							DialogFocusSourceItem.Property.Password = pw;
-						}
-						if (hint != "") {
-							DialogFocusSourceItem.Property.Hint = hint;
-						}
-						for (let A = 0; A < C.Appearance.length; A++) {
-							if (C.Appearance[A].Asset.Group.Name == C.FocusGroup.Name)
-								C.Appearance[A] = DialogFocusSourceItem;
-						}
-						if (CurrentScreen == "ChatRoom") {
-							let Dictionary = [];
-							Dictionary.push({Tag: "SourceCharacter", Text: Player.Name, MemberNumber: Player.MemberNumber});
-							Dictionary.push({Tag: "DestinationCharacter", Text: C.Name, MemberNumber: C.MemberNumber});
-							Dictionary.push({Tag: "FocusAssetGroup", AssetGroupName: C.FocusGroup.Name});
-							ChatRoomPublishCustomAction("PasswordChangeSuccess", true, Dictionary);
-							InventoryItemMiscSafewordPadlockExit();
-						}
-						else {
-							CharacterRefresh(C);
-							InventoryItemMiscSafewordPadlockExit();
-						}
-					}
-					else { PreferenceMessage = "SafewordPadlockErrorInput"; }
-
-				}
-		}
+	// Exits the screen
+	if (MouseIn(1885, 25, 90, 90)) {
+		return InventoryItemMiscSafewordPadlockExit();
 	}
 
-	// Exits the screen
-	if ((MouseX >= 1885) && (MouseX <= 1975) && (MouseY >= 25) && (MouseY <= 110)) {
-		InventoryItemMiscSafewordPadlockExit();
+	if (!DialogFocusSourceItem) return;
+	const Property = DialogFocusSourceItem.Property;
+
+	const C = CharacterGetCurrent();
+
+	if (InventoryItemMiscSafewordPadlockIsSet()) {
+		// Opens the padlock
+		if (MouseIn(1360, 871, 250, 64)) {
+			if (ElementValue("Password").toUpperCase() == Property.Password) {
+				InventoryItemMiscSafewordPadlockUnlock(C, DialogFocusSourceItem);
+				InventoryItemMiscSafewordPadlockExit();
+			}
+
+			// Send fail message if online
+			else if (CurrentScreen == "ChatRoom") {
+				let Dictionary = [];
+				Dictionary.push({ Tag: "SourceCharacter", Text: Player.Name, MemberNumber: Player.MemberNumber });
+				Dictionary.push({ Tag: "DestinationCharacter", Text: C.Name, MemberNumber: C.MemberNumber });
+				Dictionary.push({ Tag: "FocusAssetGroup", AssetGroupName: C.FocusGroup.Name });
+				Dictionary.push({ Tag: "Password", Text: ElementValue("Password") });
+				ChatRoomPublishCustomAction("PasswordFail", true, Dictionary);
+				InventoryItemMiscSafewordPadlockExit();
+			} else { PreferenceMessage = "SafewordPadlockError"; }
+		}
+
+	} else {
+		if (MouseIn(1360, 871, 250, 64)) {
+			const pw = ElementValue("SetPassword").toUpperCase();
+			const hint = ElementValue("SetHint");
+			// We only accept code made of letters
+			if (pw == "" || pw.match(InventoryItemMiscSafewordPadlockPasswordRegex)) {
+				Property.LockSet = true;
+				if (pw != "") {
+					Property.Password = pw;
+				}
+				if (hint != "") {
+					Property.Hint = hint;
+				}
+				for (let A = 0; A < C.Appearance.length; A++) {
+					if (C.Appearance[A].Asset.Group.Name == C.FocusGroup.Name)
+						C.Appearance[A] = DialogFocusSourceItem;
+				}
+				if (CurrentScreen == "ChatRoom") {
+					let Dictionary = [];
+					Dictionary.push({ Tag: "SourceCharacter", Text: Player.Name, MemberNumber: Player.MemberNumber });
+					Dictionary.push({ Tag: "DestinationCharacter", Text: C.Name, MemberNumber: C.MemberNumber });
+					Dictionary.push({ Tag: "FocusAssetGroup", AssetGroupName: C.FocusGroup.Name });
+					ChatRoomPublishCustomAction("PasswordChangeSuccess", true, Dictionary);
+					InventoryItemMiscSafewordPadlockExit();
+				} else {
+					CharacterRefresh(C);
+					InventoryItemMiscSafewordPadlockExit();
+				}
+			} else { PreferenceMessage = "SafewordPadlockErrorInput"; }
+		}
 	}
 }
 
@@ -152,4 +157,15 @@ function InventoryItemMiscSafewordPadlockExit() {
 	PreferenceMessage = "";
 	DialogFocusItem = null;
 	if (DialogInventory != null) DialogMenuButtonBuild((Player.FocusGroup != null) ? Player : CurrentCharacter);
+}
+
+function InventoryItemMiscSafewordPadlockIsSet() {
+	if (!DialogFocusSourceItem || !DialogFocusSourceItem.Property) {
+		return false;
+	} else if (DialogFocusSourceItem.Property.LockSet) {
+		return true;
+	} else {
+		const { LockMemberNumber } = DialogFocusSourceItem.Property;
+		return LockMemberNumber != null && LockMemberNumber !== Player.MemberNumber;
+	}
 }

--- a/BondageClub/Screens/Inventory/ItemMisc/TimerPasswordPadlock/TimerPasswordPadlock.js
+++ b/BondageClub/Screens/Inventory/ItemMisc/TimerPasswordPadlock/TimerPasswordPadlock.js
@@ -1,271 +1,249 @@
 "use strict";
 
-
-var PasswordTimerChooseList = [5, 10, 15, 30, 60, 120, 180, 240, -180, -120, -60, -30, -15];
-var PasswordTimerChooseIndex = 0;
-
+const PasswordTimerChooseList = [5, 10, 15, 30, 60, 120, 180, 240, -180, -120, -60, -30, -15];
+let PasswordTimerChooseIndex = 0;
 
 // Loads the item extension properties
 function InventoryItemMiscTimerPasswordPadlockLoad() {
-	var C = CharacterGetCurrent();
-	if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property == null)) DialogFocusSourceItem.Property = {};
-	if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property != null) && (DialogFocusSourceItem.Property.Password == null)) DialogFocusSourceItem.Property.Password = "PASSWORD";
-	if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property != null) && (DialogFocusSourceItem.Property.Hint == null)) DialogFocusSourceItem.Property.Hint = "Take a guess...";
-	if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property != null) && (DialogFocusSourceItem.Property.LockSet == null)) DialogFocusSourceItem.Property.LockSet = false;
-    if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property != null) && (DialogFocusSourceItem.Property.RemoveItem == null)) DialogFocusSourceItem.Property.RemoveItem = false;
-    if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property != null) && (DialogFocusSourceItem.Property.ShowTimer == null)) DialogFocusSourceItem.Property.ShowTimer = true;
-    if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property != null) && (DialogFocusSourceItem.Property.EnableRandomInput == null)) DialogFocusSourceItem.Property.EnableRandomInput = false;
-    if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property != null) && (DialogFocusSourceItem.Property.MemberNumberList == null)) DialogFocusSourceItem.Property.MemberNumberList = [];
+	if (!DialogFocusSourceItem) return;
+
+	if (!DialogFocusSourceItem.Property) DialogFocusSourceItem.Property = {};
+	const Property = DialogFocusSourceItem.Property;
+	const C = CharacterGetCurrent();
+
+	if (Property.Password == null) Property.Password = "PASSWORD";
+	if (Property.Hint == null) Property.Hint = "Take a guess...";
+	if (Property.LockSet == null) Property.LockSet = false;
+	if (Property.RemoveItem == null) Property.RemoveItem = false;
+	if (Property.ShowTimer == null) Property.ShowTimer = true;
+	if (Property.EnableRandomInput == null) Property.EnableRandomInput = false;
+	if (Property.MemberNumberList == null) Property.MemberNumberList = [];
 
 	// Only create the inputs if the zone isn't blocked
-	if (!InventoryGroupIsBlocked(C, C.FocusGroup.Name)) {
-		if (DialogFocusSourceItem.Property && (DialogFocusSourceItem.Property.LockSet ||
-		(DialogFocusSourceItem.Property.LockMemberNumber && DialogFocusSourceItem.Property.LockMemberNumber != Player.MemberNumber))) {
-			// Normal lock interface
-			ElementCreateInput("Password", "text", "", "8");
-			// the current code is shown for owners, lovers and the member whose number is on the padlock
-			if (DialogFocusSourceItem != null && ((Player.MemberNumber == DialogFocusSourceItem.Property.LockMemberNumber)
-				|| C.IsOwnedByPlayer() || C.IsLoverOfPlayer())) document.getElementById("Password").placeholder = DialogFocusSourceItem.Property.Password;
-		} else {
-			// Set a password and hint
-			ElementCreateInput("SetHint", "text", "", "140");
-			ElementCreateInput("SetPassword", "text", "", "8");
-			// the current code is shown for owners, lovers and the member whose number is on the padlock
-			document.getElementById("SetPassword").placeholder = DialogFocusSourceItem.Property.Password;
-			document.getElementById("SetHint").placeholder = DialogFocusSourceItem.Property.Hint;
+	if (InventoryGroupIsBlocked(C, C.FocusGroup.Name)) return;
+
+	// Only create the inputs if the zone isn't blocked
+	if (InventoryItemMiscPasswordPadlockIsSet()) {
+		// Normal lock interface
+		ElementCreateInput("Password", "text", "", "8");
+		// the current code is shown for owners, lovers and the member whose number is on the padlock
+		if (
+			Player.MemberNumber === Property.LockMemberNumber ||
+			C.IsOwnedByPlayer() ||
+			C.IsLoverOfPlayer()
+		) {
+			document.getElementById("Password").placeholder = Property.Password;
 		}
-
-
+	} else {
+		// Set a password and hint
+		ElementCreateInput("SetHint", "text", "", "140");
+		ElementCreateInput("SetPassword", "text", "", "8");
+		// the current code is shown for owners, lovers and the member whose number is on the padlock
+		document.getElementById("SetPassword").placeholder = DialogFocusSourceItem.Property.Password;
+		document.getElementById("SetHint").placeholder = DialogFocusSourceItem.Property.Hint;
 	}
 }
 
 // Draw the extension screen
 function InventoryItemMiscTimerPasswordPadlockDraw() {
-    if ((DialogFocusItem == null) || (DialogFocusSourceItem.Property.RemoveTimer < CurrentTime)) { InventoryItemMiscTimerPasswordPadlockExit(); return; }
-    if (DialogFocusSourceItem.Property.ShowTimer) {
-        DrawText(DialogFindPlayer("TimerLeft") + " " + TimerToString(DialogFocusSourceItem.Property.RemoveTimer - CurrentTime), 1500, 100, "white", "gray");
-    } else { DrawText(DialogFindPlayer("TimerUnknown"), 1500, 150, "white", "gray"); }
-	var C = CharacterGetCurrent();
+	if (
+		!DialogFocusItem ||
+		!DialogFocusSourceItem ||
+		!DialogFocusSourceItem.Property ||
+		DialogFocusSourceItem.Property.RemoveTimer < CurrentTime
+	) {
+		return InventoryItemMiscTimerPasswordPadlockExit();
+	}
+
+	const Property = DialogFocusSourceItem.Property;
+	const C = CharacterGetCurrent();
+
+	if (Property && Property.ShowTimer) {
+		DrawText(DialogFindPlayer("TimerLeft") + " " +
+			TimerToString(Property.RemoveTimer - CurrentTime), 1500, 100, "white", "gray");
+	} else {
+		DrawText(DialogFindPlayer("TimerUnknown"), 1500, 150, "white", "gray");
+	}
+
 	DrawAssetPreview(1387, 175, DialogFocusItem.Asset);
-	if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property != null) && (DialogFocusSourceItem.Property.LockMemberNumber != null))
-	DrawText(DialogFindPlayer("LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 500, "white", "gray");
+
+	if (Property && Property.LockMemberNumber != null) {
+		const Text = DialogFindPlayer("LockMemberNumber") + " " + Property.LockMemberNumber;
+		DrawText(Text, 1500, 500, "white", "gray");
+	}
 
 	if (InventoryGroupIsBlocked(C, C.FocusGroup.Name)) {
 		// If the zone is blocked, just display some text informing the player that they can't access the lock
 		DrawText(DialogFindPlayer("LockZoneBlocked"), 1500, 550, "white", "gray");
-	} else {
-		if (DialogFocusSourceItem.Property && (DialogFocusSourceItem.Property.LockSet ||
-		(DialogFocusSourceItem.Property.LockMemberNumber && DialogFocusSourceItem.Property.LockMemberNumber != Player.MemberNumber))) {
-			// Normal lock interface
-			if (DialogFocusSourceItem && DialogFocusSourceItem.Property && DialogFocusSourceItem.Property.Hint)
-				DrawText("\"" + DialogFocusSourceItem.Property.Hint + "\"", 1500, 550, "white", "gray");
-			MainCanvas.textAlign = "right";
-			DrawText(DialogFindPlayer("PasswordPadlockOld"), 1390, 605, "white", "gray");
-			ElementPosition("Password", 1540, 605, 250);
-			MainCanvas.textAlign = "center";
-			DrawButton(1670, 580, 250, 64, DialogFindPlayer("PasswordPadlockEnter"), "White", "");
-			if (PreferenceMessage != "") DrawText(DialogFindPlayer(PreferenceMessage), 1500, 200, "Red", "Black");
-		} else {
-			ElementPosition("SetHint", 1643, 550, 550);
-			ElementPosition("SetPassword", 1491, 620, 250);
-			MainCanvas.textAlign = "left";
-			DrawText(DialogFindPlayer("PasswordPadlockSetHint"), 1100, 553, "white", "gray");
-			DrawText(DialogFindPlayer("PasswordPadlockSetPassword"), 1100, 623, "white", "gray");
-			MainCanvas.textAlign = "center";
-			DrawButton(1653, 593, 250, 64, DialogFindPlayer("PasswordPadlockChangePassword"), "White", "");
-			if (PreferenceMessage != "") DrawText(DialogFindPlayer(PreferenceMessage), 1500, 200, "Red", "Black");
-		}
+		return;
 	}
 
-	// Copied from mistress timer padlock and modified
+	if (InventoryItemMiscPasswordPadlockIsSet()) {
+		// Normal lock interface
+		if (Property && Property.Hint) {
+			DrawText("\"" + Property.Hint + "\"", 1500, 550, "white", "gray");
+		}
+		MainCanvas.textAlign = "right";
+		DrawText(DialogFindPlayer("PasswordPadlockOld"), 1390, 610, "white", "gray");
+		ElementPosition("Password", 1585, 605, 350);
+		MainCanvas.textAlign = "center";
+		DrawButton(1775, 575, 200, 64, DialogFindPlayer("PasswordPadlockEnter"), "White", "");
+		if (PreferenceMessage != "") DrawText(DialogFindPlayer(PreferenceMessage), 1500, 200, "Red", "Black");
+	} else {
+		ElementPosition("SetHint", 1675, 550, 600);
+		ElementPosition("SetPassword", 1563, 620, 375);
+		MainCanvas.textAlign = "left";
+		DrawText(DialogFindPlayer("PasswordPadlockSetHint"), 1100, 553, "white", "gray");
+		DrawText(DialogFindPlayer("PasswordPadlockSetPassword"), 1100, 623, "white", "gray");
+		MainCanvas.textAlign = "center";
+		DrawButton(1765, 591, 200, 64, DialogFindPlayer("PasswordPadlockChangePassword"), "White", "");
+		if (PreferenceMessage != "") DrawText(DialogFindPlayer(PreferenceMessage), 1500, 200, "Red", "Black");
+	}
 
 	// Draw the settings
-    if (Player.CanInteract() && (Player.MemberNumber == DialogFocusSourceItem.Property.LockMemberNumber)) {
-        MainCanvas.textAlign = "left";
-        DrawButton(1100, 666, 64, 64, "", "White", (DialogFocusSourceItem.Property.RemoveItem) ? "Icons/Checked.png" : "");
-        DrawText(DialogFindPlayer("RemoveItemWithTimer"), 1200, 698, "white", "gray");
-        DrawButton( 1100, 746, 64, 64, "", "White", (DialogFocusSourceItem.Property.ShowTimer) ? "Icons/Checked.png" : "");
-        DrawText(DialogFind(Player,"ShowItemWithTimerRemaining"), 1200, 778, "white", "gray");
-        DrawButton(1100, 828, 64, 64, "", "White", (DialogFocusSourceItem.Property.EnableRandomInput) ? "Icons/Checked.png" : "");
-        DrawText(DialogFindPlayer("EnableRandomInput"), 1200, 858, "white", "gray");
-        MainCanvas.textAlign = "center";
-    } else {
-        if ((DialogFocusSourceItem != null) && (DialogFocusSourceItem.Property != null) && (DialogFocusSourceItem.Property.LockMemberNumber != null))
-            DrawText(DialogFindPlayer("LockMemberNumber") + " " + DialogFocusSourceItem.Property.LockMemberNumber.toString(), 1500, 700, "white", "gray");
-        DrawText(DialogFindPlayer((DialogFocusSourceItem.Property.RemoveItem) ? "WillRemoveItemWithTimer" : "WontRemoveItemWithTimer"), 1500, 868, "white", "gray");
-    }
-
-    // Draw buttons to add/remove time if available
-    if (Player.CanInteract() && (Player.MemberNumber == DialogFocusSourceItem.Property.LockMemberNumber)) {
-        DrawButton(1100, 910, 250, 70, DialogFindPlayer("AddTimerTime"), "White");
-        DrawBackNextButton(1400, 910, 250, 70, PasswordTimerChooseList[PasswordTimerChooseIndex] + " " + DialogFindPlayer("Minutes"), "White", "",
-            () => PasswordTimerChooseList[(PasswordTimerChooseList.length + PasswordTimerChooseIndex - 1) % PasswordTimerChooseList.length] + " " + DialogFindPlayer("Minutes"),
-            () => PasswordTimerChooseList[(PasswordTimerChooseIndex + 1) % PasswordTimerChooseList.length] + " " + DialogFindPlayer("Minutes"));
-    }
-    else if (Player.CanInteract() && DialogFocusSourceItem.Property.EnableRandomInput) {
-        for (let I = 0; I < DialogFocusSourceItem.Property.MemberNumberList.length; I++) {
-            if (DialogFocusSourceItem.Property.MemberNumberList[I] == Player.MemberNumber) return;
-        }
-        DrawButton(1100, 910, 250, 70, "- " + DialogFocusItem.Asset.RemoveTimer * 3 / 60 + " " + DialogFindPlayer("Minutes"), "White");
-        DrawButton(1400, 910, 250, 70, DialogFindPlayer("Random"), "White");
-        DrawButton(1700, 910, 250, 70, "+ " + DialogFocusItem.Asset.RemoveTimer * 3 / 60 + " " + DialogFindPlayer("Minutes"), "White");
-    }
-}
-
-function InventoryItemMiscTimerPasswordPadlockUnlock(C, Item) {
-	delete Item.Property.Password;
-	delete Item.Property.LockSet;
-	delete Item.Property.Hint;
-	for (let A = 0; A < C.Appearance.length; A++) {
-		if (C.Appearance[A].Asset.Group.Name == C.FocusGroup.Name)
-			C.Appearance[A] = Item;
+	if (Player.CanInteract() && (Player.MemberNumber == Property.LockMemberNumber)) {
+		MainCanvas.textAlign = "left";
+		DrawCheckbox(1100, 666, 64, 64, DialogFindPlayer("RemoveItemWithTimer"), Property.RemoveItem, false, "#fff");
+		DrawCheckbox(
+			1100, 746, 64, 64, DialogFindPlayer("ShowItemWithTimerRemaining"), Property.ShowTimer, false, "#fff");
+		DrawCheckbox(
+			1100, 828, 64, 64, DialogFindPlayer("EnableRandomInput"), Property.EnableRandomInput, false, "#fff");
+		MainCanvas.textAlign = "center";
+	} else {
+		const RemoveTextKey = (Property.RemoveItem) ? "WillRemoveItemWithTimer" : "WontRemoveItemWithTimer";
+		DrawText(DialogFindPlayer(RemoveTextKey), 1500, 868, "white", "gray");
 	}
-	InventoryUnlock(C, C.FocusGroup.Name);
-	ChatRoomPublishAction(C, Item, null, true, "ActionUnlock");
+
+	const Minutes = DialogFindPlayer("Minutes");
+	// Draw buttons to add/remove time if available
+	if (Player.CanInteract() && (Player.MemberNumber == Property.LockMemberNumber)) {
+		DrawButton(1100, 910, 250, 70, DialogFindPlayer("AddTimerTime"), "White");
+		DrawBackNextButton(1400, 910, 250, 70,
+			PasswordTimerChooseList[PasswordTimerChooseIndex] + " " + Minutes,
+			"White",
+			"",
+			() => PasswordTimerChooseList[(PasswordTimerChooseList.length + PasswordTimerChooseIndex - 1) %
+			PasswordTimerChooseList.length] + " " + Minutes,
+			() => PasswordTimerChooseList[(PasswordTimerChooseIndex + 1) % PasswordTimerChooseList.length] + " " +
+				Minutes,
+		);
+	} else if (Player.CanInteract() && Property.EnableRandomInput) {
+		for (let I = 0; I < Property.MemberNumberList.length; I++) {
+			if (Property.MemberNumberList[I] == Player.MemberNumber) return;
+		}
+		const TimeButtonSuffix = `${DialogFocusItem.Asset.RemoveTimer * 3 / 60} ${Minutes}`;
+		DrawButton(1100, 910, 250, 70, `- ${TimeButtonSuffix}`, "White");
+		DrawButton(1400, 910, 250, 70, DialogFindPlayer("Random"), "White");
+		DrawButton(1700, 910, 250, 70, `+ ${TimeButtonSuffix}`, "White");
+	}
 }
 
 // Catches the item extension clicks
 function InventoryItemMiscTimerPasswordPadlockClick() {
-	var C = CharacterGetCurrent();
-	var Item = InventoryGet(C, C.FocusGroup.Name);
-
 	// Exits the screen
-	if ((MouseX >= 1885) && (MouseX <= 1975) && (MouseY >= 25) && (MouseY <= 110)) {
+	if (MouseIn(1885, 25, 90, 90)) {
 		InventoryItemMiscTimerPasswordPadlockExit();
 	}
 
-	if ((MouseX >= 1360) && (MouseX <= 1950) && !InventoryGroupIsBlocked(C, C.FocusGroup.Name)) {
+	if (!DialogFocusSourceItem) return;
+	const Property = DialogFocusSourceItem.Property;
+	const C = CharacterGetCurrent();
 
+	if (InventoryGroupIsBlocked(C, C.FocusGroup.Name)) return;
 
-		if (DialogFocusSourceItem.Property && (DialogFocusSourceItem.Property.LockSet ||
-		(DialogFocusSourceItem.Property.LockMemberNumber && DialogFocusSourceItem.Property.LockMemberNumber != Player.MemberNumber))) {
-
-				// Opens the padlock
-				if (MouseIn(1670, 580, 250, 64)) {
-					if (ElementValue("Password").toUpperCase() == DialogFocusSourceItem.Property.Password) {
-						InventoryItemMiscTimerPasswordPadlockUnlock(C, DialogFocusSourceItem);
-						InventoryItemMiscTimerPasswordPadlockExit();
-					}
-
-					// Send fail message if online
-					else if (CurrentScreen == "ChatRoom") {
-						let Dictionary = [];
-						Dictionary.push({Tag: "SourceCharacter", Text: Player.Name, MemberNumber: Player.MemberNumber});
-						Dictionary.push({Tag: "DestinationCharacter", Text: C.Name, MemberNumber: C.MemberNumber});
-						Dictionary.push({Tag: "FocusAssetGroup", AssetGroupName: C.FocusGroup.Name});
-						Dictionary.push({Tag: "Password", Text: ElementValue("Password")});
-						ChatRoomPublishCustomAction("PasswordFail", true, Dictionary);
-						InventoryItemMiscTimerPasswordPadlockExit();
-					}
-					else { PreferenceMessage = "PasswordPadlockError"; }
-				}
-
-		} else {
-				if (MouseIn(1653, 593, 250, 64)) {
-					var pw = ElementValue("SetPassword").toUpperCase();
-					var hint =  ElementValue("SetHint");
-					var E = /^[A-Z]+$/;
-					// We only accept code made of letters
-					if (pw == "" || pw.match(E)) {
-						DialogFocusSourceItem.Property.LockSet = true;
-						if (pw != "") {
-							DialogFocusSourceItem.Property.Password = pw;
-						}
-						if (hint != "") {
-							DialogFocusSourceItem.Property.Hint = hint;
-						}
-						for (let A = 0; A < C.Appearance.length; A++) {
-							if (C.Appearance[A].Asset.Group.Name == C.FocusGroup.Name)
-								C.Appearance[A] = DialogFocusSourceItem;
-						}
-						if (CurrentScreen == "ChatRoom") {
-							let Dictionary = [];
-							Dictionary.push({Tag: "SourceCharacter", Text: Player.Name, MemberNumber: Player.MemberNumber});
-							Dictionary.push({Tag: "DestinationCharacter", Text: C.Name, MemberNumber: C.MemberNumber});
-							Dictionary.push({Tag: "FocusAssetGroup", AssetGroupName: C.FocusGroup.Name});
-							ChatRoomPublishCustomAction("PasswordChangeSuccess", true, Dictionary);
-							InventoryItemMiscTimerPasswordPadlockExit();
-						}
-						else {
-							CharacterRefresh(C);
-							InventoryItemMiscTimerPasswordPadlockExit();
-						}
-					}
-					else { PreferenceMessage = "PasswordPadlockErrorInput"; }
-
-				}
-		}
+	if (InventoryItemMiscPasswordPadlockIsSet() && MouseIn(1775, 575, 200, 64)) {
+		InventoryItemMiscPasswordPadlockHandleOpenClick(InventoryItemMiscTimerPasswordPadlockExit);
+	} else if (MouseIn(1765, 591, 200, 64)) {
+		InventoryItemMiscPasswordPadlockHandleFirstSet(InventoryItemMiscTimerPasswordPadlockExit);
 	}
 
 	// Copied from mistress timer padlock
 
-		if (!Player.CanInteract()) return;
+	if (!Player.CanInteract()) return;
 
-		if (Player.MemberNumber == DialogFocusSourceItem.Property.LockMemberNumber) {
-			if ((MouseX >= 1100) && (MouseX <= 1164)) {
-				if ((MouseY >= 666) && (MouseY <= 730)) { DialogFocusSourceItem.Property.RemoveItem = !(DialogFocusSourceItem.Property.RemoveItem); }
-				if ((MouseY >= 746) && (MouseY <= 810)) { DialogFocusSourceItem.Property.ShowTimer = !(DialogFocusSourceItem.Property.ShowTimer); }
-				if ((MouseY >= 826) && (MouseY <= 890)) { DialogFocusSourceItem.Property.EnableRandomInput = !(DialogFocusSourceItem.Property.EnableRandomInput); }
-				if (CurrentScreen == "ChatRoom") ChatRoomCharacterItemUpdate(CharacterGetCurrent());
+	if (Player.MemberNumber === Property.LockMemberNumber) {
+		if (MouseXIn(1100, 64)) {
+			let Update = true;
+			if (MouseYIn(666, 64)) {
+				Property.RemoveItem = !Property.RemoveItem;
+			} else if (MouseYIn(746, 64)) {
+				Property.ShowTimer = !Property.ShowTimer;
+			} else if (MouseYIn(826, 64)) {
+				Property.EnableRandomInput = !Property.EnableRandomInput;
+			} else {
+				Update = false;
 			}
+			if (Update && CurrentScreen == "ChatRoom") ChatRoomCharacterItemUpdate(C);
 		}
+	}
 
-		if ((MouseY >= 910) && (MouseY <= 980)) {
-			if (Player.MemberNumber == DialogFocusSourceItem.Property.LockMemberNumber) {
-				if ((MouseX >= 1100) && (MouseX < 1350)) InventoryItemMiscTimerPasswordPadlockAdd(PasswordTimerChooseList[PasswordTimerChooseIndex] * 60, false);
-				if ((MouseX >= 1400) && (MouseX < 1650)) {
-					if (MouseX <= 1525) PasswordTimerChooseIndex = (PasswordTimerChooseList.length + PasswordTimerChooseIndex - 1) % PasswordTimerChooseList.length;
-					else PasswordTimerChooseIndex = (PasswordTimerChooseIndex + 1) % PasswordTimerChooseList.length;
+	if (MouseYIn(910, 70)) {
+		if (Player.MemberNumber === Property.LockMemberNumber) {
+			if (MouseXIn(1100, 250)) {
+				InventoryItemMiscTimerPasswordPadlockAdd(PasswordTimerChooseList[PasswordTimerChooseIndex] * 60, false);
+			} else if (MouseXIn(1400, 250)) {
+				if (MouseX <= 1525) {
+					PasswordTimerChooseIndex = (PasswordTimerChooseList.length + PasswordTimerChooseIndex - 1) %
+						PasswordTimerChooseList.length;
+				} else {
+					PasswordTimerChooseIndex = (PasswordTimerChooseIndex + 1) % PasswordTimerChooseList.length;
 				}
 			}
-			else if (DialogFocusSourceItem.Property.EnableRandomInput) {
-				for (let I = 0; I < DialogFocusSourceItem.Property.MemberNumberList.length; I++) {
-					if (DialogFocusSourceItem.Property.MemberNumberList[I] == Player.MemberNumber) return;
-				}
-				if ((MouseX >= 1100) && (MouseX < 1350)) { InventoryItemMiscTimerPasswordPadlockAdd(-DialogFocusItem.Asset.RemoveTimer * 2, true); }
-				if ((MouseX >= 1400) && (MouseX < 1650)) { InventoryItemMiscTimerPasswordPadlockAdd(DialogFocusItem.Asset.RemoveTimer * 4 * ((Math.random() >= 0.5) ? 1 : -1), true); }
-				if ((MouseX >= 1700) && (MouseX < 1950)) { InventoryItemMiscTimerPasswordPadlockAdd(DialogFocusItem.Asset.RemoveTimer * 2, true); }
+		} else if (Property.EnableRandomInput) {
+			for (let I = 0; I < Property.MemberNumberList.length; I++) {
+				if (Property.MemberNumberList[I] == Player.MemberNumber) return;
 			}
+			const RemoveTimer = DialogFocusItem.Asset.RemoveTimer;
+			let TimeToAdd = 0;
+			if (MouseXIn(1100, 250)) TimeToAdd = -RemoveTimer * 2;
+			else if (MouseXIn(1400, 250)) TimeToAdd = RemoveTimer * 4 * ((Math.random() >= 0.5) ? 1 : -1);
+			else if (MouseXIn(1700, 250)) TimeToAdd = RemoveTimer * 2;
+
+			if (TimeToAdd) InventoryItemMiscTimerPasswordPadlockAdd(TimeToAdd, true);
 		}
-
-
+	}
 }
 
 // When a value is added to the timer, can be a negative one
 function InventoryItemMiscTimerPasswordPadlockAdd(TimeToAdd, PlayerMemberNumberToList) {
-    if (PlayerMemberNumberToList) DialogFocusSourceItem.Property.MemberNumberList.push(Player.MemberNumber);
-    var TimerBefore = DialogFocusSourceItem.Property.RemoveTimer;
-    if (DialogFocusItem.Asset.RemoveTimer > 0) DialogFocusSourceItem.Property.RemoveTimer = Math.round(Math.min(DialogFocusSourceItem.Property.RemoveTimer + (TimeToAdd * 1000), CurrentTime + (DialogFocusItem.Asset.MaxTimer * 1000)));
-    var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
-    if (CurrentScreen == "ChatRoom") {
-        var timeAdded = (DialogFocusSourceItem.Property.RemoveTimer - TimerBefore) / (1000 * 60);
-        var msg = ((timeAdded < 0) && DialogFocusSourceItem.Property.ShowTimer ? "TimerRemoveTime" : "TimerAddTime");
-        var Dictionary = [];
-        Dictionary.push({Tag: "SourceCharacter", Text: Player.Name, MemberNumber: Player.MemberNumber});
-        Dictionary.push({Tag: "DestinationCharacter", Text: C.Name, MemberNumber: C.MemberNumber});
-        if (DialogFocusSourceItem.Property.ShowTimer) {
-            Dictionary.push({Tag: "TimerTime", Text: Math.round(Math.abs(timeAdded))});
-            Dictionary.push({Tag: "TimerUnit", TextToLookUp: "Minutes"});
-        } else {
-            Dictionary.push({Tag: "TimerTime", TextToLookUp: "TimerAddRemoveUnknownTime"});
-            Dictionary.push({Tag: "TimerUnit", Text: ""});
-        }
-        Dictionary.push({Tag: "FocusAssetGroup", AssetGroupName: C.FocusGroup.Name});
+	const Property = DialogFocusSourceItem.Property;
+	const C = CharacterGetCurrent();
 
-        for (let A = 0; A < C.Appearance.length; A++) {
-            if (C.Appearance[A].Asset.Group.Name == C.FocusGroup.Name)
-                C.Appearance[A] = DialogFocusSourceItem;
-        }
-        ChatRoomPublishCustomAction(msg, true, Dictionary);
-    } else { CharacterRefresh(C); }
-    InventoryItemMiscTimerPasswordPadlockExit();
+	if (PlayerMemberNumberToList) Property.MemberNumberList.push(Player.MemberNumber);
+	const TimerBefore = Property.RemoveTimer;
+	if (DialogFocusItem.Asset.RemoveTimer > 0) Property.RemoveTimer = Math.round(
+		Math.min(Property.RemoveTimer + (TimeToAdd * 1000), CurrentTime + (DialogFocusItem.Asset.MaxTimer * 1000)));
+	if (CurrentScreen === "ChatRoom") {
+		const timeAdded = (Property.RemoveTimer - TimerBefore) / (1000 * 60);
+		const msg = ((timeAdded < 0) && Property.ShowTimer ? "TimerRemoveTime" : "TimerAddTime");
+		const Dictionary = [
+			{ Tag: "SourceCharacter", Text: Player.Name, MemberNumber: Player.MemberNumber },
+			{ Tag: "DestinationCharacter", Text: C.Name, MemberNumber: C.MemberNumber },
+			{ Tag: "FocusAssetGroup", AssetGroupName: C.FocusGroup.Name },
+		];
+		if (Property.ShowTimer) {
+			Dictionary.push({ Tag: "TimerTime", Text: Math.round(Math.abs(timeAdded)) });
+			Dictionary.push({ Tag: "TimerUnit", TextToLookUp: "Minutes" });
+		} else {
+			Dictionary.push({ Tag: "TimerTime", TextToLookUp: "TimerAddRemoveUnknownTime" });
+			Dictionary.push({ Tag: "TimerUnit", Text: "" });
+		}
+
+		for (let A = 0; A < C.Appearance.length; A++) {
+			if (C.Appearance[A].Asset.Group.Name == C.FocusGroup.Name) {
+				C.Appearance[A] = DialogFocusSourceItem;
+				break;
+			}
+		}
+
+		ChatRoomPublishCustomAction(msg, true, Dictionary);
+	} else {
+		CharacterRefresh(C);
+	}
+
+	InventoryItemMiscTimerPasswordPadlockExit();
 }
 
 function InventoryItemMiscTimerPasswordPadlockExit() {
-	ElementRemove("Password");
-	ElementRemove("SetPassword");
-	ElementRemove("SetHint");
-	PreferenceMessage = "";
-	DialogFocusItem = null;
-	if (DialogInventory != null) DialogMenuButtonBuild((Player.FocusGroup != null) ? Player : CurrentCharacter);
+	InventoryItemMiscPasswordPadlockExit();
 }

--- a/BondageClub/Screens/Inventory/ItemMisc/TimerPasswordPadlock/TimerPasswordPadlock.js
+++ b/BondageClub/Screens/Inventory/ItemMisc/TimerPasswordPadlock/TimerPasswordPadlock.js
@@ -157,8 +157,6 @@ function InventoryItemMiscTimerPasswordPadlockClick() {
 		InventoryItemMiscPasswordPadlockHandleFirstSet(InventoryItemMiscTimerPasswordPadlockExit);
 	}
 
-	// Copied from mistress timer padlock
-
 	if (!Player.CanInteract()) return;
 
 	if (Player.MemberNumber === Property.LockMemberNumber) {

--- a/BondageClub/Screens/Inventory/ItemMouth/FuturisticPanelGag/FuturisticPanelGag.js
+++ b/BondageClub/Screens/Inventory/ItemMouth/FuturisticPanelGag/FuturisticPanelGag.js
@@ -136,13 +136,13 @@ function InventoryItemMouthFuturisticPanelGagClickAccessDenied() {
 		var pw = ElementValue("PasswordField").toUpperCase();
 		if (DialogFocusItem && DialogFocusItem.Property && DialogFocusItem.Property.LockedBy == "PasswordPadlock" && pw == DialogFocusItem.Property.Password) {
 			let C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
-			InventoryItemMiscPasswordPadlockUnlock(C, DialogFocusItem);
+			CommonPadlockUnlock(C, DialogFocusItem);
 			DialogFocusItem = null;
 			Player.FocusGroup = null;
 			InventoryItemMouthFuturisticPanelGagExit();
 		} else if (DialogFocusItem && DialogFocusItem.Property && DialogFocusItem.Property.LockedBy == "TimerPasswordPadlock" && pw == DialogFocusItem.Property.Password) {
 			let C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
-			InventoryItemMiscTimerPasswordPadlockUnlock(C, DialogFocusItem);
+			CommonPadlockUnlock(C, DialogFocusItem);
 			DialogFocusItem = null;
 			Player.FocusGroup = null;
 			InventoryItemMouthFuturisticPanelGagExit();

--- a/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
+++ b/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
@@ -1515,8 +1515,8 @@ function ChatRoomSendChat() {
 /**
  * Publishes common player actions (add, remove, swap) to the chat.
  * @param {Character} C - Character on which the action is done.
- * @param {Asset} StruggleProgressPrevItem - The item that has been removed.
- * @param {Asset} StruggleProgressNextItem - The item that has been added.
+ * @param {Item} StruggleProgressPrevItem - The item that has been removed.
+ * @param {Item} StruggleProgressNextItem - The item that has been added.
  * @param {boolean} LeaveDialog - Whether to leave the current dialog after publishing the action.
  * @param {string} [Action] - Action modifier
  * @returns {void} - Nothing.
@@ -1563,7 +1563,7 @@ function ChatRoomPublishAction(C, StruggleProgressPrevItem, StruggleProgressNext
 /**
  * Updates an item on character for everyone in a chat room - replaces ChatRoomCharacterUpdate to cut on the lag.
  * @param {Character} C - Character to update.
- * @param {string} Group - Item group to update.
+ * @param {string} [Group] - Item group to update.
  * @returns {void} - Nothing.
  */
 function ChatRoomCharacterItemUpdate(C, Group) {

--- a/BondageClub/Scripts/Common.js
+++ b/BondageClub/Scripts/Common.js
@@ -775,3 +775,21 @@ function CommonArrayConcatDedupe(dest, src) {
 		}
 	}
 }
+
+/**
+ * Common function for removing a padlock from an item and publishing a corresponding chat message (must be called with
+ * the item's group focused)
+ * @param {Character} C - The character on whom the item is equipped
+ * @param {Item} Item - The item to unlock
+ * @returns {void} - Nothing
+ */
+function CommonPadlockUnlock(C, Item) {
+	for (let A = 0; A < C.Appearance.length; A++) {
+		if (C.Appearance[A].Asset.Group.Name === C.FocusGroup.Name) {
+			C.Appearance[A] = Item;
+			break;
+		}
+	}
+	InventoryUnlock(C, C.FocusGroup.Name);
+	ChatRoomPublishAction(C, Item, null, true, "ActionUnlock");
+}

--- a/BondageClub/Scripts/Drawing.js
+++ b/BondageClub/Scripts/Drawing.js
@@ -1219,8 +1219,8 @@ function DrawProcess() {
  * @param {number} X - Position of the preview box on the X axis
  * @param {number} Y - Position of the preview box on the Y axis
  * @param {Asset} A - The asset to draw the preview for
- * @Param {object} [Options] - Additional optional drawing options
- * @param {Character} Options.[C] - The character using the item (used to calculate dynamic item descriptions/previews)
+ * @param {object} [Options] - Additional optional drawing options
+ * @param {Character} [Options.C] - The character using the item (used to calculate dynamic item descriptions/previews)
  * @param {string} [Options.Description] - The preview box description
  * @param {string} [Options.Background] - The background color to draw the preview box in - defaults to white
  * @param {string} [Options.Foreground] - The foreground (text) color to draw the description in - defaults to black

--- a/BondageClub/Scripts/Inventory.js
+++ b/BondageClub/Scripts/Inventory.js
@@ -589,7 +589,7 @@ function InventoryGroupIsBlockedForCharacter(C, GroupName, Activity) {
 * Similar to InventoryGroupIsBlockedForCharacter but also blocks groups on all characters if the player is enclosed.
 * @param {Character} C - The character on which we validate the group
 * @param {String} GroupName - The name of the asset group (body area)
-* @param {Boolean} Activity - if TRUE check if activity is allowed on the asset group
+* @param {Boolean} [Activity] - if TRUE check if activity is allowed on the asset group
 * @returns {Boolean} - TRUE if the group is blocked
 */
 function InventoryGroupIsBlocked(C, GroupName, Activity) {
@@ -812,7 +812,7 @@ function InventoryLock(C, Item, Lock, MemberNumber, Update = true) {
 /**
 * Unlocks an item and removes all related properties
 * @param {Character} C - The character on which the item must be unlocked
-* @param {Item} Item - The item from appearance to unlock
+* @param {Item|string} Item - The item from appearance to unlock
 */
 function InventoryUnlock(C, Item) {
 	if (typeof Item === 'string') Item = InventoryGet(C, Item);


### PR DESCRIPTION
## Summary

This was originally just going to be a slight UI fix to the password padlocks (password, safeword & timer password), but whilst I was in there, I noticed that there was a lot of code duplication and general inefficiencies in the code for the password padlocks, and ended up refactoring them. This PR does a bunch of things, but should not affect the behaviour of the padlocks themselves from a player perspective:

* Fixes an issue where the password inputs weren't wide enough to accommodate all possible passwords (passwords containing several wide letters like 'm' and 'w' could result in a letter or two getting cut off, which is particularly bothersome with the safeword padlock, as it prevents most players from being able to unlock it). This particular issue has now been fixed for the safeword padlock in #2478, although that hotfix didn't address the other two locks.
* Fixes an issue with the timer password padlock where clicking in certain areas could trigger chatroom item updates, despite nothing changing
* Fixes a handful of inaccurate click zones on the interfaces for all three locks
* Changes the password timer padlock so that the timer functionality is not available when the zone is blocked. I did this because when the zone is blocked, half of the padlock's interface becomes unavailable, but the other half doesn't, which I don't feel makes a lot of sense - I've therefore chosen to hide it in line with the standard password padlock
* Removes a duplicated lock member number display from the UI for the timer password padlock (duplicated when the lock has been set to allow random input and a player other than the wearer/lock-setter inspects the lock)
* Refactors a lot of common code around the three password padlocks into common functions that are shared between all three
* Reworks a lot of old code to remove inefficiencies and make use of newer functions like `MouseIn` and `CharacterGetCurrent`, and makes some general readability improvements
* Fixes the JSDoc in a handful of adjacent functions, where my IDE had flagged issues

I've tested all three locks pretty thoroughly, and as far as I can tell, they all behave as they did before.