### PR TITLE
Fix: Dental gag cannot be changed when locked

### DIFF
--- a/BondageClub/Assets/Female3DCG/Female3DCGExtended.js
+++ b/BondageClub/Assets/Female3DCG/Female3DCGExtended.js
@@ -1310,7 +1310,8 @@ var AssetFemale3DCGExtended = {
 							Effect: ["BlockMouth", "GagMedium"],
 						},
 					},
-				]
+				],
+				ChangeWhenLocked: false,
 			},
 		}, // DentalGag
 		Ribbons: {


### PR DESCRIPTION
# Description
Just adds the `CannotChangeWhenLocked` property to the dental gag.