### PR TITLE
Advanced Denial

### DIFF
--- a/BondageClub/Screens/Character/Player/Dialog_Player.csv
+++ b/BondageClub/Screens/Character/Player/Dialog_Player.csv
@@ -34,6 +34,8 @@ PlayerGagged,,,(You can use or remove items by selecting specific body regions o
 92,0,"(Yes, I want to be released.)",,DialogChatRoomSafewordRelease(),
 92,0,"(No, don't release me.)",(You can use or remove items by selecting specific body regions on yourself.),,
 0,,(Play Kinky Dungeon),,DialogStartKinkyDungeon(),DialogHasGamingHeadset()
+OrgasmFailResist,,,"Your vibrators stop abruptly, leaving you just as aroused."
+OrgasmFailTimeout,,,"The stimulation ends just before you go over the edge."
 KinkyDungeonExit,,,"SourceCharacter quit a game of Kinky Dungeon at level KinkyDungeonLevel",,
 KinkyDungeonLose,,,"SourceCharacter met her defeat in Kinky Dungeon! She made it to level KinkyDungeonLevel before succumbing.",,
 SavedExpressionsSave,,,Save,,

--- a/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
+++ b/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
@@ -1153,9 +1153,11 @@ function ChatRoomRun() {
 			if (Player.ArousalSettings.OrgasmStage == 0) {
 				DrawText(TextGet("OrgasmComing"), 500, 410, "White", "Black");
 				DrawButton(200, 532, 250, 64, TextGet("OrgasmTryResist"), "White");
-				DrawButton(550, 532, 250, 64, TextGet("OrgasmSurrender"), "White");
+				if (!ActivityOrgasmRuined)
+					DrawButton(550, 532, 250, 64, TextGet("OrgasmSurrender"), "White");
 			}
 			if (Player.ArousalSettings.OrgasmStage == 1) DrawButton(ActivityOrgasmGameButtonX, ActivityOrgasmGameButtonY, 250, 64, ActivityOrgasmResistLabel, "White");
+			if (ActivityOrgasmRuined) ActivityOrgasmControl();
 			if (Player.ArousalSettings.OrgasmStage == 2) DrawText(TextGet("OrgasmRecovering"), 500, 500, "White", "Black");
 			ActivityOrgasmProgressBar(50, 970);
 		} else if ((Player.ArousalSettings.Progress != null) && (Player.ArousalSettings.Progress >= 91) && (Player.ArousalSettings.Progress <= 99) && !CommonPhotoMode) {
@@ -1224,7 +1226,7 @@ function ChatRoomClick() {
 
 		// On stage 0, the player can choose to resist the orgasm or not.  At 1, the player plays a mini-game to fight her orgasm
 		if (MouseIn(200, 532, 250, 68) && (Player.ArousalSettings.OrgasmStage == 0)) ActivityOrgasmGameGenerate(0);
-		if (MouseIn(550, 532, 250, 68) && (Player.ArousalSettings.OrgasmStage == 0)) ActivityOrgasmStart(Player);
+		if (!ActivityOrgasmRuined && MouseIn(550, 532, 250, 68) && (Player.ArousalSettings.OrgasmStage == 0)) ActivityOrgasmStart(Player);
 		if ((MouseX >= ActivityOrgasmGameButtonX) && (MouseX <= ActivityOrgasmGameButtonX + 250) && (MouseY >= ActivityOrgasmGameButtonY) && (MouseY <= ActivityOrgasmGameButtonY + 64) && (Player.ArousalSettings.OrgasmStage == 1)) ActivityOrgasmGameGenerate(ActivityOrgasmGameProgress + 1);
 		return;
 

--- a/BondageClub/Screens/Room/Private/Private.js
+++ b/BondageClub/Screens/Room/Private/Private.js
@@ -437,9 +437,11 @@ function PrivateRun() {
 			if (Player.ArousalSettings.OrgasmStage == 0) {
 				DrawText(TextGet("OrgasmComing"), 1000, 410, "White", "Black");
 				DrawButton(700, 532, 250, 64, TextGet("OrgasmTryResist"), "White");
-				DrawButton(1050, 532, 250, 64, TextGet("OrgasmSurrender"), "White");
+				if (!ActivityOrgasmRuined)
+					DrawButton(1050, 532, 250, 64, TextGet("OrgasmSurrender"), "White");
 			}
 			if (Player.ArousalSettings.OrgasmStage == 1) DrawButton(ActivityOrgasmGameButtonX + 500, ActivityOrgasmGameButtonY, 250, 64, ActivityOrgasmResistLabel, "White");
+			if (ActivityOrgasmRuined) ActivityOrgasmControl();
 			if (Player.ArousalSettings.OrgasmStage == 2) DrawText(TextGet("OrgasmRecovering"), 1000, 500, "White", "Black");
 			ActivityOrgasmProgressBar(550, 970);
 		} else if ((Player.ArousalSettings.Progress != null) && (Player.ArousalSettings.Progress >= 91) && (Player.ArousalSettings.Progress <= 99)) DrawRect(0, 0, 2000, 1000, "#FFB0B040");
@@ -586,7 +588,7 @@ function PrivateClick() {
 
 		// On stage 0, the player can choose to resist the orgasm or not.  At 1, the player plays a mini-game to fight her orgasm
 		if ((MouseX >= 700) && (MouseX <= 950) && (MouseY >= 532) && (MouseY <= 600) && (Player.ArousalSettings.OrgasmStage == 0)) ActivityOrgasmGameGenerate(0);
-		if ((MouseX >= 1050) && (MouseX <= 1300) && (MouseY >= 532) && (MouseY <= 600) && (Player.ArousalSettings.OrgasmStage == 0)) ActivityOrgasmStart(Player);
+		if (!ActivityOrgasmRuined && (MouseX >= 1050) && (MouseX <= 1300) && (MouseY >= 532) && (MouseY <= 600) && (Player.ArousalSettings.OrgasmStage == 0)) ActivityOrgasmStart(Player);
 		if ((MouseX >= ActivityOrgasmGameButtonX + 500) && (MouseX <= ActivityOrgasmGameButtonX + 700) && (MouseY >= ActivityOrgasmGameButtonY) && (MouseY <= ActivityOrgasmGameButtonY + 64) && (Player.ArousalSettings.OrgasmStage == 1)) ActivityOrgasmGameGenerate(ActivityOrgasmGameProgress + 1);
 		return;
 

--- a/BondageClub/Scripts/Activity.js
+++ b/BondageClub/Scripts/Activity.js
@@ -287,7 +287,7 @@ function ActivityOrgasmProgressBar(X, Y) {
 function ActivityOrgasmControl() {
 	if ((ActivityOrgasmGameTimer != null) && (ActivityOrgasmGameTimer > 0) && (CurrentTime < Player.ArousalSettings.OrgasmTimer)) {
 		// Ruin the orgasm
-		if (ActivityOrgasmGameProgress >= ActivityOrgasmGameDifficulty - 1 || CurrentTime > Player.ArousalSettings.OrgasmTimer - 3200) {
+		if (ActivityOrgasmGameProgress >= ActivityOrgasmGameDifficulty - 1 || CurrentTime > Player.ArousalSettings.OrgasmTimer - 500) {
 			if (CurrentScreen == "ChatRoom") {
 				if (CurrentTime > Player.ArousalSettings.OrgasmTimer - 500) {
 					ChatRoomMessage({ Content: "OrgasmFailTimeout", Type: "Action", Sender: Player.MemberNumber });

--- a/BondageClub/Scripts/Timer.js
+++ b/BondageClub/Scripts/Timer.js
@@ -153,7 +153,7 @@ function TimerProcess(Timestamp) {
 				// If the character is having an orgasm and the timer ran out, we move to the next orgasm stage
 				if ((Character[C].ArousalSettings != null) && (Character[C].ArousalSettings.OrgasmTimer != null) && (Character[C].ArousalSettings.OrgasmTimer > 0)) {
 					if (Character[C].ArousalSettings.OrgasmTimer < CurrentTime) {
-						if ((Character[C].ArousalSettings.OrgasmStage == null) || (Character[C].ArousalSettings.OrgasmStage <= 1)) ActivityOrgasmStart(Character[C]);
+						if (!ActivityOrgasmRuined && ((Character[C].ArousalSettings.OrgasmStage == null) || (Character[C].ArousalSettings.OrgasmStage <= 1))) ActivityOrgasmStart(Character[C]);
 						else ActivityOrgasmStop(Character[C], 20);
 					}
 				} else {

--- a/BondageClub/Scripts/VibratorMode.js
+++ b/BondageClub/Scripts/VibratorMode.js
@@ -491,10 +491,12 @@ function VibratorModeStateUpdateDeny(C, Arousal, TimeSinceLastChange, OldIntensi
 	var State = VibratorModeState.DENY;
 	var Intensity = OldIntensity;
 	if (Arousal >= 95 && TimeSinceLastChange > OneMinute && Math.random() < 0.2) {
-		// In deny mode, there's a small chance to change to give a fake orgasm and then go to rest mode after a minute
-		// Here we give the fake orgasm, passing a special parameter that indicates we bypass the usual restriction on Edge
-		ActivityOrgasmGameGenerate(0); // We generate the orgasm stage to deny the player the opportunity to surrender
-		ActivityOrgasmPrepare(C, true);
+		if (Player.IsEdged()) {
+			// In deny mode, there's a small chance to change to give a fake orgasm and then go to rest mode after a minute
+			// Here we give the fake orgasm, passing a special parameter that indicates we bypass the usual restriction on Edge
+			ActivityOrgasmGameGenerate(0); // We generate the orgasm stage to deny the player the opportunity to surrender
+			ActivityOrgasmPrepare(C, true);
+		}
 		
 		// Set the vibrator to rest
 		State = VibratorModeState.REST;

--- a/BondageClub/Scripts/VibratorMode.js
+++ b/BondageClub/Scripts/VibratorMode.js
@@ -491,7 +491,14 @@ function VibratorModeStateUpdateDeny(C, Arousal, TimeSinceLastChange, OldIntensi
 	var State = VibratorModeState.DENY;
 	var Intensity = OldIntensity;
 	if (Arousal >= 95 && TimeSinceLastChange > OneMinute && Math.random() < 0.2) {
-		// In deny mode, there's a small chance to change to rest mode after a minute
+		// In deny mode, there's a small chance to change to give a fake orgasm and then go to rest mode after a minute
+		// Here we give the fake orgasm, passing a special parameter that indicates we bypass the usual restriction on Edge
+		if (C.ArousalSettings.OrgasmStage == 0) {
+			ActivityOrgasmGameGenerate(0); // We generate the orgasm stage to deny the player the opportunity to surrender
+			ActivityOrgasmPrepare(C, true);
+		}
+		
+		// Set the vibrator to rest
 		State = VibratorModeState.REST;
 		Intensity = -1;
 	} else if (Arousal >= 95) {

--- a/BondageClub/Scripts/VibratorMode.js
+++ b/BondageClub/Scripts/VibratorMode.js
@@ -493,10 +493,8 @@ function VibratorModeStateUpdateDeny(C, Arousal, TimeSinceLastChange, OldIntensi
 	if (Arousal >= 95 && TimeSinceLastChange > OneMinute && Math.random() < 0.2) {
 		// In deny mode, there's a small chance to change to give a fake orgasm and then go to rest mode after a minute
 		// Here we give the fake orgasm, passing a special parameter that indicates we bypass the usual restriction on Edge
-		if (C.ArousalSettings.OrgasmStage == 0) {
-			ActivityOrgasmGameGenerate(0); // We generate the orgasm stage to deny the player the opportunity to surrender
-			ActivityOrgasmPrepare(C, true);
-		}
+		ActivityOrgasmGameGenerate(0); // We generate the orgasm stage to deny the player the opportunity to surrender
+		ActivityOrgasmPrepare(C, true);
 		
 		// Set the vibrator to rest
 		State = VibratorModeState.REST;


### PR DESCRIPTION
Adds a new feature to the Deny mode of most vibrators... ruined orgasms!

When the vibrator switches off, it will first edge the player and bring them to the orgasm screen. At this point there is nothing the player can do to orgasm, as the surrender button will be missing and the orgasm will cancel right before the timer runs out.

The mode is manually triggered by the vibrator. It will not be triggered in any other modes, so the change should be mostly safe.

This does not send a chat message to anyone but the player, in an effort to reduce chat spam in chat rooms. Deny mode will remain safe for use in rooms with 9 AFK dolls set to deny, for better or for worse.