### PR TITLE
Bugfix: Cafe item fixes

### DIFF
--- a/BondageClub/Screens/Room/Cafe/Cafe.js
+++ b/BondageClub/Screens/Room/Cafe/Cafe.js
@@ -208,8 +208,9 @@ function CafeServiceBound(Style) {
 		if (Bondage == "ClothGag") {
             Player.FocusGroup = AssetGroupGet("Female3DCG", "ItemMouth");
 			DialogExtendItem(InventoryGet(Player, "ItemMouth"));
-			Option = CommonRandomItemFromList(null, InventoryItemMouthClothGagOptions);
-			ExtendedItemSetType(Player, InventoryItemMouthClothGagOptions, Option);
+			const Options = TypedItemGetOptions("ItemMouth", Bondage);
+			Option = CommonRandomItemFromList(null, Options);
+			ExtendedItemSetType(Player, Options, Option);
 		}
 	}
 
@@ -231,8 +232,9 @@ function CafeServiceBound(Style) {
         // Gag Sub Type
         Player.FocusGroup = AssetGroupGet("Female3DCG", "ItemMouth");
         DialogExtendItem(InventoryGet(Player, "ItemMouth"));
-        Option = CommonRandomItemFromList(null, InventoryItemMouthDuctTapeOptions);
-        ExtendedItemSetType(Player, InventoryItemMouthDuctTapeOptions, Option);
+        const Options = TypedItemGetOptions("ItemMouth", "DuctTape")
+        Option = CommonRandomItemFromList(null, Options);
+        ExtendedItemSetType(Player, Options, Option);
 	}
 
 	if (Style == "Leather") {
@@ -249,8 +251,9 @@ function CafeServiceBound(Style) {
 		if (Bondage == "LeatherCuffs") {
             Player.FocusGroup = AssetGroupGet("Female3DCG", "ItemArms");
             DialogExtendItem(InventoryGet(Player, "ItemArms"));
-            Option = CommonRandomItemFromList(null, InventoryItemArmsLeatherCuffsOptions);
-            ExtendedItemSetType(Player, InventoryItemArmsLeatherCuffsOptions, Option);
+            const Options = TypedItemGetOptions("ItemArms", Bondage);
+            Option = CommonRandomItemFromList(null, Options);
+            ExtendedItemSetType(Player, Options, Option);
 		}
 
 		// Legs
@@ -265,7 +268,8 @@ function CafeServiceBound(Style) {
 		if (Bondage == "LeatherLegCuffs") {
             Player.FocusGroup = AssetGroupGet("Female3DCG", "ItemLegs");
 			DialogExtendItem(InventoryGet(Player, "ItemLegs"));
-			InventoryItemLegsLeatherLegCuffsSetPose("Closed");
+			const Option = InventoryItemLegsLeatherLegCuffsOptions.find(O => O.Name === "Closed");
+			ExtendedItemSetType(Player, InventoryItemLegsLeatherLegCuffsOptions, Option);
 		}
 
 		// Gag
@@ -315,9 +319,9 @@ function CafeServiceBound(Style) {
 		if (Bondage == "PumpGag") {
             Player.FocusGroup = AssetGroupGet("Female3DCG", "ItemMouth");
             DialogExtendItem(InventoryGet(Player, "ItemMouth"));
-            Option = CommonRandomItemFromList(null, InventoryItemMouthPumpGagOptions);
-            ExtendedItemSetType(Player, InventoryItemMouthPumpGagOptions, Option);
-            CharacterLoadEffect(Player);
+            const Options = TypedItemGetOptions("ItemMouth", Bondage);
+            Option = CommonRandomItemFromList(null, Options);
+            ExtendedItemSetType(Player, Options, Option);
 		}
 	}
 
@@ -335,8 +339,9 @@ function CafeServiceBound(Style) {
 		if (Bondage == "StraitJacket") {
             Player.FocusGroup = AssetGroupGet("Female3DCG", "ItemArms");
 			DialogExtendItem(InventoryGet(Player, "ItemArms"));
-			const Option = CommonRandomItemFromList(null, InventoryItemArmsStraitJacketOptions);
-			ExtendedItemSetType(Player, InventoryItemArmsStraitJacketOptions, Option);
+			const Options = TypedItemGetOptions("ItemArms", Bondage);
+			const Option = CommonRandomItemFromList(null, Options);
+			ExtendedItemSetType(Player, Options, Option);
 		}
 
 		// Legs
@@ -353,7 +358,8 @@ function CafeServiceBound(Style) {
 			if (Bondage == "LeatherLegCuffs") {
                 Player.FocusGroup = AssetGroupGet("Female3DCG", "ItemLegs");
 				DialogExtendItem(InventoryGet(Player, "ItemLegs"));
-				InventoryItemLegsLeatherLegCuffsSetPose("Closed");
+				const Option = InventoryItemLegsLeatherLegCuffsOptions.find(O => O.Name === "Closed");
+				ExtendedItemSetType(Player, InventoryItemLegsLeatherLegCuffsOptions, Option);
 			}
 		}
 
@@ -371,16 +377,18 @@ function CafeServiceBound(Style) {
 		if (Bondage == "PumpGag") {
             Player.FocusGroup = AssetGroupGet("Female3DCG", "ItemMouth");
             DialogExtendItem(InventoryGet(Player, "ItemMouth"));
-            Option = CommonRandomItemFromList(null, InventoryItemMouthPumpGagOptions);
-            ExtendedItemSetType(Player, InventoryItemMouthPumpGagOptions, Option);
+            const Options = TypedItemGetOptions("ItemMouth", Bondage);
+            Option = CommonRandomItemFromList(null, Options);
+            ExtendedItemSetType(Player, Options, Option);
             CharacterLoadEffect(Player);
 		}
 
 		if (Bondage == "PlugGag") {
             Player.FocusGroup = AssetGroupGet("Female3DCG", "ItemMouth");
 			DialogExtendItem(InventoryGet(Player, "ItemMouth"));
-			Option = CommonRandomItemFromList(null, InventoryItemMouthPlugGagOptions);
-			ExtendedItemSetType(Player, InventoryItemMouthPlugGagOptions, Option);
+			const Options = TypedItemGetOptions("ItemMouth", Bondage);
+			Option = CommonRandomItemFromList(null, Options);
+			ExtendedItemSetType(Player, Options, Option);
 		}
 
 		// Head
@@ -443,6 +451,6 @@ function CafeGivenDildo() {
  */
 function CafeTurnDildoUp() {
 	DialogExtendItem(InventoryGet(Player, "ItemVulva"));
-	InventoryItemVulvaInflatableVibeDildoSetIntensity(1);
+	InventoryItemButtInflVibeButtPlugSetIntensity(1);
 	CafeVibeIncreased = true;
 }

--- a/BondageClub/Scripts/TypedItem.js
+++ b/BondageClub/Scripts/TypedItem.js
@@ -257,3 +257,26 @@ function TypedItemMapChatTagToDictionaryEntry(C, asset, tag) {
 			return null;
 	}
 }
+
+/**
+ * Returns the options configuration array for a typed item
+ * @param {string} groupName - The name of the asset group
+ * @param {string} assetName - The name of the asset
+ * @returns {ExtendedItemOption[]|null} - The options array for the item, or null if no typed item data was found
+ */
+function TypedItemGetOptions(groupName, assetName) {
+	const data = TypedItemDataLookup[`${groupName}${assetName}`];
+	return data ? data.options : null;
+}
+
+/**
+ * Returns the named option configuration object for a typed item
+ * @param {string} groupName - The name of the asset group
+ * @param {string} assetName - The name of the asset
+ * @param {string} optionName - The name of the option
+ * @returns {ExtendedItemOption|null} - The named option configuration object, or null if none was found
+ */
+function TypedItemGetOption(groupName, assetName, optionName) {
+	const options = TypedItemGetOptions(groupName, assetName);
+	return options ? options.find(option => option.Name === optionName) : null;
+}


### PR DESCRIPTION
## Summary

Over the last release or two, several items have been migrated over to the archetype system. However, the Cafe room was making use of the options objects that were previously defined in the item scripts. This would cause the Cafe to crash on several of the Cafe maid's dialogue options. This updates the Cafe code to get the options objects out of the typed item data lookup, which restores the previous functionality.