### PR TITLE
Item Expression Trigger Preference

### DIFF
--- a/BondageClub/Screens/Character/Preference/Preference.js
+++ b/BondageClub/Screens/Character/Preference/Preference.js
@@ -636,11 +636,12 @@ function PreferenceSubscreenGeneralRun() {
 	// Checkboxes (Some are not available when playing on Hardcore or Extreme)
 	DrawCheckbox(500, 402, 64, 64, TextGet("ForceFullHeight"), Player.VisualSettings.ForceFullHeight);
 	DrawCheckbox(500, 482, 64, 64, TextGet("DisablePickingLocksOnSelf"), Player.OnlineSharedSettings.DisablePickingLocksOnSelf);
-	if (Player.GetDifficulty() < 2) {
-		DrawCheckbox(500, 722, 64, 64, TextGet(PreferenceSafewordConfirm ? "ConfirmSafeword" : "EnableSafeword"), Player.GameplaySettings.EnableSafeword);
-		DrawCheckbox(500, 562, 64, 64, TextGet("DisableAutoMaid"), !Player.GameplaySettings.DisableAutoMaid);
-		DrawCheckbox(500, 642, 64, 64, TextGet("OfflineLockedRestrained"), Player.GameplaySettings.OfflineLockedRestrained);
-	} else DrawText(TextGet("GeneralHardcoreWarning"), 500, 622, "Red", "Gray");
+	const onHighDifficulty = Player.GetDifficulty() >= 2;
+	DrawCheckbox(500, 722, 64, 64, TextGet(PreferenceSafewordConfirm ? "ConfirmSafeword" : "EnableSafeword"), Player.GameplaySettings.EnableSafeword, onHighDifficulty);
+	DrawCheckbox(500, 562, 64, 64, TextGet("DisableAutoMaid"), !Player.GameplaySettings.DisableAutoMaid, onHighDifficulty);
+	DrawCheckbox(500, 642, 64, 64, TextGet("OfflineLockedRestrained"), Player.GameplaySettings.OfflineLockedRestrained, onHighDifficulty);
+	if (onHighDifficulty) DrawTextWrap(TextGet("GeneralHardcoreWarning"), 1225, 622, 450, 100, "Red");
+	DrawCheckbox(500, 802, 64, 64, TextGet("ItemsAffectExpressions"), Player.OnlineSharedSettings.ItemsAffectExpressions);
 
 	// Draw the player & controls
 	DrawCharacter(Player, 50, 50, 0.9);
@@ -784,6 +785,7 @@ function PreferenceSubscreenGeneralClick() {
 	} else PreferenceSafewordConfirm = false;
 	if (MouseIn(500, 562, 64, 64) && (Player.GetDifficulty() < 2)) Player.GameplaySettings.DisableAutoMaid = !Player.GameplaySettings.DisableAutoMaid;
 	if (MouseIn(500, 642, 64, 64) && (Player.GetDifficulty() < 2)) Player.GameplaySettings.OfflineLockedRestrained = !Player.GameplaySettings.OfflineLockedRestrained;
+	if (MouseIn(500, 802, 64, 64)) Player.OnlineSharedSettings.ItemsAffectExpressions = !Player.OnlineSharedSettings.ItemsAffectExpressions;
 }
 
 /**

--- a/BondageClub/Screens/Character/Preference/Preference.js
+++ b/BondageClub/Screens/Character/Preference/Preference.js
@@ -414,6 +414,7 @@ function PreferenceInitPlayer() {
 		}
 		C.OnlineSharedSettings.GameVersion = GameVersion;
 	}
+	if (typeof C.OnlineSharedSettings.ItemsAffectExpressions !== "boolean") C.OnlineSharedSettings.ItemsAffectExpressions = true;
 
 	// Graphical settings
 	if (!C.GraphicsSettings) C.GraphicsSettings = {};

--- a/BondageClub/Screens/Character/Preference/Text_Preference.csv
+++ b/BondageClub/Screens/Character/Preference/Text_Preference.csv
@@ -129,6 +129,7 @@ BlindDisableExamine,Disable examining when blind
 DisableAutoRemoveLogin,Keep all restraints when relogging
 OfflineLockedRestrained,Cannot enter single-player rooms when restrained
 GeneralHardcoreWarning,Safewords and help from NPCs are disabled on Hardcore or Extreme
+ItemsAffectExpressions,Items can affect your facial expression
 GeneralAnimationQuality0,Max
 GeneralAnimationQuality50,High
 GeneralAnimationQuality100,Medium

--- a/BondageClub/Screens/Inventory/ItemMouth/FuturisticPanelGag/FuturisticPanelGag.js
+++ b/BondageClub/Screens/Inventory/ItemMouth/FuturisticPanelGag/FuturisticPanelGag.js
@@ -397,9 +397,12 @@ function InventoryItemMouthFuturisticPanelGagTrigger(C, Item, Reset, Options) {
 			InventoryItemMouthFuturisticPanelGagPublishActionTrigger(C, Item, Options[OptionLevel], Reset);
 		Item.Property.OriginalSetting = OriginalItemSetting; // After automatically changing it, we put it back to original setting
 
-		CharacterSetFacialExpression(C, "Eyebrows", "Soft", 10);
-		CharacterSetFacialExpression(C, "Blush", "Extreme", 15);
-		CharacterSetFacialExpression(C, "Eyes", "Lewd", 5);
+		const expressions = [
+			{ Group: "Eyebrows", Name: "Soft", Timer: 10 },
+			{ Group: "Blush", Name: "Extreme", Timer: 15 },
+			{ Group: "Eyes", Name: "Lewd", Timer: 5 },
+		];
+		InventoryExpressionTriggerApply(C, expressions);
 
 		/*var vol = 1
 		if (Player.AudioSettings && Player.AudioSettings.Volume) {

--- a/BondageClub/Screens/Inventory/ItemNeckAccessories/CollarAutoShockUnit/CollarAutoShockUnit.js
+++ b/BondageClub/Screens/Inventory/ItemNeckAccessories/CollarAutoShockUnit/CollarAutoShockUnit.js
@@ -168,9 +168,7 @@ function InventoryItemNeckAccessoriesCollarAutoShockUnitTriggerAutomatic(data) {
 		ChatRoomCharacterItemUpdate(C, data.Item.Asset.Group.Name);
 	}
 
-    CharacterSetFacialExpression(C, "Eyebrows", "Soft", 10);
-    CharacterSetFacialExpression(C, "Blush", "Soft", 15);
-    CharacterSetFacialExpression(C, "Eyes", "Closed", 5);
+	InventoryShockExpression(C);
 }
 
 // Trigger a shock from the dialog menu
@@ -199,9 +197,7 @@ function InventoryItemNeckAccessoriesCollarAutoShockUnitTrigger(data) {
 
 	ChatRoomPublishCustomAction("TriggerShock" + DialogFocusItem.Property.Intensity, true, Dictionary);
 
-    CharacterSetFacialExpression(C, "Eyebrows", "Soft", 10);
-    CharacterSetFacialExpression(C, "Blush", "Soft", 15);
-    CharacterSetFacialExpression(C, "Eyes", "Closed", 5);
+	InventoryShockExpression(C);
 }
 
 function AssetsItemNeckAccessoriesCollarAutoShockUnitBeforeDraw(data) {

--- a/BondageClub/Screens/Inventory/ItemNeckAccessories/CollarShockUnit/CollarShockUnit.js
+++ b/BondageClub/Screens/Inventory/ItemNeckAccessories/CollarShockUnit/CollarShockUnit.js
@@ -81,9 +81,7 @@ function InventoryItemNeckAccessoriesCollarShockUnitTrigger() {
 	}
 	if (CurrentScreen == "ChatRoom") DialogLeave();
 
-    CharacterSetFacialExpression(C, "Eyebrows", "Soft", 10);
-    CharacterSetFacialExpression(C, "Blush", "Soft", 15);
-    CharacterSetFacialExpression(C, "Eyes", "Closed", 5);
+	InventoryShockExpression(C);
 }
 
 function AssetsItemNeckAccessoriesCollarShockUnitBeforeDraw(data) {

--- a/BondageClub/Screens/Inventory/ItemPelvis/FuturisticChastityBelt/FuturisticChastityBelt.js
+++ b/BondageClub/Screens/Inventory/ItemPelvis/FuturisticChastityBelt/FuturisticChastityBelt.js
@@ -213,9 +213,7 @@ function AssetsItemPelvisFuturisticChastityBeltScriptTrigger(C, Item, ShockType)
 			ServerSend("ChatRoomChat", { Content: "FuturisticChastityBeltShock" + ShockType, Type: "Action", Dictionary });
 		}
 	}
-    CharacterSetFacialExpression(C, "Eyebrows", "Soft", 10);
-    CharacterSetFacialExpression(C, "Blush", "Soft", 15);
-    CharacterSetFacialExpression(C, "Eyes", "Closed", 5);
+	InventoryShockExpression(C);
 }
 
 

--- a/BondageClub/Screens/Inventory/ItemPelvis/SciFiPleasurePanties/SciFiPleasurePanties.js
+++ b/BondageClub/Screens/Inventory/ItemPelvis/SciFiPleasurePanties/SciFiPleasurePanties.js
@@ -211,9 +211,7 @@ function InventoryItemPelvisSciFiPleasurePantiesShockTrigger() {
 	Dictionary.push({ Tag: "DestinationCharacterName", Text: C.Name, MemberNumber: C.MemberNumber });
     ChatRoomPublishCustomAction("SciFiPleasurePantiesShockTrigger" + DialogFocusItem.Property.ShockLevel, true, Dictionary);
 
-    CharacterSetFacialExpression(C, "Eyebrows", "Soft", 10);
-    CharacterSetFacialExpression(C, "Blush", "ShockLow", 15);
-    CharacterSetFacialExpression(C, "Eyes", "Closed", 5);
+	InventoryShockExpression(C);
 }
 
 function InventoryItemPelvisSciFiPleasurePantiesExit() {

--- a/BondageClub/Screens/Inventory/ItemVulva/FuturisticVibrator/FuturisticVibrator.js
+++ b/BondageClub/Screens/Inventory/ItemVulva/FuturisticVibrator/FuturisticVibrator.js
@@ -126,7 +126,15 @@ function InventoryItemVulvaFuturisticVibratorSetMode(C, Item, Option) {
 		Dictionary.push({ Automatic: true });
 		ServerSend("ChatRoomChat", { Content: Message, Type: "Action", Dictionary });
 	}
-    CharacterSetFacialExpression(C, "Blush", "Soft", 5);
+
+	if (C.OnlineSharedSettings && C.OnlineSharedSettings.ItemsAffectExpressions) {
+		if (Item.Property.Intensity > -1) {
+			CharacterSetFacialExpression(C, "Blush", "Medium", 5);
+		}
+		else {
+			CharacterSetFacialExpression(C, "Eyebrows", "Soft", 5);
+		}
+	}
 }
 
 // Trigger a shock automatically
@@ -140,9 +148,7 @@ function InventoryItemVulvaFuturisticVibratorTriggerShock(C, Item) {
 			ServerSend("ChatRoomChat", { Content: "FuturisticVibratorShockTrigger", Type: "Action", Dictionary });
 	}
 
-	CharacterSetFacialExpression(C, "Eyebrows", "Soft", 10);
-	CharacterSetFacialExpression(C, "Blush", "Soft", 15);
-	CharacterSetFacialExpression(C, "Eyes", "Closed", 5);
+	InventoryShockExpression(C);
 }
 
 

--- a/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
+++ b/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
@@ -1360,7 +1360,7 @@ function ChatRoomAttemptStandMinigameEnd() {
 			ServerSend("ChatRoomChat", { Content: (!Player.IsKneeling()) ? "KneelDownFail" : "StandUpFail", Type: "Action", Dictionary: [{ Tag: "SourceCharacter", Text: Player.Name, MemberNumber: Player.MemberNumber }] });
 			if (!Player.IsKneeling()) {
 				CharacterSetFacialExpression(Player, "Eyebrows", "Soft", 15);
-				CharacterSetFacialExpression(Player, "Blush", "Soft", 15);
+				CharacterSetFacialExpression(Player, "Blush", "Medium", 15);
 				CharacterSetFacialExpression(Player, "Eyes", "Dizzy", 15);
 			}
 		}

--- a/BondageClub/Scripts/ExtendedItem.js
+++ b/BondageClub/Scripts/ExtendedItem.js
@@ -327,8 +327,7 @@ function ExtendedItemSetType(C, Options, Option) {
 	if (!IsCloth) {
 		// If the item triggers an expression, start the expression change
 		if (Option.Expression) {
-			const E = Option.Expression[0];
-			CharacterSetFacialExpression(C, E.Group, E.Name, E.Timer);
+			InventoryExpressionTriggerApply(C, Option.Expression);
 		}
 		ChatRoomCharacterUpdate(C);
 		if (CurrentScreen === "ChatRoom") {

--- a/BondageClub/Scripts/Inventory.js
+++ b/BondageClub/Scripts/Inventory.js
@@ -1016,3 +1016,17 @@ function InventoryChatRoomAllow(Category) {
 				return false;
 	return true;
 }
+
+/**
+ * Applies a preset expression from being shocked to the character if able
+ * @param {Character} C - The character to update
+ * @returns {void} - Nothing
+ */
+function InventoryShockExpression(C) {
+	const expressions = [
+		{ Group: "Eyebrows", Name: "Soft", Timer: 10 },
+		{ Group: "Blush", Name: "Medium", Timer: 15 },
+		{ Group: "Eyes", Name: "Closed", Timer: 5 },
+	];
+	InventoryExpressionTriggerApply(C, expressions);
+}

