### PR TITLE
Bugfix: Prevents `HideItem` declarations from being short-circuited

### DIFF
--- a/BondageClub/Screens/Character/Appearance/Appearance.js
+++ b/BondageClub/Screens/Character/Appearance/Appearance.js
@@ -386,12 +386,9 @@ function CharacterAppearanceVisible(C, AssetName, GroupName, Recursive = true) {
 		else if (item.Asset.HideItemAttribute.length && assetToCheck.Attribute.length) {
 			HidingItem = item.Asset.HideItemAttribute.some((val) => assetToCheck.Attribute.indexOf(val) !== -1);
 		}
-		else if (item.Property != null) {
-			if (((Array.isArray(item.Property.Hide)) && (item.Property.Hide.indexOf(GroupName) >= 0)) ||
-				((Array.isArray(item.Property.HideItem)) && (item.Property.HideItem.indexOf(GroupName + AssetName) >= 0)))
-				HidingItem = true;
-		}
+		else if ((item.Property != null) && (item.Property.Hide != null) && (item.Property.Hide.indexOf(GroupName) >= 0)) HidingItem = true;
 		else if ((item.Asset.HideItem != null) && (item.Asset.HideItem.indexOf(GroupName + AssetName) >= 0)) HidingItem = true;
+		else if ((item.Property != null) && (item.Property.HideItem != null) && (item.Property.HideItem.indexOf(GroupName + AssetName) >= 0)) HidingItem = true;
 		if (HidingItem) {
 			if (Recursive) {
 				if (CharacterAppearanceVisible(C, item.Asset.Name, item.Asset.Group.Name, false)) {


### PR DESCRIPTION
## Summary

As part of #2548, some of the item-hiding logic was refactored to try to merge handling of `item.Property.Hide` and `item.Property.HideItem`. However, this would cause the `else if` block handling `item.Asset.HideItem` to be short-circuited incorrectly. This PR reverts that change, but maintains the new `HideItemAttribute` handling.

## Steps to reproduce

1. Equip a pair of Futuristic Earphones and exit the extended menu
2. Equip a gas mask (`OldGasMask`) on top
3. Note that the Futuristic Earphones are still visible, despite being listed in the gas mask's `HideItem` array