### PR TITLE
Bot Command

### DIFF
--- a/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
+++ b/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
@@ -1470,7 +1470,11 @@ function ChatRoomSendChat() {
 		else if (m.indexOf("/promote ") == 0) ChatRoomAdminChatAction("Promote", msg);
 		else if (m.indexOf("/demote ") == 0) ChatRoomAdminChatAction("Demote", msg);
 		else if (m.indexOf("/afk") == 0) CharacterSetFacialExpression(Player, "Emoticon", "Afk");
-		else {
+		else if (m.indexOf("/bot") == 0) {
+			for (let CC = 0; CC < ChatRoomCharacter.length; CC++)
+				if (ChatRoomCharacter[CC].MemberNumber && ChatRoomCharacter[CC].ID != 0)
+					ServerSend("ChatRoomChat", { Content: "ChatRoomBot " + msg.substring(4), Type: "Hidden", Target: ChatRoomCharacter[CC].MemberNumber});
+		} else {
 			var WhisperTarget = null;
 			for (let C = 0; C < ChatRoomCharacter.length; C++)
 						if (ChatRoomTargetMemberNumber == ChatRoomCharacter[C].MemberNumber)


### PR DESCRIPTION
Implements a /bot command which does nothing except send a hidden message to all other players. This message will get ignored on the default client, but a modded client might be able to interpret the bot command. This specifically enables bots that work even if the player can't whisper due to immersion settings.