### PR TITLE
Extended Item Type Permissions on Extreme Difficulty

### DIFF
--- a/BondageClub/Scripts/ExtendedItem.js
+++ b/BondageClub/Scripts/ExtendedItem.js
@@ -156,8 +156,10 @@ function ExtendedItemDraw(Options, DialogPrefix, OptionsPerPage, ShowImages = tr
 		}
 	}
 
-	// Permission mode toggle is always available
-	DrawButton(1775, 25, 90, 90, "", "White", ExtendedItemPermissionMode ? "Icons/DialogNormalMode.png" : "Icons/DialogPermissionMode.png", DialogFindPlayer(ExtendedItemPermissionMode ? "DialogNormalMode" : "DialogPermissionMode"));
+	// Permission mode toggle
+	if (Player.GetDifficulty() < 3) {
+		DrawButton(1775, 25, 90, 90, "", "White", ExtendedItemPermissionMode ? "Icons/DialogNormalMode.png" : "Icons/DialogPermissionMode.png", DialogFindPlayer(ExtendedItemPermissionMode ? "DialogNormalMode" : "DialogPermissionMode"));
+	}
 }
 
 /**
@@ -240,7 +242,7 @@ function ExtendedItemClick(Options, OptionsPerPage, ShowImages = true) {
 	}
 
 	// Permission toggle button
-	if (MouseIn(1775, 25, 90, 90)) {
+	if (MouseIn(1775, 25, 90, 90) && Player.GetDifficulty() < 3) {
 		if (ExtendedItemPermissionMode && CurrentScreen == "ChatRoom") ChatRoomCharacterUpdate(Player);
 		ExtendedItemPermissionMode = !ExtendedItemPermissionMode;
 	}


### PR DESCRIPTION
On the Extreme difficulty, the button to switch to Permissions mode for extended items was accessible, allowing specific options to be blocked. These settings were at least reset on logging in again but could still be changed temporarily. Now the button will be hidden.