### PR TITLE
Bugfix: Adds a null check to extended item `ChangeWhenLocked` checks

### DIFF
--- a/BondageClub/Scripts/ExtendedItem.js
+++ b/BondageClub/Scripts/ExtendedItem.js
@@ -430,7 +430,7 @@ function ExtendedItemValidate(C, { Prerequisite, SelfBlockCheck, Property }, Cur
 	const CurrentProperty = DialogFocusItem && DialogFocusItem.Property;
 	const CurrentLockedBy = CurrentProperty && CurrentProperty.LockedBy;
 
-	if (CurrentOption.ChangeWhenLocked === false && CurrentLockedBy && !DialogCanUnlock(C, DialogFocusItem)) {
+	if (CurrentOption && CurrentOption.ChangeWhenLocked === false && CurrentLockedBy && !DialogCanUnlock(C, DialogFocusItem)) {
 		// If the option can't be changed when locked, ensure that the player can unlock the item (if it's locked)
 		return DialogFindPlayer("CantChangeWhileLocked");
 	} else if (Prerequisite && SelfBlockCheck && !ExtendedItemSelfProofRequirementCheck(C, Prerequisite)) {


### PR DESCRIPTION
## Summary

Under some circumstances (that I've yet to reproduce), it appears to be possible to reach the extended item draw function in a state where the extended item script can't identify the currently selected extended option. This results in the following error being thrown:

![error](https://cdn.discordapp.com/attachments/554378725916147722/855549746160599060/download.png)

I suspect this may happen when the item's `Property` ends up being `undefined` (generally due to the player leaving the extended menu immediately after equipping the item), although I've not managed to figure out how the game is hitting the `Draw` function without first hitting the load function immediately beforehand.

In any case, this adds a null check for `CurrentOption` inside the `ExtendedItemValidate`, which should fix this particular error, although I'm still unsure about the root cause.