### PR TITLE
Save input text when relogging in chat rooms.

### DIFF
--- a/BondageClub/Screens/Character/Relog/Relog.js
+++ b/BondageClub/Screens/Character/Relog/Relog.js
@@ -3,6 +3,7 @@ var RelogBackground = "";
 var RelogCanvas = document.createElement("canvas");
 var RelogData = null;
 var RelogChatLog = null;
+var RelogInputText = "";
 
 /**
  * Loads the relog screen

--- a/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
+++ b/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
@@ -455,7 +455,9 @@ function ChatRoomCreateElement() {
 		if (RelogChatLog != null) {
 			while (RelogChatLog.children.length > 0)
 				document.getElementById("TextAreaChatLog").appendChild(RelogChatLog.children[0]);
+			ElementValue("InputChat", RelogInputText);
 			RelogChatLog = null;
+			RelogInputText = "";
 		} else ElementContent("TextAreaChatLog", "");
 
 		// Creates listener for resize events.

--- a/BondageClub/Scripts/Server.js
+++ b/BondageClub/Scripts/Server.js
@@ -193,12 +193,16 @@ function ServerDisconnect(data, close = false) {
 				RelogChatLog = document.getElementById("TextAreaChatLog").cloneNode(true);
 				RelogChatLog.id = "RelogChatLog";
 				RelogChatLog.name = "RelogChatLog";
+				RelogInputText = ElementValue("InputChat").trim();
 				ElementRemove("InputChat");
 				ElementRemove("TextAreaChatLog");
 				CurrentScreen = "ChatSearch";
 				CurrentModule = "Online";
 				CurrentCharacter = null;
-			} else RelogChatLog = null;
+			} else {
+				RelogChatLog = null;
+				RelogInputText = "";
+			}
 
 			// Keeps the relog data
 			RelogData = { Screen: CurrentScreen, Module: CurrentModule, Character: CurrentCharacter };


### PR DESCRIPTION
When relogging, the contents of InputChat are saved in the same manner that the chat log is saved.

This pull request is motivated by having, multiple times, lost a paragraph I was typing because there was a disconnect to the server and I had to retype the entire thing.  Now, the text that was being entered wont get cleared and wont have to be retyped.