### PR TITLE
Bugfix: `SetPose` property validation

### DIFF
--- a/BondageClub/Assets/Female3DCG/Female3DCG.js
+++ b/BondageClub/Assets/Female3DCG/Female3DCG.js
@@ -4431,6 +4431,12 @@ var PoseFemale3DCG = [
 	},
 ];
 
+/**
+ * List of all available pose names in the game
+ * @constant {string[]}
+ */
+var PoseFemale3DCGNames = PoseFemale3DCG.map(pose => pose.Name);
+
 // 3D Custom Girl based activities
 var ActivityFemale3DCG = [
 	{

--- a/BondageClub/Scripts/Validation.js
+++ b/BondageClub/Scripts/Validation.js
@@ -477,6 +477,7 @@ function ValidationSanitizeProperties(C, item) {
 	// Sanitize various properties
 	let changed = ValidationSanitizeEffects(C, item);
 	changed = ValidationSanitizeBlocks(C, item) || changed;
+	changed = ValidationSanitizeSetPose(C, item) || changed;
 	changed = ValidationSanitizeStringArray(property, "Hide") || changed;
 
 	const asset = item.Asset;
@@ -700,6 +701,32 @@ function ValidationSanitizeBlocks(C, item) {
 	property.Block = property.Block.filter((block) => {
 		if (!assetBlock.includes(block) && !allowBlock.includes(block)) {
 			console.warn(`Filtering out invalid Block entry on ${item.Asset.Name}:`, block);
+			changed = true;
+			return false;
+		} else return true;
+	});
+	return changed;
+}
+
+/**
+ * Sanitizes the `SetPose` array on an item's Property object, if present. This ensures that it is a valid array of
+ * strings, and that each item in the array is present in the list of poses available in the game.
+ * @param {Character} C - The character on whom the item is equipped
+ * @param {Item} item - The item whose `SetPose` property should be sanitized
+ * @returns {boolean} - TRUE if the item's `SetPose` property was modified as part of the sanitization process
+ * (indicating it was not a valid string array, or that invalid entries were present), FALSE otherwise
+ */
+function ValidationSanitizeSetPose(C, item) {
+	const property = item.Property;
+	let changed = ValidationSanitizeStringArray(property, "SetPose");
+
+	// If there is no SetPose array, no further sanitization is needed
+	if (!Array.isArray(property.SetPose)) return changed;
+
+	// The SetPose array must contain a list of valid pose names
+	property.SetPose = property.SetPose.filter((pose) => {
+		if (!PoseFemale3DCGNames.includes(pose)) {
+			console.warn(`Filtering out invalid SetPose entry on ${item.Asset.Name}:`, pose);
 			changed = true;
 			return false;
 		} else return true;


### PR DESCRIPTION
## Summary

It is currently possible to use console to set the `SetPose` array on an item's `Property` to a value other than an array, which can cause another player's game to crash when they click on the character with the offending property (or if the property is set on them). This adds a sanitization check in `Validation.js` which ensures that `SetPose` entries on an item's property are valid string arrays, whose entries are all valid pose names.

## Steps to reproduce

1. Equip an extended item on a character
2. Using console, set `Property = {SetPose: "Broken"}` on the item
3. Note that the game will crash for the player on whom the property was set, and for anyone else, clicking on that character will crash their game, with the following stack trace:

```
Character.js:720 Uncaught TypeError: SetPose.find is not a function
    at CharacterItemsHavePoseAvailable (Character.js:720)
    at CharacterCanChangeToPose (Character.js:696)
    at Object.CanChangeToPose (Character.js:244)
    at CharacterCanKneel (Character.js:1421)
    at Object.CanKneel (Character.js:72)
    at ChatRoomMenuDraw (ChatRoom.js:1155)
    at ChatRoomRun (ChatRoom.js:1100)
    at DrawProcess (Drawing.js:1202)
    at MainRun ((index):385)
CharacterItemsHavePoseAvailable @ Character.js:720
CharacterCanChangeToPose @ Character.js:696
CanChangeToPose @ Character.js:244
CharacterCanKneel @ Character.js:1421
CanKneel @ Character.js:72
ChatRoomMenuDraw @ ChatRoom.js:1155
ChatRoomRun @ ChatRoom.js:1100
DrawProcess @ Drawing.js:1202
MainRun @ (index):385
requestAnimationFrame (async)
TimerProcess @ Timer.js:252
MainRun @ (index):386
```