### PR TITLE
Bugfix: Item update rollback mitigation

### DIFF
--- a/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
+++ b/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
@@ -2443,20 +2443,21 @@ function ChatRoomSyncItem(data) {
 			} else {
 				InventoryRemove(ChatRoomCharacter[C], data.Item.Group);
 			}
-			CharacterRefresh(ChatRoomCharacter[C], false);
-
-
-			// Keeps the change in the chat room data and allows the character to be updated again
-			for (let R = 0; R < ChatRoomData.Character.length; R++)
-				if (ChatRoomData.Character[R].MemberNumber == data.Item.Target)
-					ChatRoomData.Character[R].Appearance = ChatRoomCharacter[C].Appearance;
-			ChatRoomAllowCharacterUpdate = true;
 
 			// If the update was invalid, send a correction update
 			if (ChatRoomCharacter[C].ID === 0 && !valid) {
 				console.warn(`Invalid appearance update to group ${data.Item.Group}. Updating with sanitized appearance.`);
 				ChatRoomCharacterUpdate(ChatRoomCharacter[C]);
+			} else {
+				CharacterRefresh(ChatRoomCharacter[C]);
 			}
+
+			// Keeps the change in the chat room data and allows the character to be updated again
+			for (let R = 0; R < ChatRoomData.Character.length; R++) {
+				if (ChatRoomData.Character[R].MemberNumber == data.Item.Target)
+					ChatRoomData.Character[R].Appearance = ChatRoomCharacter[C].Appearance;
+			}
+			ChatRoomAllowCharacterUpdate = true;
 
 			return;
 		}


### PR DESCRIPTION
## Summary

This PR mitigates a longstanding issue with the handling of `ChatRoomCharacterItemUpdate` messages on the server. At the moment, whereas a `ChatRoomCharacterUpdate` call persists the character's new appearance to the DB, `ChatRoomCharacterItemUpdate` calls don't, which results in items and locks sometimes disappearing after a player relogs if no `CharacterRefresh` or `ChatRoomCharacterUpdate` calls are made before they log out.

This modifies the `ChatRoomSyncItem` function so that it syncs its `CharacterRefresh` call if the update is not invalid, which means that a player's appearance will be persisted to the DB on receiving a valid `ChatRoomSyncItem` message. While this issue isn't directly caused by this release, it might be a nice one to hotfix as it's relatively small and impacts players fairly frequently.

It's important to note that this should be considered a temporary fix. Ultimately, we should probably be looking to change `ChatRoomCharacterItemUpdate` so that it actually persists its appearance changes properly.

## Steps to reproduce

There are a handful of ways to reproduce the issue:

1. Player B equips a non-extended item on player A
2. Player A immediately refreshes the game and relogs
3. The item has disappeared

And with locks:

1. Player B locks an existing item on player A
2. Player A immediately refreshes the game and relogs
3. The lock has disappeared

And item types:

1. Player B changes the type of an existing extended typed item on player A
2. Player A immediately refreshes the game and relogs
3. The item's type has reverted to its previous value