### PR TITLE
Animation Quality Preference

### DIFF
--- a/BondageClub/Screens/Character/ItemColor/ItemColor.js
+++ b/BondageClub/Screens/Character/ItemColor/ItemColor.js
@@ -211,7 +211,7 @@ function ItemColorDrawDefault(x, y) {
  * indices
  * @const {function(): void}
  */
-const ItemColorOnPickerChange = CommonDebounce((color) => {
+const ItemColorOnPickerChange = CommonLimitFunction((color) => {
 	const newColors = ItemColorState.colors.slice();
 	ItemColorPickerIndices.forEach(i => newColors[i] = color);
 	ItemColorItem.Color = newColors;

--- a/BondageClub/Screens/Character/Preference/Preference.js
+++ b/BondageClub/Screens/Character/Preference/Preference.js
@@ -55,6 +55,8 @@ var PreferenceDifficultyLevel = null;
 var PreferenceDifficultyAccept = false;
 var PreferenceGraphicsFontList = ["Arial", "TimesNewRoman", "Papyrus", "ComicSans", "Impact", "HelveticaNeue", "Verdana", "CenturyGothic", "Georgia", "CourierNew", "Copperplate"];
 var PreferenceGraphicsFontIndex = 0;
+var PreferenceGraphicsAnimationQualityIndex = null;
+var PreferenceGraphicsAnimationQualityList = [200, 100, 50, 0];
 var PreferenceCalibrationStage = 0;
 
 /**
@@ -419,6 +421,7 @@ function PreferenceInitPlayer() {
 	if (typeof C.GraphicsSettings.InvertRoom !== "boolean") C.GraphicsSettings.InvertRoom = true;
 	if (typeof C.GraphicsSettings.StimulationFlashes !== "boolean") C.GraphicsSettings.StimulationFlashes = true;
 	if (typeof C.GraphicsSettings.DoBlindFlash !== "boolean") C.GraphicsSettings.DoBlindFlash = false;
+	if (typeof C.GraphicsSettings.AnimationQuality !== "number") C.GraphicsSettings.AnimationQuality = 100;
 
 	// Notification settings
 	let NS = C.NotificationSettings;
@@ -575,9 +578,9 @@ function PreferenceLoad() {
 	PreferenceArousalFetishIndex = 0;
 	PreferenceLoadFetishFactor();
 
-	// Sets the Players text font
+	// Prepares the graphics settings
 	PreferenceGraphicsFontIndex = (PreferenceGraphicsFontList.indexOf(Player.GraphicsSettings.Font) < 0) ? 0 : PreferenceGraphicsFontList.indexOf(Player.GraphicsSettings.Font);
-
+	PreferenceGraphicsAnimationQualityIndex = (PreferenceGraphicsAnimationQualityList.indexOf(Player.GraphicsSettings.AnimationQuality) < 0) ? 0 : PreferenceGraphicsAnimationQualityList.indexOf(Player.GraphicsSettings.AnimationQuality);
 }
 
 /**
@@ -1253,6 +1256,7 @@ function PreferenceSubscreenGraphicsRun() {
 	DrawCheckbox(500, 470, 64, 64, TextGet("GraphicsInvertRoom"), Player.GraphicsSettings.InvertRoom);
 	DrawCheckbox(500, 550, 64, 64, TextGet("GraphicsStimulationFlash"), Player.GraphicsSettings.StimulationFlash);
 	DrawCheckbox(500, 630, 64, 64, TextGet("DoBlindFlash"), Player.GraphicsSettings.DoBlindFlash);
+	DrawText(TextGet("GeneralAnimationQualityText"), 750, 742, "Black", "Gray");
 
 	MainCanvas.textAlign = "center";
 	DrawBackNextButton(500, 212, 250, 64, TextGet(Player.ArousalSettings.VFX), "White", "",
@@ -1262,6 +1266,10 @@ function PreferenceSubscreenGraphicsRun() {
 	DrawBackNextButton(500, 300, 250, 64, TextGet(Player.GraphicsSettings.Font), "White", "",
 		() => TextGet(PreferenceGraphicsFontList[(PreferenceGraphicsFontIndex + PreferenceGraphicsFontList.length - 1) % PreferenceGraphicsFontList.length]),
 		() => TextGet(PreferenceGraphicsFontList[(PreferenceGraphicsFontIndex + 1) % PreferenceGraphicsFontList.length]));
+
+	DrawBackNextButton(500, 710, 200, 64, TextGet("GeneralAnimationQuality" + Player.GraphicsSettings.AnimationQuality), "White", "",
+		() => PreferenceGraphicsAnimationQualityIndex == 0 ? "" : TextGet("GeneralAnimationQuality" + PreferenceGraphicsAnimationQualityList[PreferenceGraphicsAnimationQualityIndex - 1].toString()),
+		() => PreferenceGraphicsAnimationQualityIndex == PreferenceGraphicsAnimationQualityList.length - 1 ? "" : TextGet("GeneralAnimationQuality" + PreferenceGraphicsAnimationQualityList[PreferenceGraphicsAnimationQualityIndex + 1].toString()));
 }
 
 /**
@@ -1285,6 +1293,14 @@ function PreferenceSubscreenGraphicsClick() {
 	if (MouseIn(500, 470, 64, 64)) Player.GraphicsSettings.InvertRoom = !Player.GraphicsSettings.InvertRoom;
 	if (MouseIn(500, 550, 64, 64)) Player.GraphicsSettings.StimulationFlash = !Player.GraphicsSettings.StimulationFlash;
 	if (MouseIn(500, 630, 64, 64)) Player.GraphicsSettings.DoBlindFlash = !Player.GraphicsSettings.DoBlindFlash;
+	if (MouseIn(500, 710, 200, 64)) {
+		if (MouseX <= 600) {
+			if (PreferenceGraphicsAnimationQualityIndex > 0) PreferenceGraphicsAnimationQualityIndex--;
+		} else {
+			if (PreferenceGraphicsAnimationQualityIndex < PreferenceGraphicsAnimationQualityList.length - 1) PreferenceGraphicsAnimationQualityIndex++;
+		}
+		Player.GraphicsSettings.AnimationQuality = PreferenceGraphicsAnimationQualityList[PreferenceGraphicsAnimationQualityIndex];
+	}
 }
 
 /**

--- a/BondageClub/Screens/Character/Preference/Text_Preference.csv
+++ b/BondageClub/Screens/Character/Preference/Text_Preference.csv
@@ -129,6 +129,11 @@ BlindDisableExamine,Disable examining when blind
 DisableAutoRemoveLogin,Keep all restraints when relogging
 OfflineLockedRestrained,Cannot enter single-player rooms when restrained
 GeneralHardcoreWarning,Safewords and help from NPCs are disabled on Hardcore or Extreme
+GeneralAnimationQuality0,Max
+GeneralAnimationQuality50,High
+GeneralAnimationQuality100,Medium
+GeneralAnimationQuality200,Low
+GeneralAnimationQualityText,Animation quality (reduce if inputs such as sliders are slow to respond)
 ForceFullHeight,Display all characters at maximum height
 EnableAfkTimer,Show AFK bubble if idle for 5 minutes
 EnableSafeword,Allow Safeword use (Cannot enable while bound)

--- a/BondageClub/Screens/Inventory/HairAccessory1/Halo/Halo.js
+++ b/BondageClub/Screens/Inventory/HairAccessory1/Halo/Halo.js
@@ -103,10 +103,10 @@ function InventoryHairAccessory1HaloClick() {
  * @param {number} brightness - The new brightness to set on the halo
  * @returns {void} - Nothing
  */
-const InventoryHairAccessory1HaloBrightnessChange = CommonDebounce((C, item, brightness) => {
+const InventoryHairAccessory1HaloBrightnessChange = CommonLimitFunction((C, item, brightness) => {
 	item.Property.Opacity = brightness;
 	CharacterRefresh(C, false);
-}, 100);
+});
 
 /**
  * Exit handler for the Halo's extended item screen. Updates the character and removes UI components.

--- a/BondageClub/Screens/Inventory/HairAccessory1/Halo/Halo.js
+++ b/BondageClub/Screens/Inventory/HairAccessory1/Halo/Halo.js
@@ -105,7 +105,7 @@ function InventoryHairAccessory1HaloClick() {
  */
 const InventoryHairAccessory1HaloBrightnessChange = CommonLimitFunction((C, item, brightness) => {
 	item.Property.Opacity = brightness;
-	CharacterRefresh(C, false);
+	CharacterLoadCanvas(C);
 });
 
 /**

--- a/BondageClub/Screens/Inventory/ItemArms/HempRope/HempRopeSuspensionHogtied.js
+++ b/BondageClub/Screens/Inventory/ItemArms/HempRope/HempRopeSuspensionHogtied.js
@@ -73,8 +73,8 @@ const InventoryItemArmsHempRopeSuspensionHogtiedHeightChange = CommonLimitFuncti
 	item.Property.OverrideHeight.HeightRatioProportion = 1 - height;
 	item.Property.OverrideHeight.Height = Math.round(HempRopeSuspensionHogtiedMaxHeight - (1 - height) * (HempRopeSuspensionHogtiedMaxHeight - HempRopeSuspensionHogtiedMinHeight));
 
-	// Refresh to see the change
-	CharacterRefresh(C, false, false);
+	// Reload to see the change
+	CharacterLoadCanvas(C);
 });
 
 /**

--- a/BondageClub/Screens/Inventory/ItemArms/HempRope/HempRopeSuspensionHogtied.js
+++ b/BondageClub/Screens/Inventory/ItemArms/HempRope/HempRopeSuspensionHogtied.js
@@ -54,7 +54,7 @@ function InventoryItemArmsHempRopeSuspensionHogtiedLoad(C, Option) {
  * @param {string} fromElementId - The control that triggered the change
  * @returns {void} - Nothing
  */
-const InventoryItemArmsHempRopeSuspensionHogtiedHeightChange = CommonThrottle((C, item, height, fromElementId) => {
+const InventoryItemArmsHempRopeSuspensionHogtiedHeightChange = CommonLimitFunction((C, item, height, fromElementId) => {
 	// Validate the value
 	if (isNaN(height) || height < 0 || height > 1) return;
 
@@ -75,7 +75,7 @@ const InventoryItemArmsHempRopeSuspensionHogtiedHeightChange = CommonThrottle((C
 
 	// Refresh to see the change
 	CharacterRefresh(C, false, false);
-}, 100);
+});
 
 /**
  * Handles drawing the extended item's screen

--- a/BondageClub/Screens/Inventory/ItemArms/TransportJacket/TransportJacket.js
+++ b/BondageClub/Screens/Inventory/ItemArms/TransportJacket/TransportJacket.js
@@ -91,7 +91,7 @@ const InventoryItemArmsTransportJacketTextChange = CommonLimitFunction((C, item,
 	item = DialogFocusItem || item;
 	if (DynamicDrawTextRegex.test(text)) {
 		item.Property.Text = text.substring(0, InventoryItemDevicesWoodenBoxMaxLength);
-		CharacterRefresh(C, false);
+		CharacterLoadCanvas(C);
 	}
 });
 

--- a/BondageClub/Screens/Inventory/ItemArms/TransportJacket/TransportJacket.js
+++ b/BondageClub/Screens/Inventory/ItemArms/TransportJacket/TransportJacket.js
@@ -87,13 +87,13 @@ function InventoryItemArmsTransportJacketPublishAction(C, Option, PreviousOption
 	ChatRoomPublishCustomAction(msg, true, Dictionary);
 }
 
-const InventoryItemArmsTransportJacketTextChange = CommonDebounce((C, item, text) => {
+const InventoryItemArmsTransportJacketTextChange = CommonLimitFunction((C, item, text) => {
 	item = DialogFocusItem || item;
 	if (DynamicDrawTextRegex.test(text)) {
 		item.Property.Text = text.substring(0, InventoryItemDevicesWoodenBoxMaxLength);
 		CharacterRefresh(C, false);
 	}
-}, 200);
+});
 
 function InventoryItemArmsTransportJacketExit() {
 	const C = CharacterGetCurrent();

--- a/BondageClub/Screens/Inventory/ItemDevices/Locker/Locker.js
+++ b/BondageClub/Screens/Inventory/ItemDevices/Locker/Locker.js
@@ -34,7 +34,6 @@ function InventoryItemDevicesLockerLoad() {
 	}
 }
 
-
 function InventoryItemDevicesLockerDraw() {
 	const asset = DialogFocusItem.Asset;
 	const property = DialogFocusItem.Property;
@@ -87,10 +86,10 @@ function InventoryItemDevicesLockerClick() {
  * @param {number} brightness - The new brightness to set on the item
  * @returns {void} - Nothing
  */
-const InventoryItemDevicesLockerOpacityChange = CommonThrottle((C, item, brightness) => {
+const InventoryItemDevicesLockerOpacityChange = CommonLimitFunction((C, item, brightness) => {
 	item.Property.Opacity = brightness;
 	CharacterRefresh(C, false);
-}, 100);
+});
 
 /**
  * Exit handler for the item's extended item screen. Updates the character and removes UI components.

--- a/BondageClub/Screens/Inventory/ItemDevices/Locker/Locker.js
+++ b/BondageClub/Screens/Inventory/ItemDevices/Locker/Locker.js
@@ -88,7 +88,7 @@ function InventoryItemDevicesLockerClick() {
  */
 const InventoryItemDevicesLockerOpacityChange = CommonLimitFunction((C, item, brightness) => {
 	item.Property.Opacity = brightness;
-	CharacterRefresh(C, false);
+	CharacterLoadCanvas(C);
 });
 
 /**

--- a/BondageClub/Screens/Inventory/ItemDevices/WoodenBox/WoodenBox.js
+++ b/BondageClub/Screens/Inventory/ItemDevices/WoodenBox/WoodenBox.js
@@ -179,7 +179,7 @@ function InventoryItemDevicesWoodenBoxSetOpacity(property, opacity) {
 const InventoryItemDevicesWoodenBoxOpacityChange = CommonLimitFunction((C, item, opacity) => {
 	item = DialogFocusItem || item;
 	item.Property.Opacity = Number(opacity);
-	CharacterRefresh(C, false);
+	CharacterLoadCanvas(C);
 });
 
 /**
@@ -190,7 +190,7 @@ const InventoryItemDevicesWoodenBoxTextChange = CommonLimitFunction((C, item, te
 	item = DialogFocusItem || item;
 	if (DynamicDrawTextRegex.test(text)) {
 		item.Property.Text = text.substring(0, InventoryItemDevicesWoodenBoxMaxLength);
-		CharacterRefresh(C, false);
+		CharacterLoadCanvas(C);
 	}
 });
 

--- a/BondageClub/Screens/Inventory/ItemDevices/WoodenBox/WoodenBox.js
+++ b/BondageClub/Screens/Inventory/ItemDevices/WoodenBox/WoodenBox.js
@@ -176,23 +176,23 @@ function InventoryItemDevicesWoodenBoxSetOpacity(property, opacity) {
  * Handles wooden box opacity changes. Refreshes the character locally
  * @returns {void} - Nothing
  */
-const InventoryItemDevicesWoodenBoxOpacityChange = CommonDebounce((C, item, opacity) => {
+const InventoryItemDevicesWoodenBoxOpacityChange = CommonLimitFunction((C, item, opacity) => {
 	item = DialogFocusItem || item;
 	item.Property.Opacity = Number(opacity);
 	CharacterRefresh(C, false);
-}, 100);
+});
 
 /**
  * Handles wooden box text changes. Refreshes the character locally
  * @returns {void} - Nothing
  */
-const InventoryItemDevicesWoodenBoxTextChange = CommonDebounce((C, item, text) => {
+const InventoryItemDevicesWoodenBoxTextChange = CommonLimitFunction((C, item, text) => {
 	item = DialogFocusItem || item;
 	if (DynamicDrawTextRegex.test(text)) {
 		item.Property.Text = text.substring(0, InventoryItemDevicesWoodenBoxMaxLength);
 		CharacterRefresh(C, false);
 	}
-}, 200);
+});
 
 /**
  * Fetches the current text input value, trimmed appropriately

--- a/BondageClub/Scripts/Typedef.d.ts
+++ b/BondageClub/Scripts/Typedef.d.ts
@@ -502,6 +502,7 @@ interface PlayerCharacter extends Character {
 		InvertRoom: boolean;
 		StimulationFlashes: boolean;
 		DoBlindFlash: boolean;
+		AnimationQuality: number;
 	}
 	NotificationSettings?: {
 		/** @deprecated */


### PR DESCRIPTION
At the moment most functions that update the character appearance repeatedly are limited by debouncing (delaying updates until a set time has passed without change) with a wait interval of 100 ms.
This feature creates a new "Animation Quality" preference in the Graphics settings page to let users indirectly decide this limit themselves. The options are Low/Medium/High/Max corresponding to wait intervals of 200/100/50/0 milliseconds respectively. By default the setting will be Medium = 100 which is the current behaviour for most cases.
For Low and Medium these character refreshes will still be debounced, while for High and Max they'll be throttled instead (delaying updates until a set time has passed) which will provide a faster smoother response to appearance setting changes, provided the user's device can handle it. These refreshes all occur entirely client-side and won't affect the server.

At the moment this affects:
- The colour picker
- The hemp rope suspension height setting
- Opacity sliders for
	- Halo
	- Lockers
	- Wooden boxes 
- Text changes for
	- Wooden boxes
	- Transport jacket

While the term 'animation' isn't entirely accurate for current uses, I'm hoping to create an animated item implementing this setting and the impact will be very noticeable there.