### PR TITLE
Preserve scroll location in TextAreaChatLog on window resize

### DIFF
--- a/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
+++ b/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
@@ -81,27 +81,31 @@ var ChatRoomMenuButtons = [];
  let ChatRoomResizeManager = {
 	atStart : true, // Is this the first event in a chain of resize events?
 	timer : null, // Timer that triggers the end function after no resize events have been received recently.
+	timeOut : 200, // The amount of milliseconds that has to pass before the chain of resize events is considered over and the timer is called.
 	ChatRoomScrollPercentage : 0, // Height of the chat log scroll bar before the first resize event occurs, as a percentage.
+	ChatLogScrolledToEnd : false, // Is the chat log scrolled all the way to the end before the first resize event occurs?
 
 	// Triggered by resize event
 	ChatRoomResizeEvent : function() {
 		if(ChatRoomResizeManager.atStart) { // Run code for the first resize event in a chain of resize events.
 			ChatRoomResizeManager.ChatRoomScrollPercentage = ElementGetScrollPercentage("TextAreaChatLog");
+			ChatRoomResizeManager.ChatLogScrolledToEnd = ElementIsScrolledToEnd("TextAreaChatLog");
 			ChatRoomResizeManager.atStart = false;
 		}
 
 		// Reset timer if an event was received recently.
 		if (ChatRoomResizeManager.timer) clearTimeout(ChatRoomResizeManager.timer);
-		ChatRoomResizeManager.timer = setTimeout(ChatRoomResizeManager.ChatRoomResizeEventsEnd, 200);
+		ChatRoomResizeManager.timer = setTimeout(ChatRoomResizeManager.ChatRoomResizeEventsEnd, ChatRoomResizeManager.timeOut);
 	},
 
-	// Triggered by ChatRoomResizeManager.timer
+	// Triggered by ChatRoomResizeManager.timer at the end of a chain of resize events
 	ChatRoomResizeEventsEnd : function(){
 		var TextAreaChatLog = document.getElementById("TextAreaChatLog");
 
 		if (TextAreaChatLog != null) {
 			// Scrolls to the position held before the resize events.
-			TextAreaChatLog.scrollTo(0, ChatRoomResizeManager.ChatRoomScrollPercentage * TextAreaChatLog.scrollHeight);
+			if (ChatRoomResizeManager.ChatLogScrolledToEnd) ElementScrollToEnd("TextAreaChatLog"); // Prevents drift away from the end of the chat log.
+			else TextAreaChatLog.scrollTop = (ChatRoomResizeManager.ChatRoomScrollPercentage * TextAreaChatLog.scrollHeight) - TextAreaChatLog.clientHeight;
 		}
 		ChatRoomResizeManager.atStart = true;
 	},

--- a/BondageClub/Scripts/Element.js
+++ b/BondageClub/Scripts/Element.js
@@ -343,13 +343,14 @@ function ElementScrollToEnd(ID) {
 }
 
 /**
- * Returns the given element's scroll position as a percentage, with the top of the element being 0, and the bottom being close to 1.
+ * Returns the given element's scroll position as a percentage, with the top of the element being close to 0 depending on scroll bar size, and the bottom being around 1.
+ * To clarify, this is the position of the bottom edge of the scroll bar.
  * @param {string} ID - The id of the element to find the scroll percentage of.
  * @returns {(number|null)} - A float representing the scroll percentage.
  */
  function ElementGetScrollPercentage(ID) {
 	var element = document.getElementById(ID);
-	if (element != null) return element.scrollTop / element.scrollHeight;
+	if (element != null) return (element.scrollTop + element.clientHeight) / element.scrollHeight;
 
 	return null;
 }

--- a/BondageClub/Scripts/Element.js
+++ b/BondageClub/Scripts/Element.js
@@ -343,6 +343,18 @@ function ElementScrollToEnd(ID) {
 }
 
 /**
+ * Returns the given element's scroll position as a percentage, with the top of the element being 0, and the bottom being close to 1.
+ * @param {string} ID - The id of the element to find the scroll percentage of.
+ * @returns {(number|null)} - A float representing the scroll percentage.
+ */
+ function ElementGetScrollPercentage(ID) {
+	var element = document.getElementById(ID);
+	if (element != null) return element.scrollTop / element.scrollHeight;
+
+	return null;
+}
+
+/**
  * Checks if a given HTML element is scrolled to the very bottom.
  * @param {string} ID - The id of the element to check for scroll height.
  * @returns {boolean} - Returns TRUE if the specified element is scrolled to the very bottom


### PR DESCRIPTION
When resizing the window, this prevents your location in the TextAreaChatLog, in chat rooms, from changing.  It keeps you at the exact end of the chat log if you were there at the beginning of the resize event, or otherwise keeps you at about the same position in the chat log.  Triggered by a resize event listener, which is added and removed when the chat log is added and removed.