### PR TITLE
Bugfix: Crash after calling the maids from a chatroom

### DIFF
--- a/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
+++ b/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
@@ -2560,9 +2560,10 @@ function DialogCallMaids() {
 	ChatRoomClearAllElements();
 	ChatRoomSetLastChatRoom("");
 	ServerSend("ChatRoomLeave", "");
-	if (!Player.RestrictionSettings || !Player.RestrictionSettings.BypassNPCPunishments)
-		MainHallPunishFromChatroom();
 	CommonSetScreen("Room", "MainHall");
+	if (!Player.RestrictionSettings || !Player.RestrictionSettings.BypassNPCPunishments) {
+		MainHallPunishFromChatroom();
+	}
 }
 
 


### PR DESCRIPTION
## Summary

#2104 deferred the assignment of the main hall maid NPC. However, when calling the maids from the chatroom, the `DialogCallMaids` function would call `MainHallPunishFromChatroom` before setting the screen to the main hall. This could result in the game crashing under certain circumstances with the following stack trace (because `MainHallPunishFromChatroom` expects the main hall maid to have been created already). This fix modifies `DialogCallMaids` to ensure that the screen is set to the main hall before calling `MainHallPunishFromChatroom` in order to prevent this issue.

```
MainHall.js:498 Uncaught TypeError: Cannot set property 'Stage' of null
    at MainHallPunishFromChatroom (MainHall.js:498)
    at DialogCallMaids (ChatRoom.js:2564)
    at CommonDynamicFunctionParams (Common.js:323)
    at DialogClick (Dialog.js:1405)
    at CommonClick (Common.js:258)
    at Click ((index):387)
    at HTMLCanvasElement.onclick ((index):469)
```

## Steps to reproduce

1. Enter a chatroom, and ensure that the "Return to chatrooms on relog" and "Auto-remake rooms" immersion preferences are on
2. Apply restraints so that the "Call the maids for help" dialog option to become available
3. Refresh the page and relog - you should be taken back to the chatroom
4. Click the "Call the maids for help" dialog option
5. The dialog option will not work, and the above error will be displayed in the console