### PR TITLE
fix light/dark 2 mobile

### DIFF
--- a/BondageClub/CSS/Styles.css
+++ b/BondageClub/CSS/Styles.css
@@ -75,11 +75,8 @@ TextArea {
 #TextAreaChatLog[data-colortheme=dark] .ChatMessageWhisper, #TextAreaChatLog[data-colortheme="dark2"] .ChatMessageWhisper {
   color: #555;
 }
-#TextAreaChatLog[data-colortheme="dark2"], #TextAreaChatLog[data-colortheme="light2"] {
-  font-size: 1.6rem !important;
-}
+
 #TextAreaChatLog[data-colortheme="dark2"] .ChatMessage, #TextAreaChatLog[data-colortheme="light2"] .ChatMessage {
-  font-size: 1.4rem;
   line-height: 1.4em;
   padding: 0.1em;
   padding-right: 2em;


### PR DESCRIPTION
- Fixed the newer chat styles (dark/light 2) on mobile.
Font-size was insanely huge on mobile, removing these keeps it on par with other styles and doesn't change much other than making it usable on mobile/small windows.

(Had Ellie's permission for this fix)