### PR TITLE
Advanced Vibrator Modes Disable

### DIFF
--- a/BondageClub/Screens/Character/Preference/Preference.js
+++ b/BondageClub/Screens/Character/Preference/Preference.js
@@ -215,6 +215,7 @@ function PreferenceInit(C) {
 	if (typeof C.ArousalSettings.Active !== "string") C.ArousalSettings.Active = "Hybrid";
 	if (typeof C.ArousalSettings.Visible !== "string") C.ArousalSettings.Visible = "Access";
 	if (typeof C.ArousalSettings.ShowOtherMeter !== "boolean") C.ArousalSettings.ShowOtherMeter = true;
+	if (typeof C.ArousalSettings.DisableAdvancedVibes !== "boolean") C.ArousalSettings.DisableAdvancedVibes = false;
 	if (typeof C.ArousalSettings.AffectExpression !== "boolean") C.ArousalSettings.AffectExpression = true;
 	if (typeof C.ArousalSettings.AffectStutter !== "string") C.ArousalSettings.AffectStutter = "All";
 	if (typeof C.ArousalSettings.VFX !== "string") C.ArousalSettings.VFX = "VFXAnimatedTemp";
@@ -482,6 +483,7 @@ function PreferenceInitPlayer() {
 		C.GameplaySettings.SensDepChatLog = PreferenceSettingsSensDepList[PreferenceSettingsSensDepIndex];
 		C.GameplaySettings.BlindDisableExamine = true;
 		C.GameplaySettings.DisableAutoRemoveLogin = true;
+		C.ArousalSettings.DisableAdvancedVibes = false;
 		C.GameplaySettings.ImmersionLockSetting = true;
 		C.ImmersionSettings.BlockGaggedOOC = true;
 		C.ImmersionSettings.StimulationEvents = true;
@@ -1129,19 +1131,21 @@ function PreferenceSubscreenArousalRun() {
 	MainCanvas.textAlign = "left";
 	DrawText(TextGet("ArousalPreferences"), 550, 125, "Black", "Gray");
 	DrawText(TextGet("ArousalActive"), 550, 225, "Black", "Gray");
-	DrawText(TextGet("ArousalStutter"), 550, 410, "Black", "Gray");
-	DrawCheckbox(550, 286, 64, 64, TextGet("ArousalShowOtherMeter"), Player.ArousalSettings.ShowOtherMeter);
+	DrawText(TextGet("ArousalStutter"), 550, 460, "Black", "Gray");
+	DrawCheckbox(550, 276, 64, 64, TextGet("ArousalShowOtherMeter"), Player.ArousalSettings.ShowOtherMeter);
+	DrawCheckbox(550, 356, 64, 64, TextGet("ArousalDisableAdvancedVibes"), Player.ArousalSettings.DisableAdvancedVibes, Player.GetDifficulty() >= 3);
+	
 
 	// The other controls are only drawn if the arousal is active
 	if (PreferenceArousalIsActive()) {
 
 		// Draws the labels and check boxes
-		DrawCheckbox(1250, 286, 64, 64, TextGet("ArousalAffectExpression"), Player.ArousalSettings.AffectExpression);
+		DrawCheckbox(1250, 276, 64, 64, TextGet("ArousalAffectExpression"), Player.ArousalSettings.AffectExpression);
 		DrawText(TextGet("ArousalVisible"), 1240, 225, "Black", "Gray");
-		DrawText(TextGet("ArousalFetish"), 550, 495, "Black", "Gray");
-		DrawText(TextGet("ArousalActivity"), 550, 580, "Black", "Gray");
-		DrawText(TextGet("ArousalActivityLoveSelf"), 550, 665, "Black", "Gray");
-		DrawText(TextGet("ArousalActivityLoveOther"), 1255, 665, "Black", "Gray");
+		DrawText(TextGet("ArousalFetish"), 550, 555, "Black", "Gray");
+		DrawText(TextGet("ArousalActivity"), 550, 640, "Black", "Gray");
+		DrawText(TextGet("ArousalActivityLoveSelf"), 550, 725, "Black", "Gray");
+		DrawText(TextGet("ArousalActivityLoveOther"), 1255, 725, "Black", "Gray");
 
 		// Draws all the available character zones
 		for (let A = 0; A < AssetGroup.length; A++)
@@ -1150,30 +1154,30 @@ function PreferenceSubscreenArousalRun() {
 
 		// The zones can be selected and drawn on the character
 		if (Player.FocusGroup != null) {
-			DrawCheckbox(1230, 813, 64, 64, TextGet("ArousalAllowOrgasm"), PreferenceGetZoneOrgasm(Player, Player.FocusGroup.Name));
-			DrawText(TextGet("ArousalZone" + Player.FocusGroup.Name) + " - " + TextGet("ArousalConfigureErogenousZones"), 550, 745, "Black", "Gray");
+			DrawCheckbox(1230, 853, 64, 64, TextGet("ArousalAllowOrgasm"), PreferenceGetZoneOrgasm(Player, Player.FocusGroup.Name));
+			DrawText(TextGet("ArousalZone" + Player.FocusGroup.Name) + " - " + TextGet("ArousalConfigureErogenousZones"), 550, 795, "Black", "Gray");
 			DrawAssetGroupZone(Player, Player.FocusGroup.Zone, 0.9, 50, 50, 1, "cyan");
 			MainCanvas.textAlign = "center";
-			DrawBackNextButton(550, 813, 600, 64, TextGet("ArousalZoneLove" + PreferenceArousalZoneFactor), PreferenceGetFactorColor(PreferenceGetZoneFactor(Player, Player.FocusGroup.Name)), "", () => "", () => "");
+			DrawBackNextButton(550, 853, 600, 64, TextGet("ArousalZoneLove" + PreferenceArousalZoneFactor), PreferenceGetFactorColor(PreferenceGetZoneFactor(Player, Player.FocusGroup.Name)), "", () => "", () => "");
 		}
-		else DrawText(TextGet("ArousalSelectErogenousZones"), 550, 745, "Black", "Gray");
+		else DrawText(TextGet("ArousalSelectErogenousZones"), 550, 795, "Black", "Gray");
 
 		// Draws the sub-selection controls
 		MainCanvas.textAlign = "center";
 		DrawBackNextButton(1505, 193, 400, 64, TextGet("ArousalVisible" + PreferenceArousalVisibleList[PreferenceArousalVisibleIndex]), "White", "", () => "", () => "");
-		DrawBackNextButton(900, 548, 500, 64, ActivityDictionaryText("Activity" + PreferenceArousalActivityList[PreferenceArousalActivityIndex]), "White", "", () => "", () => "");
-		DrawBackNextButton(900, 633, 300, 64, TextGet("ArousalActivityLove" + PreferenceArousalActivityFactorSelf), PreferenceGetFactorColor(PreferenceGetActivityFactor(Player, PreferenceArousalActivityList[PreferenceArousalActivityIndex], true)), "", () => "", () => "");
-		DrawBackNextButton(1605, 633, 300, 64, TextGet("ArousalActivityLove" + PreferenceArousalActivityFactorOther), PreferenceGetFactorColor(PreferenceGetActivityFactor(Player, PreferenceArousalActivityList[PreferenceArousalActivityIndex], false)), "", () => "", () => "");
+		DrawBackNextButton(900, 598, 500, 64, ActivityDictionaryText("Activity" + PreferenceArousalActivityList[PreferenceArousalActivityIndex]), "White", "", () => "", () => "");
+		DrawBackNextButton(900, 683, 300, 64, TextGet("ArousalActivityLove" + PreferenceArousalActivityFactorSelf), PreferenceGetFactorColor(PreferenceGetActivityFactor(Player, PreferenceArousalActivityList[PreferenceArousalActivityIndex], true)), "", () => "", () => "");
+		DrawBackNextButton(1605, 683, 300, 64, TextGet("ArousalActivityLove" + PreferenceArousalActivityFactorOther), PreferenceGetFactorColor(PreferenceGetActivityFactor(Player, PreferenceArousalActivityList[PreferenceArousalActivityIndex], false)), "", () => "", () => "");
 
 		// Fetish elements
-		DrawBackNextButton(900, 463, 500, 64, TextGet("ArousalFetish" + PreferenceArousalFetishList[PreferenceArousalFetishIndex]), "White", "", () => "", () => "");
-		DrawBackNextButton(1455, 463, 450, 64, TextGet("ArousalFetishLove" + PreferenceArousalFetishFactor), PreferenceGetFactorColor(PreferenceGetFetishFactor(Player, PreferenceArousalFetishList[PreferenceArousalFetishIndex], false)), "", () => "", () => "");
+		DrawBackNextButton(900, 513, 500, 64, TextGet("ArousalFetish" + PreferenceArousalFetishList[PreferenceArousalFetishIndex]), "White", "", () => "", () => "");
+		DrawBackNextButton(1455, 513, 450, 64, TextGet("ArousalFetishLove" + PreferenceArousalFetishFactor), PreferenceGetFactorColor(PreferenceGetFetishFactor(Player, PreferenceArousalFetishList[PreferenceArousalFetishIndex], false)), "", () => "", () => "");
 	}
 
 	// We always draw the active & stutter control
 	MainCanvas.textAlign = "center";
 	DrawBackNextButton(750, 193, 450, 64, TextGet("ArousalActive" + PreferenceArousalActiveList[PreferenceArousalActiveIndex]), "White", "", () => "", () => "");
-	DrawBackNextButton(900, 378, 500, 64, TextGet("ArousalStutter" + PreferenceArousalAffectStutterList[PreferenceArousalAffectStutterIndex]), "White", "", () => "", () => "");
+	DrawBackNextButton(900, 428, 500, 64, TextGet("ArousalStutter" + PreferenceArousalAffectStutterList[PreferenceArousalAffectStutterIndex]), "White", "", () => "", () => "");
 	DrawButton(1815, 75, 90, 90, "", "White", "Icons/Exit.png");
 
 }
@@ -1474,21 +1478,25 @@ function PreferenceSubscreenArousalClick() {
 	}
 
 	// Speech stuttering control
-	if (MouseIn(900, 378, 500, 64)) {
+	if (MouseIn(900, 428, 500, 64)) {
 		if (MouseX <= 1150) PreferenceArousalAffectStutterIndex = (PreferenceArousalAffectStutterList.length + PreferenceArousalAffectStutterIndex - 1) % PreferenceArousalAffectStutterList.length;
 		else PreferenceArousalAffectStutterIndex = (PreferenceArousalAffectStutterIndex + 1) % PreferenceArousalAffectStutterList.length;
 		Player.ArousalSettings.AffectStutter = PreferenceArousalAffectStutterList[PreferenceArousalAffectStutterIndex];
 	}
 
 	// Show other player meter check box
-	if (MouseIn(550, 286, 64, 350))
+	if (MouseIn(550, 276, 64, 64))
 		Player.ArousalSettings.ShowOtherMeter = !Player.ArousalSettings.ShowOtherMeter;
+	
+	// Block advanced modes check box
+	if (MouseIn(550, 356, 64, 64) && Player.GetDifficulty() < 3)
+		Player.ArousalSettings.DisableAdvancedVibes = !Player.ArousalSettings.DisableAdvancedVibes;
 
 	// If the arousal is active, we allow more controls
 	if (PreferenceArousalIsActive()) {
 
 		// Meter affect your facial expressions check box
-		if (MouseIn(1250, 286, 64, 64))
+		if (MouseIn(1250, 276, 64, 64))
 			Player.ArousalSettings.AffectExpression = !Player.ArousalSettings.AffectExpression;
 
 		// Arousal visible control
@@ -1499,14 +1507,14 @@ function PreferenceSubscreenArousalClick() {
 		}
 
 		// Fetish master control
-		if (MouseIn(900, 463, 500, 64)) {
+		if (MouseIn(900, 513, 500, 64)) {
 			if (MouseX <= 1150) PreferenceArousalFetishIndex = (PreferenceArousalFetishList.length + PreferenceArousalFetishIndex - 1) % PreferenceArousalFetishList.length;
 			else PreferenceArousalFetishIndex = (PreferenceArousalFetishIndex + 1) % PreferenceArousalFetishList.length;
 			PreferenceLoadFetishFactor();
 		}
 
 		// Fetish love control
-		if (MouseIn(1455, 463, 450, 64)) {
+		if (MouseIn(1455, 513, 450, 64)) {
 			if (MouseX <= 1680) PreferenceArousalFetishFactor = (5 + PreferenceArousalFetishFactor - 1) % 5;
 			else PreferenceArousalFetishFactor = (PreferenceArousalFetishFactor + 1) % 5;
 			for (let F = 0; F < Player.ArousalSettings.Fetish.length; F++)
@@ -1515,35 +1523,35 @@ function PreferenceSubscreenArousalClick() {
 		}
 
 		// Arousal activity control
-		if (MouseIn(900, 548, 500, 64)) {
+		if (MouseIn(900, 598, 500, 64)) {
 			if (MouseX <= 1150) PreferenceArousalActivityIndex = (PreferenceArousalActivityList.length + PreferenceArousalActivityIndex - 1) % PreferenceArousalActivityList.length;
 			else PreferenceArousalActivityIndex = (PreferenceArousalActivityIndex + 1) % PreferenceArousalActivityList.length;
 			PreferenceLoadActivityFactor();
 		}
 
 		// Arousal activity love on self control
-		if (MouseIn(900, 633, 300, 64)) {
+		if (MouseIn(900, 683, 300, 64)) {
 			if (MouseX <= 1050) PreferenceArousalActivityFactorSelf = (5 + PreferenceArousalActivityFactorSelf - 1) % 5;
 			else PreferenceArousalActivityFactorSelf = (PreferenceArousalActivityFactorSelf + 1) % 5;
 			PreferenceSetActivityFactor(Player, PreferenceArousalActivityList[PreferenceArousalActivityIndex], true, PreferenceArousalActivityFactorSelf);
 		}
 
 		// Arousal activity love on other control
-		if (MouseIn(1605, 633, 300, 64)) {
+		if (MouseIn(1605, 683, 300, 64)) {
 			if (MouseX <= 1755) PreferenceArousalActivityFactorOther = (5 + PreferenceArousalActivityFactorOther - 1) % 5;
 			else PreferenceArousalActivityFactorOther = (PreferenceArousalActivityFactorOther + 1) % 5;
 			PreferenceSetActivityFactor(Player, PreferenceArousalActivityList[PreferenceArousalActivityIndex], false, PreferenceArousalActivityFactorOther);
 		}
 
 		// Arousal zone love control
-		if ((Player.FocusGroup != null) && MouseIn(550, 813, 600, 64)) {
+		if ((Player.FocusGroup != null) && MouseIn(550, 853, 600, 64)) {
 			if (MouseX <= 850) PreferenceArousalZoneFactor = (5 + PreferenceArousalZoneFactor - 1) % 5;
 			else PreferenceArousalZoneFactor = (PreferenceArousalZoneFactor + 1) % 5;
 			PreferenceSetZoneFactor(Player, Player.FocusGroup.Name, PreferenceArousalZoneFactor);
 		}
 
 		// Arousal zone orgasm check box
-		if ((Player.FocusGroup != null) && MouseIn(1230, 813, 64, 64))
+		if ((Player.FocusGroup != null) && MouseIn(1230, 853, 64, 64))
 			PreferenceSetZoneOrgasm(Player, Player.FocusGroup.Name, !PreferenceGetZoneOrgasm(Player, Player.FocusGroup.Name));
 
 		// In arousal mode, the player can click on her zones

--- a/BondageClub/Screens/Character/Preference/Text_Preference.csv
+++ b/BondageClub/Screens/Character/Preference/Text_Preference.csv
@@ -128,6 +128,7 @@ DisablePickingLocksOnSelf,Locks on you can't be picked
 BlindDisableExamine,Disable examining when blind
 DisableAutoRemoveLogin,Keep all restraints when relogging
 OfflineLockedRestrained,Cannot enter single-player rooms when restrained
+ArousalDisableAdvancedVibes,"Block advanced vibrator modes (edge, random, etc)"
 GeneralHardcoreWarning,Safewords and help from NPCs are disabled on Hardcore or Extreme
 ItemsAffectExpressions,Items can affect your facial expression
 GeneralAnimationQuality0,Max

--- a/BondageClub/Scripts/Validation.js
+++ b/BondageClub/Scripts/Validation.js
@@ -553,7 +553,7 @@ function ValidationSanitizeProperties(C, item) {
 	}
 	
 	// Block advanced vibrator modes if disabled
-	if (property && typeof property.Mode === "string" && Player.ArousalSettings && Player.ArousalSettings.DisableAdvancedVibes) {
+	if (typeof property.Mode === "string"&& Player.ArousalSettings && Player.ArousalSettings.DisableAdvancedVibes && !VibratorModeOptions[VibratorModeSet.STANDARD].includes(VibratorModeGetOption(property.Mode)) ) {
 		console.warn(`Removing invalid mode "${property.Mode}" from ${asset.Name}`);
 		property.Mode = VibratorModeOptions[VibratorModeSet.STANDARD][0];
 		changed = true;

--- a/BondageClub/Scripts/Validation.js
+++ b/BondageClub/Scripts/Validation.js
@@ -551,6 +551,13 @@ function ValidationSanitizeProperties(C, item) {
 			}
 		});
 	}
+	
+	// Block advanced vibrator modes if disabled
+	if (property && typeof property.Mode === "string" && Player.ArousalSettings && Player.ArousalSettings.DisableAdvancedVibes) {
+		console.warn(`Removing invalid mode "${property.Mode}" from ${asset.Name}`);
+		property.Mode = VibratorModeOptions[VibratorModeSet.STANDARD][0];
+		changed = true;
+	}
 
 	return changed;
 }

--- a/BondageClub/Scripts/Validation.js
+++ b/BondageClub/Scripts/Validation.js
@@ -553,7 +553,7 @@ function ValidationSanitizeProperties(C, item) {
 	}
 	
 	// Block advanced vibrator modes if disabled
-	if (typeof property.Mode === "string"&& Player.ArousalSettings && Player.ArousalSettings.DisableAdvancedVibes && !VibratorModeOptions[VibratorModeSet.STANDARD].includes(VibratorModeGetOption(property.Mode)) ) {
+	if (typeof property.Mode === "string" && C.ArousalSettings && C.ArousalSettings.DisableAdvancedVibes && !VibratorModeOptions[VibratorModeSet.STANDARD].includes(VibratorModeGetOption(property.Mode))) {
 		console.warn(`Removing invalid mode "${property.Mode}" from ${asset.Name}`);
 		property.Mode = VibratorModeOptions[VibratorModeSet.STANDARD][0];
 		changed = true;

--- a/BondageClub/Scripts/VibratorMode.js
+++ b/BondageClub/Scripts/VibratorMode.js
@@ -187,6 +187,7 @@ function VibratorModeDrawHeader() {
  */
 function VibratorModeDrawControls(Options, Y) {
 	Y = typeof Y === "number" ? Y : 450;
+	let C = CharacterGetCurrent();
 	Options = Options || [VibratorModeSet.STANDARD];
 	var Property = DialogFocusItem.Property;
 	if (Property == null) return;
@@ -198,7 +199,7 @@ function VibratorModeDrawControls(Options, Y) {
 		OptionGroup.forEach((Option, I) => {
 			var X = 1175 + (I % 3) * 225;
 			if (I % 3 === 0) Y += 75;
-			var Color = Property.Mode === Option.Property.Mode ? "#888" : (!(OptionName == VibratorModeSet.ADVANCED && CurrentCharacter.ArousalSettings && CurrentCharacter.ArousalSettings.DisableAdvancedVibes) ? "White" : "Pink");
+			var Color = Property.Mode === Option.Property.Mode ? "#888" : (!(OptionName == VibratorModeSet.ADVANCED && C.ArousalSettings && C.ArousalSettings.DisableAdvancedVibes) ? "White" : "Pink");
 			DrawButton(X, Y, 200, 55, DialogFindPlayer(Option.Name), Color);
 		});
 		Y += 40;
@@ -213,6 +214,7 @@ function VibratorModeDrawControls(Options, Y) {
  */
 function VibratorModeClick(Options, Y) {
 	Y = typeof Y === "number" ? Y : 450;
+	let C = CharacterGetCurrent();
 	// Exit Button
 	if (MouseIn(1885, 25, 90, 85)) DialogFocusItem = null;
 
@@ -222,7 +224,7 @@ function VibratorModeClick(Options, Y) {
 			var X = 1175 + (I % 3) * 225;
 			if (I % 3 === 0) Y += 75;
 			if (MouseIn(X, Y, 200, 55)) {
-				if ((Option.Property != null) && (DialogFocusItem.Property != null) && (Option.Property.Mode !== DialogFocusItem.Property.Mode) && !(OptionName == VibratorModeSet.ADVANCED && CurrentCharacter.ArousalSettings && CurrentCharacter.ArousalSettings.DisableAdvancedVibes))
+				if ((Option.Property != null) && (DialogFocusItem.Property != null) && (Option.Property.Mode !== DialogFocusItem.Property.Mode) && !(OptionName == VibratorModeSet.ADVANCED && C.ArousalSettings && C.ArousalSettings.DisableAdvancedVibes))
 					VibratorModeSetMode(Option);
 				return true;
 			}

--- a/BondageClub/Scripts/VibratorMode.js
+++ b/BondageClub/Scripts/VibratorMode.js
@@ -198,7 +198,7 @@ function VibratorModeDrawControls(Options, Y) {
 		OptionGroup.forEach((Option, I) => {
 			var X = 1175 + (I % 3) * 225;
 			if (I % 3 === 0) Y += 75;
-			var Color = Property.Mode === Option.Property.Mode ? "#888" : "White";
+			var Color = Property.Mode === Option.Property.Mode ? "#888" : (!(OptionName == VibratorModeSet.ADVANCED && CurrentCharacter.ArousalSettings && CurrentCharacter.ArousalSettings.DisableAdvancedVibes) ? "White" : "Pink");
 			DrawButton(X, Y, 200, 55, DialogFindPlayer(Option.Name), Color);
 		});
 		Y += 40;
@@ -222,7 +222,7 @@ function VibratorModeClick(Options, Y) {
 			var X = 1175 + (I % 3) * 225;
 			if (I % 3 === 0) Y += 75;
 			if (MouseIn(X, Y, 200, 55)) {
-				if ((Option.Property != null) && (DialogFocusItem.Property != null) && (Option.Property.Mode !== DialogFocusItem.Property.Mode))
+				if ((Option.Property != null) && (DialogFocusItem.Property != null) && (Option.Property.Mode !== DialogFocusItem.Property.Mode) && !(OptionName == VibratorModeSet.ADVANCED && CurrentCharacter.ArousalSettings && CurrentCharacter.ArousalSettings.DisableAdvancedVibes))
 					VibratorModeSetMode(Option);
 				return true;
 			}


### PR DESCRIPTION
Allows the player (if appearance is below Extreme) to block advanced vibrator modes in the arousal menu. If the player is extreme, it is forced off (because the player cannot block any items or types).

Also adds validation to prevent trolling.