--- a/BondageClub/Scripts/Inventory.js
+++ b/BondageClub/Scripts/Inventory.js
@@ -656,15 +656,30 @@ function InventoryGetItemProperty(Item, PropertyName, CheckGroup=false) {
 /**
 * Check if we must trigger an expression for the character after an item is used/applied
 * @param {Character} C - The character that we must validate
-* @param {Item} Item - The item from appearance that we must validate
+* @param {Item} item - The item from appearance that we must validate
 */
-function InventoryExpressionTrigger(C, Item) {
-	if ((Item != null) && (Item.Asset != null) && (Item.Asset.DynamicExpressionTrigger(C) != null))
-		for (let E = 0; E < Item.Asset.DynamicExpressionTrigger(C).length; E++) {
-			var Ex = InventoryGet(C, Item.Asset.DynamicExpressionTrigger(C)[E].Group);
-			if ((Ex == null) || (Ex.Property == null) || (Ex.Property.Expression == null) || (Ex.Property.Expression == ""))
-				CharacterSetFacialExpression(C, Item.Asset.DynamicExpressionTrigger(C)[E].Group, Item.Asset.DynamicExpressionTrigger(C)[E].Name, Item.Asset.DynamicExpressionTrigger(C)[E].Timer);
-		}
+function InventoryExpressionTrigger(C, item) {
+	const expressions = item.Asset.DynamicExpressionTrigger(C);
+	if (item && item.Asset && expressions) {
+		InventoryExpressionTriggerApply(C, expressions);
+	}
+}
+
+/**
+ * Apply an item's expression trigger to a character if able
+ * @param {Character} C - The character to update
+ * @param {ExpressionTrigger[]} expressions - The expression change to apply to each group
+ */
+function InventoryExpressionTriggerApply(C, expressions) {
+	const expressionsAllowed = C.ID === 0 || C.AccountName.startsWith("Online-") ? C.OnlineSharedSettings.ItemsAffectExpressions : true;
+	if (expressionsAllowed) {
+		expressions.forEach(expression => {
+			const targetGroupItem = InventoryGet(C, expression.Group);
+			if (!targetGroupItem || !targetGroupItem.Property || !targetGroupItem.Property.Expression) {
+				CharacterSetFacialExpression(C, expression.Group, expression.Name, expression.Timer);
+			}
+		});
+	}
 }
 
 /**

--- a/BondageClub/Scripts/Inventory.js
+++ b/BondageClub/Scripts/Inventory.js
@@ -659,9 +659,9 @@ function InventoryGetItemProperty(Item, PropertyName, CheckGroup=false) {
 * @param {Item} item - The item from appearance that we must validate
 */
 function InventoryExpressionTrigger(C, item) {
-	const expressions = item.Asset.DynamicExpressionTrigger(C);
-	if (item && item.Asset && expressions) {
-		InventoryExpressionTriggerApply(C, expressions);
+	if (item && item.Asset) {
+		const expressions = item.Asset.DynamicExpressionTrigger(C);
+		if (expressions) InventoryExpressionTriggerApply(C, expressions);
 	}
 }
 

--- a/BondageClub/Scripts/Struggle.js
+++ b/BondageClub/Scripts/Struggle.js
@@ -289,21 +289,22 @@ function StruggleStrength(Reverse) {
 	if (!Reverse) StruggleProgressStruggleCount++;
 	if ((StruggleProgressStruggleCount >= 50) && (StruggleProgressChallenge > 6) && (StruggleProgressAuto < 0)) StruggleProgressOperation = DialogFindPlayer("Impossible");
 
-	// At 15 hit: low blush, 50: Medium and 125: High
-	if (DialogAllowBlush && !Reverse) {
-		if (StruggleProgressStruggleCount == 15) CharacterSetFacialExpression(Player, "Blush", "Low");
-		if (StruggleProgressStruggleCount == 50) CharacterSetFacialExpression(Player, "Blush", "Medium");
-		if (StruggleProgressStruggleCount == 125) CharacterSetFacialExpression(Player, "Blush", "High");
+	if (!Reverse && Player.OnlineSharedSettings.ItemsAffectExpressions) {
+		// At 15 hit: low blush, 50: Medium and 125: High
+		if (DialogAllowBlush) {
+			if (StruggleProgressStruggleCount == 15) CharacterSetFacialExpression(Player, "Blush", "Low");
+			if (StruggleProgressStruggleCount == 50) CharacterSetFacialExpression(Player, "Blush", "Medium");
+			if (StruggleProgressStruggleCount == 125) CharacterSetFacialExpression(Player, "Blush", "High");
+		}
+
+		// At 15 hit: Start drooling
+		if (DialogAllowFluids) {
+			if (StruggleProgressStruggleCount == 15) CharacterSetFacialExpression(Player, "Fluids", "DroolMessy");
+		}
+
+		// Over 50 progress, the character frowns
+		if (DialogAllowEyebrows) CharacterSetFacialExpression(Player, "Eyebrows", (StruggleProgress >= 50) ? "Angry" : null);
 	}
-
-	// At 15 hit: Start drooling
-	if (DialogAllowFluids && !Reverse) {
-		if (StruggleProgressStruggleCount == 15) CharacterSetFacialExpression(Player, "Fluids", "DroolMessy");
-	}
-
-	// Over 50 progress, the character frowns
-	if (DialogAllowEyebrows && !Reverse) CharacterSetFacialExpression(Player, "Eyebrows", (StruggleProgress >= 50) ? "Angry" : null);
-
 
 }
 /**
@@ -611,21 +612,22 @@ function StruggleFlexibility(Reverse, Hover) {
 	if (!Reverse) StruggleProgressStruggleCount += 3;
 	if ((StruggleProgressStruggleCount >= 50) && (StruggleProgressChallenge > 6) && (StruggleProgressAuto < 0)) StruggleProgressOperation = DialogFindPlayer("Impossible");
 
-	// At 15 hit: low blush, 50: Medium and 125: High
-	if (DialogAllowBlush && !Reverse) {
-		if (StruggleProgressStruggleCount == 15) CharacterSetFacialExpression(Player, "Blush", "Low");
-		if (StruggleProgressStruggleCount == 50) CharacterSetFacialExpression(Player, "Blush", "Medium");
-		if (StruggleProgressStruggleCount == 125) CharacterSetFacialExpression(Player, "Blush", "High");
+	if (!Reverse && Player.OnlineSharedSettings.ItemsAffectExpressions) {
+		// At 15 hit: low blush, 50: Medium and 125: High
+		if (DialogAllowBlush) {
+			if (StruggleProgressStruggleCount == 15) CharacterSetFacialExpression(Player, "Blush", "Low");
+			if (StruggleProgressStruggleCount == 50) CharacterSetFacialExpression(Player, "Blush", "Medium");
+			if (StruggleProgressStruggleCount == 125) CharacterSetFacialExpression(Player, "Blush", "High");
+		}
+
+		// At 25 hit: Start one eye closed
+		if (DialogAllowFluids) {
+			if (StruggleProgressStruggleCount == 25) CharacterSetFacialExpression(Player, "Eyes2", "Closed");
+		}
+
+		// Over 50 progress, the character frowns
+		if (DialogAllowEyebrows) CharacterSetFacialExpression(Player, "Eyebrows", (StruggleProgress >= 50) ? "Angry" : null);
 	}
-
-	// At 25 hit: Start one eye closed
-	if (DialogAllowFluids && !Reverse) {
-		if (StruggleProgressStruggleCount == 25) CharacterSetFacialExpression(Player, "Eyes2", "Closed");
-	}
-
-	// Over 50 progress, the character frowns
-	if (DialogAllowEyebrows && !Reverse) CharacterSetFacialExpression(Player, "Eyebrows", (StruggleProgress >= 50) ? "Angry" : null);
-
 
 }
 
@@ -807,21 +809,22 @@ function StruggleDexterity(Reverse) {
 	StruggleProgressStruggleCount += Math.max(1, 3*(distMult + 0.5));
 	if ((StruggleProgressStruggleCount >= 50) && (StruggleProgressChallenge > 6) && (StruggleProgressAuto < 0)) StruggleProgressOperation = DialogFindPlayer("Impossible");
 
-	// At 15 hit: low blush, 50: Medium and 125: High
-	if (DialogAllowBlush) {
-		if (StruggleProgressStruggleCount == 15) CharacterSetFacialExpression(Player, "Blush", "Low");
-		if (StruggleProgressStruggleCount == 50) CharacterSetFacialExpression(Player, "Blush", "Medium");
-		if (StruggleProgressStruggleCount == 125) CharacterSetFacialExpression(Player, "Blush", "High");
+	if (Player.OnlineSharedSettings.ItemsAffectExpressions) {
+		// At 15 hit: low blush, 50: Medium and 125: High
+		if (DialogAllowBlush) {
+			if (StruggleProgressStruggleCount == 15) CharacterSetFacialExpression(Player, "Blush", "Low");
+			if (StruggleProgressStruggleCount == 50) CharacterSetFacialExpression(Player, "Blush", "Medium");
+			if (StruggleProgressStruggleCount == 125) CharacterSetFacialExpression(Player, "Blush", "High");
+		}
+
+		// At 25 hit: Eyes look glazed
+		if (DialogAllowFluids) {
+			if (StruggleProgressStruggleCount == 25) CharacterSetFacialExpression(Player, "Eyes", "Dazed");
+		}
+
+		// Over 50 progress, the character frowns
+		if (DialogAllowEyebrows) CharacterSetFacialExpression(Player, "Eyebrows", (StruggleProgress >= 50) ? "Angry" : null);
 	}
-
-	// At 25 hit: Eyes look glazed
-	if (DialogAllowFluids) {
-		if (StruggleProgressStruggleCount == 25) CharacterSetFacialExpression(Player, "Eyes", "Dazed");
-	}
-
-	// Over 50 progress, the character frowns
-	if (DialogAllowEyebrows) CharacterSetFacialExpression(Player, "Eyebrows", (StruggleProgress >= 50) ? "Angry" : null);
-
 
 }
 

--- a/BondageClub/Scripts/Typedef.d.ts
+++ b/BondageClub/Scripts/Typedef.d.ts
@@ -199,7 +199,7 @@ interface Asset {
 	DynamicDescription: (C: Character) => string;
 	DynamicPreviewIcon: (C: Character) => string;
 	DynamicAllowInventoryAdd: (C: Character) => boolean;
-	DynamicExpressionTrigger: (C: Character) => ExpressionTrigger;
+	DynamicExpressionTrigger: (C: Character) => ExpressionTrigger[];
 	DynamicName: (C?: Character) => string;
 	DynamicGroupName: string;
 	DynamicActivity: () => string[] | string | undefined;
@@ -408,6 +408,7 @@ interface Character {
 		AllowPlayerLeashing: boolean;
 		DisablePickingLocksOnSelf: boolean;
 		GameVersion: string;
+		ItemsAffectExpressions: boolean;
 	};
 	Game?: any;
 	BlackList: number[];


### PR DESCRIPTION
This adds a new "Items can affect your facial expression" shared preference in the General settings menu, true by default. When disabled, changes to facial expression triggered by assets or extended item options will no longer occur. It also disables expression changes from struggling. This option has been requested a few times.

Also:
- Fixes made to expression-affecting shocks which weren't applying the blush.
- Fixed the extended option expressions to allow several changes like assets (though the currently existing cases only ever change one).
- Tweaked some General settings to appear on Extreme difficulty but disabled instead of being hidden.