### PR TITLE
Feature: Extended modular item property support

### DIFF
--- a/BondageClub/Scripts/Common.js
+++ b/BondageClub/Scripts/Common.js
@@ -785,7 +785,7 @@ function CommonDeepEqual(obj1, obj2) {
  * Adds all items from the source array to the destination array if they aren't already included
  * @param {*[]} dest - The destination array
  * @param {*[]} src - The source array
- * @returns {void} - Nothing
+ * @returns {*[]} - The destination array
  */
 function CommonArrayConcatDedupe(dest, src) {
 	if (Array.isArray(src) && Array.isArray(dest)) {
@@ -793,6 +793,7 @@ function CommonArrayConcatDedupe(dest, src) {
 			if (!dest.includes(item)) dest.push(item);
 		}
 	}
+	return dest;
 }
 
 /**

--- a/BondageClub/Scripts/ModularItem.js
+++ b/BondageClub/Scripts/ModularItem.js
@@ -429,6 +429,9 @@ function ModularItemMergeModuleValues({ asset, modules }, moduleValues) {
 		if (Property.Effect) CommonArrayConcatDedupe(mergedProperty.Effect, Property.Effect);
 		if (Property.Hide) CommonArrayConcatDedupe(mergedProperty.Hide, Property.Hide);
 		if (Property.HideItem) CommonArrayConcatDedupe(mergedProperty.HideItem, Property.HideItem);
+		if (Property.SetPose) mergedProperty.SetPose = CommonArrayConcatDedupe(mergedProperty.SetPose || [], Property.SetPose);
+		if (typeof Property.OverridePriority === "number") mergedProperty.OverridePriority = Property.OverridePriority;
+		if (typeof Property.HeightModifier === "number") mergedProperty.HeightModifier = (mergedProperty.HeightModifier || 0) + Property.HeightModifier;
 		return mergedProperty;
 	}, {
 		Type: ModularItemConstructType(modules, moduleValues),


### PR DESCRIPTION
## Summary

This adds support for a few extra properties to modular items. These are things that are not currently used, but have been requested or discussed by other contributors. The newly supported properties are:

* `SetPose` - The `SetPose` array for each module will be merged into the final `SetPose` array. Asset contributors should take care not to create modular items where the `SetPose` properties might conflict or cause unpredictable results
* `OverridePriority` - The final merged `OverridePriority` will be the `OverridePriority` of the _last_ module that defines one. Again, asset contributors should take care not to create modular items where the `OverridePriority` properties might conflict or cause unpredictable results
* `HeightModifier` - The `HeightModifier` of each module will be summed to get the final `HeightModifier` value 