### PR TITLE
Bugfix: Reinstates accidentally removed extended script for web

### DIFF
--- a/BondageClub/index.html
+++ b/BondageClub/index.html
@@ -158,6 +158,7 @@
 <script src="Screens/Inventory/ItemArms/HempRope/HempRope.js"></script>
 <script src="Screens/Inventory/ItemArms/HempRope/HempRopeSuspensionHogtied.js"></script>
 <script src="Screens/Inventory/ItemArms/Chains/Chains.js"></script>
+<script src="Screens/Inventory/ItemArms/Web/Web.js"></script>
 <script src="Screens/Inventory/ItemHands/PaddedMittens/PaddedMittens.js"></script>
 <script src="Screens/Inventory/ItemHands/PawMittens/PawMittens.js"></script>
 <script src="Screens/Inventory/ItemMisc/MetalPadlock/MetalPadlock.js"></script>


### PR DESCRIPTION
## Summary

The script reference for the web arms item was accidentally removed in #2542, which means that the extended menu for the web no longer works. This PR reinstates the script.