### PR TITLE
Bugfix: Error thrown when inspecting the Bondage Bench

### DIFF
--- a/BondageClub/Scripts/Dialog.js
+++ b/BondageClub/Scripts/Dialog.js
@@ -730,7 +730,7 @@ function DialogMenuButtonBuild(C) {
 			if ((Item != null) && (C.ID == 0) && (!Player.CanInteract() || (IsItemLocked && !DialogCanUnlock(C, Item))) && (DialogMenuButton.indexOf("Unlock") < 0) && InventoryAllow(C, Item.Asset.Prerequisite) && !IsGroupBlocked) DialogMenuButton.push("Struggle");
 			if ((Item != null) && !IsItemLocked && Player.CanInteract() && InventoryAllow(C, Item.Asset.Prerequisite) && !IsGroupBlocked) {
 				if (Item.Asset.AllowLock && (!Item.Property || (Item.Property && Item.Property.AllowLock !== false))) {
-					if (!Item.Asset.AllowLockType || Item.Asset.AllowLockType.includes(Item.Property.Type)) {
+					if (!Item.Asset.AllowLockType || (Item.Property && Item.Asset.AllowLockType.includes(Item.Property.Type))) {
 						DialogMenuButton.push(ItemBlockedOrLimited ? "LockDisabled" : "Lock");
 					}
 				}


### PR DESCRIPTION
## Summary

Probably not strictly a beta fix, but this fixes an error that can occur when inspecting items using the `AllowLockType` property (currently only the Bondage Bench).

## Steps to reproduce

1. Player A equips a Bondage Bench on player B and immediately exits the extended menu
2. Player B clicks on themselves and selects the `ItemDevices` slot
3. The following error is thrown:

```
Dialog.js:733 Uncaught TypeError: Cannot read property 'Type' of undefined
    at DialogMenuButtonBuild (Dialog.js:733)
    at DialogInventoryBuild (Dialog.js:846)
    at DialogClick (Dialog.js:1300)
    at CommonClick (Common.js:258)
    at Click ((index):385)
    at HTMLCanvasElement.onclick ((index):467)
```
