### PR TITLE
Bugfix: Prevents difficulty from increasing when sending single item updates

### DIFF
--- a/BondageClub/Screens/Character/Appearance/Appearance.js
+++ b/BondageClub/Screens/Character/Appearance/Appearance.js
@@ -815,7 +815,8 @@ function AppearancePreviewUseCharacter(assetGroup) {
  * @param {string} Group - The name of the corresponding groupr for the item
  * @param {Asset|null} ItemAsset - The asset collection of the item to be changed
  * @param {string|string[]} [NewColor] - The new color (as "#xxyyzz" hex value) for that item
- * @param {number} [DifficultyFactor=0] - The difficulty factor of the ne item
+ * @param {number} [DifficultyFactor=0] - The difficulty, on top of the base asset difficulty, that should be assigned
+ * to the item
  * @param {number} [ItemMemberNumber=-1] - The member number of the player adding the item - defaults to -1
  * @param {boolean} [Refresh=true] - Determines, wether the character should be redrawn after the item change
  * @returns {void} - Nothing

--- a/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
+++ b/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
@@ -1624,7 +1624,7 @@ function ChatRoomCharacterItemUpdate(C, Group) {
 		P.Group = Group;
 		P.Name = (Item != null) ? Item.Asset.Name : undefined;
 		P.Color = ((Item != null) && (Item.Color != null)) ? Item.Color : "Default";
-		P.Difficulty = (Item != null) ? Item.Difficulty : SkillGetWithRatio("Bondage");
+		P.Difficulty = (Item != null) ? Item.Difficulty - Item.Asset.Difficulty : SkillGetWithRatio("Bondage");
 		P.Property = ((Item != null) && (Item.Property != null)) ? Item.Property : undefined;
 		ServerSend("ChatRoomCharacterItemUpdate", P);
 	}

--- a/BondageClub/Scripts/Inventory.js
+++ b/BondageClub/Scripts/Inventory.js
@@ -364,7 +364,7 @@ function InventoryGet(C, AssetGroup) {
 * @param {string} AssetName - The name of the asset to wear
 * @param {string} AssetGroup - The name of the asset group to wear
 * @param {string} [ItemColor] - The hex color of the item, can be undefined or "Default"
-* @param {number} [Difficulty] - The difficulty level to escape from the item
+* @param {number} [Difficulty] - The difficulty, on top of the base asset difficulty, to assign to the item
 * @param {number} [MemberNumber] - The member number of the character putting the item on - defaults to -1
 */
 function InventoryWear(C, AssetName, AssetGroup, ItemColor, Difficulty, MemberNumber) {
@@ -406,7 +406,7 @@ function InventoryLocked(C, AssetGroup, CheckProperties) {
 * Makes the character wear a random item from a body area
 * @param {Character} C - The character that must wear the item
 * @param {string} GroupName - The name of the asset group (body area)
-* @param {number} [Difficulty] - The difficulty level to escape from the item
+* @param {number} [Difficulty] - The difficulty, on top of the base asset difficulty, to assign to the item
 * @param {boolean} [Refresh] - Do not call CharacterRefresh if false
 * @param {boolean} [MustOwn=false] - If TRUE, only assets that the character owns can be worn. Otherwise any asset can be used
 * @returns {void} - Nothing


### PR DESCRIPTION
## Summary

This fixes an issue where single item updates could cause an item's difficulty to increase if the item's current difficulty is sent along with each update. I've also added some clarification to some of the JSDoc documentation regarding difficulty when adding items. Not strictly a beta fix, but would be good to include in this release.

## Steps to reproduce

1. Player A equips an extended item (with types) on player B
2. Player A leaves the room and re-enters (this ensures the difficulty value is synced properly between players, as it can go out of sync - this PR also fixes that)
3. Player A changes the type of the item on player B
4. Note that the difficulty of the item has increased by the base difficulty of the asset
5. Steps 2-4 can be repeated to increase the difficulty indefinitely