### PR TITLE
Kinky Dungeon Spectator Fix

### DIFF
--- a/BondageClub/Screens/MiniGame/KinkyDungeon/KinkyDungeonMultiplayer.js
+++ b/BondageClub/Screens/MiniGame/KinkyDungeon/KinkyDungeonMultiplayer.js
@@ -246,7 +246,7 @@ function KinkyDungeonSendData(data) {
  * @returns {void}
  */
 function KinkyDungeonHandleData(data, SourceMemberNumber) {
-    if (CurrentScreen == "KinkyDungeon")
+    if (CurrentScreen == "KinkyDungeon" && SourceMemberNumber == KinkyDungeonPlayerCharacter.MemberNumber)
         KinkyDungeonUnpackData(data); // Unpack the rest of the data
 }
 

--- a/BondageClub/Scripts/Dialog.js
+++ b/BondageClub/Scripts/Dialog.js
@@ -353,11 +353,10 @@ function DialogCanWatchKinkyDungeon() {
 function DialogStartKinkyDungeon() {
 	if (CurrentCharacter) {
 		KinkyDungeonPlayerCharacter = CurrentCharacter;
+		KinkyDungeonGameRunning = false; // Reset the game to prevent carrying over spectator data
 		if (KinkyDungeonPlayerCharacter != Player && CurrentCharacter.MemberNumber) {
 			KinkyDungeonGameData = null;
 			ServerSend("ChatRoomChat", { Content: "RequestFullKinkyDungeonData", Type: "Hidden", Target: CurrentCharacter.MemberNumber });
-		} else {
-			KinkyDungeonGameRunning = false; // Reset the game to prevent carrying over spectator data
 		}
 	}
 	DialogGamingPreviousRoom = CurrentScreen;

--- a/BondageClub/Scripts/Dialog.js
+++ b/BondageClub/Scripts/Dialog.js
@@ -356,6 +356,8 @@ function DialogStartKinkyDungeon() {
 		if (KinkyDungeonPlayerCharacter != Player && CurrentCharacter.MemberNumber) {
 			KinkyDungeonGameData = null;
 			ServerSend("ChatRoomChat", { Content: "RequestFullKinkyDungeonData", Type: "Hidden", Target: CurrentCharacter.MemberNumber });
+		} else {
+			KinkyDungeonGameRunning = false; // Reset the game to prevent carrying over spectator data
 		}
 	}
 	DialogGamingPreviousRoom = CurrentScreen;


### PR DESCRIPTION
Fixes 2 bugs:
-Played as the wrong character when playing Kinky dungeon after spectating someone else
-Crash or desync when there are multiple players playing kinky dungeon in a room and you are spectating one of them