### PR TITLE
Bugfix: Reinstates accidentally deleted sturdy leather belt configuration

### DIFF
--- a/BondageClub/Assets/Female3DCG/Female3DCGExtended.js
+++ b/BondageClub/Assets/Female3DCG/Female3DCGExtended.js
@@ -731,6 +731,32 @@ var AssetFemale3DCGExtended = {
 				},
 			},
 		}, // Ribbons
+		SturdyLeatherBelts: {
+			Archetype: ExtendedArchetype.TYPED,
+			Config: {
+				ChatTags: [CommonChatTags.SOURCE_CHAR, CommonChatTags.TARGET_CHAR],
+				ChangeWhenLocked: false,
+				Dialog: {
+					Load: "SturdyLeatherBeltsSelectTightness",
+					TypePrefix: "SturdyLeatherBeltsPose",
+					ChatPrefix: "SturdyLeatherBeltsRestrain",
+				},
+				Options: [
+					{
+						Name: "One",
+						Property: { Type: null, },
+					},
+					{
+						Name: "Two",
+						Property: { Type: "Two", Difficulty: 2, },
+					},
+					{
+						Name: "Three",
+						Property: { Type: "Three", Difficulty: 4, },
+					},
+				],
+			}
+		}, // SturdyLeatherBelts
 	}, // ItemArms
 	ItemNeck: {
 		ShinySteelCollar: {


### PR DESCRIPTION
## Summary

#2520 accidentally deleted the extended item configuration for the sturdy leather belts, presumably as a result of a merge conflict, meaning that the extended menu for the belts no longer works. This reinstates the missing configuration.