### PR TITLE
Improvement: Clientside GetAllowItem

### DIFF
--- a/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
+++ b/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
@@ -839,7 +839,7 @@ function ChatRoomClickCharacter(C, CharX, CharY, Zoom, ClickX, ClickY, Pos) {
 	document.getElementById("InputChat").style.display = "none";
 	document.getElementById("TextAreaChatLog").style.display = "none";
 	ChatRoomBackground = ChatRoomData.Background;
-	C.AllowItem = (C.ID === 0);
+	C.AllowItem = C.ID === 0 || ServerChatRoomGetAllowItem(Player, C);
 	ChatRoomOwnershipOption = "";
 	ChatRoomLovershipOption = "";
 	if (C.ID !== 0) ServerSend("ChatRoomAllowItem", { MemberNumber: C.MemberNumber });
@@ -2762,7 +2762,8 @@ function ChatRoomListManipulation(Add, Remove, Message) {
  */
 function ChatRoomAllowItem(data) {
 	if ((data != null) && (typeof data === "object") && (data.MemberNumber != null) && (typeof data.MemberNumber === "number") && (data.AllowItem != null) && (typeof data.AllowItem === "boolean"))
-		if ((CurrentCharacter != null) && (CurrentCharacter.MemberNumber == data.MemberNumber)) {
+		if (CurrentCharacter != null && CurrentCharacter.MemberNumber == data.MemberNumber && data.AllowItem !== CurrentCharacter.AllowItem) {
+			console.warn(`ChatRoomGetAllowItem mismatch trying to access ${CurrentCharacter.Name} (${CurrentCharacter.MemberNumber})`);
 			CurrentCharacter.AllowItem = data.AllowItem;
 			CharacterSetCurrent(CurrentCharacter);
 		}

--- a/BondageClub/Scripts/Common.js
+++ b/BondageClub/Scripts/Common.js
@@ -6,6 +6,7 @@ var Player;
 var KeyPress = "";
 var CurrentModule;
 var CurrentScreen;
+/** @type {Character|null} */
 var CurrentCharacter = null;
 var CurrentOnlinePlayers = 0;
 var CurrentDarkFactor = 1.0;

--- a/BondageClub/Scripts/Server.js
+++ b/BondageClub/Scripts/Server.js
@@ -618,3 +618,41 @@ function ServerAccountLovership(data) {
 		LoginLoversItems();
 	}
 }
+
+/**
+ * Compares the source account and target account to check if we allow using an item
+ *
+ * **This function MUST match server's identical function!**
+ * @param {Character} Source
+ * @param {Character} Target
+ * @returns {boolean}
+ */
+function ServerChatRoomGetAllowItem(Source, Target) {
+
+	// Make sure we have the required data
+	if ((Source == null) || (Target == null)) return false;
+
+	// NPC
+	if (typeof Target.MemberNumber !== "number") return true;
+
+	// At zero permission level or if target is source or if owner, we allow it
+	if ((Target.ItemPermission <= 0) || (Source.MemberNumber == Target.MemberNumber) || ((Target.Ownership != null) && (Target.Ownership.MemberNumber != null) && (Target.Ownership.MemberNumber == Source.MemberNumber))) return true;
+
+	// At one, we allow if the source isn't on the blacklist
+	if ((Target.ItemPermission == 1) && (Target.BlackList.indexOf(Source.MemberNumber) < 0)) return true;
+
+	var LoversNumbers = CharacterGetLoversNumbers(Target, true);
+
+	// At two, we allow if the source is Dominant compared to the Target (25 points allowed) or on whitelist or a lover
+	if ((Target.ItemPermission == 2) && (Target.BlackList.indexOf(Source.MemberNumber) < 0) && ((ReputationCharacterGet(Source, "Dominant") + 25 >= ReputationCharacterGet(Target, "Dominant")) || (Target.WhiteList.indexOf(Source.MemberNumber) >= 0) || (LoversNumbers.indexOf(Source.MemberNumber) >= 0))) return true;
+
+	// At three, we allow if the source is on the whitelist of the Target or a lover
+	if ((Target.ItemPermission == 3) && ((Target.WhiteList.indexOf(Source.MemberNumber) >= 0) || (LoversNumbers.indexOf(Source.MemberNumber) >= 0))) return true;
+
+	// At four, we allow if the source is a lover
+	if ((Target.ItemPermission == 4) && (LoversNumbers.indexOf(Source.MemberNumber) >= 0)) return true;
+
+	// No valid combo, we don't allow the item
+	return false;
+
+}

--- a/BondageClub/Scripts/Typedef.d.ts
+++ b/BondageClub/Scripts/Typedef.d.ts
@@ -399,7 +399,7 @@ interface Character {
 		GameVersion: string;
 	};
 	Game?: any;
-	BlackList?: number[];
+	BlackList: number[];
 	RunScripts?: boolean;
 	HasScriptedAssets?: boolean;
 	Cage?: true | null;


### PR DESCRIPTION
Implements clientside `ChatRoomGetAllowItem` from server to allow for instantaneous resolving of access to target character, removing delay after clicking.

Original behaviour is still preserved, including aking server and if there is mismatch, server has final say.