### PR TITLE
Adds a few keywords to the auto shock blacklist

### DIFF
--- a/BondageClub/Screens/Inventory/ItemMouth/FuturisticPanelGag/FuturisticPanelGag.js
+++ b/BondageClub/Screens/Inventory/ItemMouth/FuturisticPanelGag/FuturisticPanelGag.js
@@ -40,6 +40,14 @@ var AutoPunishKeywords = [
 "growl",
 "laugh",
 "giggle",
+"mutter",
+"stutter",
+"stammer",
+"grunt",
+"hiss",
+"screech",
+"bark",
+"mumble",
 ];
 
 var AutoPunishGagActionFlag = false;


### PR DESCRIPTION
There is a blacklist of words that will always get the player shocked even if the player does an emote. For example, writing "/me shouts into her gag" will still shock the player even if they aren't sending a normal chat message. This just adds a few extra keywords to catch clever subs.