### PR TITLE
Feature: Chat font size preference

### DIFF
--- a/BondageClub/Screens/Character/Preference/Preference.js
+++ b/BondageClub/Screens/Character/Preference/Preference.js
@@ -2,7 +2,6 @@
 var PreferenceBackground = "Sheet";
 var PreferenceMessage = "";
 var PreferenceSafewordConfirm = false;
-var PreferenceMaidsButton = true;
 var PreferenceColorPick = "";
 var PreferenceSubscreen = "";
 var PreferenceSubscreenList = ["General", "Difficulty", "Restriction", "Chat", "Audio", "Arousal", "Security", "Online", "Visibility", "Immersion", "Graphics", "Controller", "Notifications"];
@@ -25,7 +24,6 @@ var PreferenceSettingsDeadZoneList = [0, 0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.0
 var PreferenceSettingsVolumeIndex = 0;
 var PreferenceSettingsSensitivityIndex = 13;
 var PreferenceSettingsDeadZoneIndex = 1;
-var PreferenceEmailStatusReceived = false;
 var PreferenceArousalActiveList = ["Inactive", "NoMeter", "Manual", "Hybrid", "Automatic"];
 var PreferenceArousalActiveIndex = 0;
 var PreferenceArousalVisibleList = ["All", "Access", "Self"];

--- a/BondageClub/Screens/Character/Preference/Preference.js
+++ b/BondageClub/Screens/Character/Preference/Preference.js
@@ -7,15 +7,14 @@ var PreferenceColorPick = "";
 var PreferenceSubscreen = "";
 var PreferenceSubscreenList = ["General", "Difficulty", "Restriction", "Chat", "Audio", "Arousal", "Security", "Online", "Visibility", "Immersion", "Graphics", "Controller", "Notifications"];
 var PreferencePageCurrent = 1;
-var PreferenceChatColorThemeSelected = "";
 var PreferenceChatColorThemeList = ["Light", "Dark", "Light2", "Dark2"];
 var PreferenceChatColorThemeIndex = 0;
-var PreferenceChatEnterLeaveSelected = "";
 var PreferenceChatEnterLeaveList = ["Normal", "Smaller", "Hidden"];
 var PreferenceChatEnterLeaveIndex = 0;
-var PreferenceChatMemberNumbersSelected = "";
 var PreferenceChatMemberNumbersList = ["Always", "Never", "OnMouseover"];
 var PreferenceChatMemberNumbersIndex = 0;
+var PreferenceChatFontSizeList = ["Small", "Medium", "Large"];
+var PreferenceChatFontSizeIndex = 1;
 var PreferenceSettingsSensDepList = ["SensDepLight", "Normal", "SensDepNames", "SensDepTotal", "SensDepExtreme"];
 var PreferenceSettingsSensDepIndex = 0;
 var PreferenceSettingsVFXList = ["VFXInactive", "VFXSolid", "VFXAnimatedTemp", "VFXAnimated"];
@@ -64,7 +63,8 @@ var PreferenceCalibrationStage = 0;
  * @param {Character} C - The player who performs the sexual activity
  * @param {string} Type - The type of the activity that is performed
  * @param {boolean} Self - Determines, if the current player is giving (false) or receiving (true)
- * @returns {number} - Returns the love factor of the activity for the character (0 is horrible, 2 is normal, 4 is great)
+ * @returns {number} - Returns the love factor of the activity for the character (0 is horrible, 2 is normal, 4 is
+ *     great)
  */
 function PreferenceGetActivityFactor(C, Type, Self) {
 	var Factor = 2;
@@ -301,6 +301,7 @@ function PreferenceInitPlayer() {
 
 	// Chat settings
 	if (!C.ChatSettings) C.ChatSettings = {};
+	if (typeof C.ChatSettings.FontSize !== "string") C.ChatSettings.FontSize = "Medium";
 	if (typeof C.ChatSettings.DisplayTimestamps !== "boolean") C.ChatSettings.DisplayTimestamps = true;
 	if (typeof C.ChatSettings.ColorNames !== "boolean") C.ChatSettings.ColorNames = true;
 	if (typeof C.ChatSettings.ColorActions !== "boolean") C.ChatSettings.ColorActions = true;
@@ -542,7 +543,8 @@ function PreferenceMigrate(from, to, prefName, defaultValue) {
 }
 
 /**
- * Loads the preference screen. This function is called dynamically, when the character enters the preference screen for the first time
+ * Loads the preference screen. This function is called dynamically, when the character enters the preference screen
+ * for the first time
  * @returns {void} - Nothing
  */
 function PreferenceLoad() {
@@ -556,15 +558,14 @@ function PreferenceLoad() {
 	PreferenceChatColorThemeIndex = (PreferenceChatColorThemeList.indexOf(Player.ChatSettings.ColorTheme) < 0) ? 0 : PreferenceChatColorThemeList.indexOf(Player.ChatSettings.ColorTheme);
 	PreferenceChatEnterLeaveIndex = (PreferenceChatEnterLeaveList.indexOf(Player.ChatSettings.EnterLeave) < 0) ? 0 : PreferenceChatEnterLeaveList.indexOf(Player.ChatSettings.EnterLeave);
 	PreferenceChatMemberNumbersIndex = (PreferenceChatMemberNumbersList.indexOf(Player.ChatSettings.MemberNumbers) < 0) ? 0 : PreferenceChatMemberNumbersList.indexOf(Player.ChatSettings.MemberNumbers);
+	PreferenceChatFontSizeIndex = (PreferenceChatFontSizeList.indexOf(Player.ChatSettings.FontSize)) < 0 ? 1 : PreferenceChatFontSizeList.indexOf(Player.ChatSettings.FontSize);
 	PreferenceSettingsSensDepIndex = (PreferenceSettingsSensDepList.indexOf(Player.GameplaySettings.SensDepChatLog) < 0) ? 0 : PreferenceSettingsSensDepList.indexOf(Player.GameplaySettings.SensDepChatLog);
 	PreferenceSettingsVolumeIndex = (PreferenceSettingsVolumeList.indexOf(Player.AudioSettings.Volume) < 0) ? 0 : PreferenceSettingsVolumeList.indexOf(Player.AudioSettings.Volume);
 	PreferenceArousalActiveIndex = (PreferenceArousalActiveList.indexOf(Player.ArousalSettings.Active) < 0) ? 0 : PreferenceArousalActiveList.indexOf(Player.ArousalSettings.Active);
 	PreferenceSettingsVFXIndex = (PreferenceSettingsVFXList.indexOf(Player.ArousalSettings.VFX) < 0) ? 0 : PreferenceSettingsVFXList.indexOf(Player.ArousalSettings.VFX);
 	PreferenceArousalVisibleIndex = (PreferenceArousalVisibleList.indexOf(Player.ArousalSettings.Visible) < 0) ? 0 : PreferenceArousalVisibleList.indexOf(Player.ArousalSettings.Visible);
 	PreferenceArousalAffectStutterIndex = (PreferenceArousalAffectStutterList.indexOf(Player.ArousalSettings.AffectStutter) < 0) ? 0 : PreferenceArousalAffectStutterList.indexOf(Player.ArousalSettings.AffectStutter);
-	PreferenceChatColorThemeSelected = PreferenceChatColorThemeList[PreferenceChatColorThemeIndex];
-	PreferenceChatEnterLeaveSelected = PreferenceChatEnterLeaveList[PreferenceChatEnterLeaveIndex];
-	PreferenceChatMemberNumbersSelected = PreferenceChatMemberNumbersList[PreferenceChatMemberNumbersIndex];
+	ChatRoomRefreshFontSize();
 
 	// Prepares the activity list
 	PreferenceArousalActivityList = [];
@@ -974,7 +975,8 @@ function PreferenceExit() {
 }
 
 /**
- * Sets the audio preferences for the player. Redirected to from the main Run function if the player is in the audio settings subscreen
+ * Sets the audio preferences for the player. Redirected to from the main Run function if the player is in the audio
+ * settings subscreen
  * @returns {void} - Nothing
  */
 function PreferenceSubscreenAudioRun() {
@@ -994,7 +996,8 @@ function PreferenceSubscreenAudioRun() {
 }
 
 /**
- * Sets the audio preferences for the player. Redirected to from the main Run function if the player is in the audio settings subscreen
+ * Sets the audio preferences for the player. Redirected to from the main Run function if the player is in the audio
+ * settings subscreen
  * @returns {void} - Nothing
  */
 function PreferenceSubscreenControllerRun() {
@@ -1066,15 +1069,17 @@ function PreferenceSubscreenControllerRun() {
 }
 
 /**
- * Sets the chat preferences for the player. Redirected to from the main Run function if the player is in the chat settings subscreen.
+ * Sets the chat preferences for the player. Redirected to from the main Run function if the player is in the chat
+ * settings subscreen.
  * @returns {void} - Nothing
  */
 function PreferenceSubscreenChatRun() {
 	MainCanvas.textAlign = "left";
 	DrawText(TextGet("ChatPreferences"), 500, 125, "Black", "Gray");
-	DrawText(TextGet("ColorTheme"), 500, 225, "Black", "Gray");
-	DrawText(TextGet("EnterLeaveStyle"), 500, 325, "Black", "Gray");
-	DrawText(TextGet("DisplayMemberNumbers"), 500, 425, "Black", "Gray");
+	DrawText(TextGet("ColorTheme"), 500, 200, "Black", "Gray");
+	DrawText(TextGet("EnterLeaveStyle"), 500, 280, "Black", "Gray");
+	DrawText(TextGet("DisplayMemberNumbers"), 500, 360, "Black", "Gray");
+	DrawText(TextGet("FontSize"), 500, 440, "Black", "Gray");
 	DrawCheckbox(500, 492, 64, 64, TextGet("DisplayTimestamps"), Player.ChatSettings.DisplayTimestamps);
 	DrawCheckbox(500, 572, 64, 64, TextGet("ColorNames"), Player.ChatSettings.ColorNames);
 	DrawCheckbox(500, 652, 64, 64, TextGet("ColorActions"), Player.ChatSettings.ColorActions);
@@ -1087,21 +1092,17 @@ function PreferenceSubscreenChatRun() {
 	DrawCheckbox(1200, 812, 64, 64, TextGet("MuStylePoses"), Player.ChatSettings.MuStylePoses);
 
 	MainCanvas.textAlign = "center";
-	DrawBackNextButton(1000, 190, 350, 70, TextGet(PreferenceChatColorThemeSelected), "White", "",
-		() => TextGet((PreferenceChatColorThemeIndex == 0) ? PreferenceChatColorThemeList[PreferenceChatColorThemeList.length - 1] : PreferenceChatColorThemeList[PreferenceChatColorThemeIndex - 1]),
-		() => TextGet((PreferenceChatColorThemeIndex >= PreferenceChatColorThemeList.length - 1) ? PreferenceChatColorThemeList[0] : PreferenceChatColorThemeList[PreferenceChatColorThemeIndex + 1]));
-	DrawBackNextButton(1000, 290, 350, 70, TextGet(PreferenceChatEnterLeaveSelected), "White", "",
-		() => TextGet((PreferenceChatEnterLeaveIndex == 0) ? PreferenceChatEnterLeaveList[PreferenceChatEnterLeaveList.length - 1] : PreferenceChatEnterLeaveList[PreferenceChatEnterLeaveIndex - 1]),
-		() => TextGet((PreferenceChatEnterLeaveIndex >= PreferenceChatEnterLeaveList.length - 1) ? PreferenceChatEnterLeaveList[0] : PreferenceChatEnterLeaveList[PreferenceChatEnterLeaveIndex + 1]));
-	DrawBackNextButton(1000, 390, 350, 70, TextGet(PreferenceChatMemberNumbersSelected), "White", "",
-		() => TextGet((PreferenceChatMemberNumbersIndex == 0) ? PreferenceChatMemberNumbersList[PreferenceChatMemberNumbersList.length - 1] : PreferenceChatMemberNumbersList[PreferenceChatMemberNumbersIndex - 1]),
-		() => TextGet((PreferenceChatMemberNumbersIndex >= PreferenceChatMemberNumbersList.length - 1) ? PreferenceChatMemberNumbersList[0] : PreferenceChatMemberNumbersList[PreferenceChatMemberNumbersIndex + 1]));
+	PreferenceDrawBackNextButton(1000, 170, 350, 60, PreferenceChatColorThemeList, PreferenceChatColorThemeIndex);
+	PreferenceDrawBackNextButton(1000, 250, 350, 60, PreferenceChatEnterLeaveList, PreferenceChatEnterLeaveIndex);
+	PreferenceDrawBackNextButton(1000, 330, 350, 60, PreferenceChatMemberNumbersList, PreferenceChatMemberNumbersIndex);
+	PreferenceDrawBackNextButton(1000, 410, 350, 60, PreferenceChatFontSizeList, PreferenceChatFontSizeIndex);
 	DrawButton(1815, 75, 90, 90, "", "White", "Icons/Exit.png");
 	DrawCharacter(Player, 50, 50, 0.9);
 }
 
 /**
- * Sets the online preferences for the player. Redirected to from the main Run function if the player is in the online settings subscreen.
+ * Sets the online preferences for the player. Redirected to from the main Run function if the player is in the online
+ * settings subscreen.
  * @returns {void} - Nothing
  */
 function PreferenceSubscreenOnlineRun() {
@@ -1123,7 +1124,8 @@ function PreferenceSubscreenOnlineRun() {
 }
 
 /**
- * Sets the arousal preferences for a player. Redirected to from the main Run function if the player is in the arousal settings subscreen
+ * Sets the arousal preferences for a player. Redirected to from the main Run function if the player is in the arousal
+ * settings subscreen
  * @returns {void} - Nothing
  */
 function PreferenceSubscreenArousalRun() {
@@ -1185,7 +1187,8 @@ function PreferenceSubscreenArousalRun() {
 }
 
 /**
- * Sets the security preferences for a player. Redirected to from the main Run function if the player is in the security settings subscreen
+ * Sets the security preferences for a player. Redirected to from the main Run function if the player is in the
+ * security settings subscreen
  * @returns {void} - Nothing
  */
 function PreferenceSubscreenSecurityRun() {
@@ -1203,7 +1206,8 @@ function PreferenceSubscreenSecurityRun() {
 }
 
 /**
- * Sets the item visibility preferences for a player. Redirected to from the main Run function if the player is in the visibility settings subscreen
+ * Sets the item visibility preferences for a player. Redirected to from the main Run function if the player is in the
+ * visibility settings subscreen
  * @returns {void} - Nothing
  */
 function PreferenceSubscreenVisibilityRun() {
@@ -1247,7 +1251,8 @@ function PreferenceSubscreenVisibilityRun() {
 }
 
 /**
- * Sets the graphical preferences for a player. Redirected to from the main Run function if the player is in the visibility settings subscreen
+ * Sets the graphical preferences for a player. Redirected to from the main Run function if the player is in the
+ * visibility settings subscreen
  * @returns {void} - Nothing
  */
 function PreferenceSubscreenGraphicsRun() {
@@ -1418,23 +1423,27 @@ function PreferenceSubscreenChatClick() {
 	}
 
 	// If the user used one of the BackNextButtons
-	if (MouseIn(1000, 190, 350, 80)) {
-		if (MouseX <= 1175) PreferenceChatColorThemeIndex = (PreferenceChatColorThemeIndex <= 0) ? PreferenceChatColorThemeList.length - 1 : PreferenceChatColorThemeIndex - 1;
-		else PreferenceChatColorThemeIndex = (PreferenceChatColorThemeIndex >= PreferenceChatColorThemeList.length - 1) ? 0 : PreferenceChatColorThemeIndex + 1;
-		PreferenceChatColorThemeSelected = PreferenceChatColorThemeList[PreferenceChatColorThemeIndex];
-		Player.ChatSettings.ColorTheme = PreferenceChatColorThemeSelected;
+	if (MouseIn(1000, 170, 350, 60)) {
+		if (MouseX <= 1175) PreferenceChatColorThemeIndex = PreferenceGetPreviousIndex(PreferenceChatColorThemeList, PreferenceChatColorThemeIndex);
+		else PreferenceChatColorThemeIndex = PreferenceGetNextIndex(PreferenceChatColorThemeList, PreferenceChatColorThemeIndex);
+		Player.ChatSettings.ColorTheme = PreferenceChatColorThemeList[PreferenceChatColorThemeIndex];
 	}
-	if (MouseIn(1000, 290, 350, 80)) {
-		if (MouseX <= 1175) PreferenceChatEnterLeaveIndex = (PreferenceChatEnterLeaveIndex <= 0) ? PreferenceChatEnterLeaveList.length - 1 : PreferenceChatEnterLeaveIndex - 1;
-		else PreferenceChatEnterLeaveIndex = (PreferenceChatEnterLeaveIndex >= PreferenceChatEnterLeaveList.length - 1) ? 0 : PreferenceChatEnterLeaveIndex + 1;
-		PreferenceChatEnterLeaveSelected = PreferenceChatEnterLeaveList[PreferenceChatEnterLeaveIndex];
-		Player.ChatSettings.EnterLeave = PreferenceChatEnterLeaveSelected;
+	if (MouseIn(1000, 250, 350, 60)) {
+		if (MouseX <= 1175) PreferenceChatEnterLeaveIndex = PreferenceGetPreviousIndex(PreferenceChatEnterLeaveList, PreferenceChatEnterLeaveIndex);
+		else PreferenceChatEnterLeaveIndex = PreferenceGetNextIndex(PreferenceChatEnterLeaveList, PreferenceChatEnterLeaveIndex);
+		Player.ChatSettings.EnterLeave = PreferenceChatEnterLeaveList[PreferenceChatEnterLeaveIndex];
 	}
-	if (MouseIn(1000, 390, 350, 80)) {
-		if (MouseX <= 1175) PreferenceChatMemberNumbersIndex = (PreferenceChatMemberNumbersIndex <= 0) ? PreferenceChatMemberNumbersList.length - 1 : PreferenceChatMemberNumbersIndex - 1;
-		else PreferenceChatMemberNumbersIndex = (PreferenceChatMemberNumbersIndex >= PreferenceChatMemberNumbersList.length - 1) ? 0 : PreferenceChatMemberNumbersIndex + 1;
-		PreferenceChatMemberNumbersSelected = PreferenceChatMemberNumbersList[PreferenceChatMemberNumbersIndex];
-		Player.ChatSettings.MemberNumbers = PreferenceChatMemberNumbersSelected;
+	if (MouseIn(1000, 330, 350, 60)) {
+		if (MouseX <= 1175) PreferenceChatMemberNumbersIndex = PreferenceGetPreviousIndex(PreferenceChatMemberNumbersList, PreferenceChatMemberNumbersIndex);
+		else PreferenceChatMemberNumbersIndex = PreferenceGetNextIndex(PreferenceChatMemberNumbersList, PreferenceChatMemberNumbersIndex);
+		Player.ChatSettings.MemberNumbers = PreferenceChatMemberNumbersList[PreferenceChatMemberNumbersIndex];
+	}
+
+	if (MouseIn(1000, 410, 350, 60)) {
+		if (MouseX <= 1175) PreferenceChatFontSizeIndex = PreferenceGetPreviousIndex(PreferenceChatFontSizeList, PreferenceChatFontSizeIndex);
+		else PreferenceChatFontSizeIndex = PreferenceGetNextIndex(PreferenceChatFontSizeList, PreferenceChatFontSizeIndex);
+		Player.ChatSettings.FontSize = PreferenceChatFontSizeList[PreferenceChatFontSizeIndex];
+		ChatRoomRefreshFontSize();
 	}
 
 	// If the user clicked the exit icon to return to the main screen
@@ -1685,7 +1694,8 @@ function PreferenceSubscreenVisibilityLoad() {
 
 /**
  * Update the checkbox settings and asset preview image based on the new asset selection
- * @param {boolean} RefreshCheckboxes - If TRUE, load the new asset settings. If FALSE, a checkbox was just manually changed so don't refresh them
+ * @param {boolean} RefreshCheckboxes - If TRUE, load the new asset settings. If FALSE, a checkbox was just manually
+ *     changed so don't refresh them
  * @returns {void} - Nothing
  */
 function PreferenceVisibilityAssetChanged(RefreshCheckboxes) {
@@ -1815,7 +1825,8 @@ function PreferenceIsPlayerInSensDep() {
 }
 
 /**
- * Loads the preference screen. This function is called dynamically, when the character enters the preference screen for the first time
+ * Loads the preference screen. This function is called dynamically, when the character enters the preference screen
+ * for the first time
  * @returns {void} - Nothing
  */
 function PreferenceSubscreenNotificationsLoad() {
@@ -1838,7 +1849,8 @@ function PreferenceNotificationsCheckSetting(setting) {
 }
 
 /**
- * Sets the notifications preferences for a player. Redirected to from the main Run function if the player is in the notifications settings subscreen
+ * Sets the notifications preferences for a player. Redirected to from the main Run function if the player is in the
+ * notifications settings subscreen
  * @returns {void} - Nothing
  */
 function PreferenceSubscreenNotificationsRun() {
@@ -2083,4 +2095,41 @@ function PreferencePageChangeClick(Left, Top, TotalPages) {
 		PreferencePageCurrent++;
 		if (PreferencePageCurrent > TotalPages) PreferencePageCurrent = 1;
 	}
+}
+
+/**
+ * Draws a back/next button for use on preference pages
+ * @param {number} Left - The left offset of the button
+ * @param {number} Top - The top offset of the button
+ * @param {number} Width - The width of the button
+ * @param {number} Height - The height of the button
+ * @param {any[]} List - The preference list that the button should be associated with
+ * @param {number} Index - The current preference index for the given preference list
+ * @returns {void} - Nothing
+ */
+function PreferenceDrawBackNextButton(Left, Top, Width, Height, List, Index) {
+	DrawBackNextButton(Left, Top, Width, Height, TextGet(List[Index]), "White", "",
+		() => TextGet(List[PreferenceGetPreviousIndex(List, Index)]),
+		() => TextGet(List[PreferenceGetNextIndex(List, Index)]),
+	);
+}
+
+/**
+ * Returns the index of the previous preference list item (and wraps back to the end of the list if currently at 0)
+ * @param {any[]} List - The preference list
+ * @param {number} Index - The current preference index for the given list
+ * @returns {number} - The index of the previous item in the array, or the last item in the array if currently at 0
+ */
+function PreferenceGetPreviousIndex(List, Index) {
+	return (List.length + Index - 1) % List.length;
+}
+
+/**
+ * Returns the index of the next preference list item (and wraps back to the start of the list if currently at the end)
+ * @param {any[]} List - The preference list
+ * @param {number} Index - The current preference index for the given list
+ * @returns {number} - The index of the next item in the array, or 0 if the array is currently at the last item
+ */
+function PreferenceGetNextIndex(List, Index) {
+	return (Index + 1) % List.length;
 }

--- a/BondageClub/Screens/Character/Preference/Text_Preference.csv
+++ b/BondageClub/Screens/Character/Preference/Text_Preference.csv
@@ -89,6 +89,10 @@ DisplayMemberNumbers,Display member numbers:
 Always,Always
 Never,Never
 OnMouseover,On Mouseover
+FontSize,Font size
+Small,Small
+Medium,Medium
+Large,Large
 DisplayTimestamps,Display timestamps
 ColorNames,Color names
 ColorActions,Color actions

--- a/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
+++ b/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
@@ -75,11 +75,18 @@ const ChatRoomArousalMsg_ChanceGagMod = {
 var ChatRoomPinkFlashTime = 0;
 var ChatRoomHideIconState = 0;
 var ChatRoomMenuButtons = [];
+let ChatRoomFontSize = 30;
+const ChatRoomFontSizes = {
+	Small: 24,
+	Medium: 30,
+	Large: 36,
+};
 
 /**
  * Chat room resize manager object: Handles resize events for the chat log.
  * @constant
- * @type {object} - The chat room resize manager object. Contains the functions and properties required to handle resize events.
+ * @type {object} - The chat room resize manager object. Contains the functions and properties required to handle
+ *     resize events.
  */
  let ChatRoomResizeManager = {
 	atStart : true, // Is this the first event in a chain of resize events?
@@ -450,7 +457,7 @@ function ChatRoomCreateElement() {
 
 		// Sets the size and position
 		ElementCreateDiv("TextAreaChatLog");
-		ElementPositionFix("TextAreaChatLog", 36, 1005, 5, 988, 859);
+		ElementPositionFix("TextAreaChatLog", ChatRoomFontSize, 1005, 5, 988, 859);
 		ElementScrollToEnd("TextAreaChatLog");
 		ChatRoomRefreshChatSettings();
 
@@ -482,6 +489,7 @@ function ChatRoomLoad() {
 	ElementRemove("InputName");
 	ElementRemove("InputDescription");
 	ElementRemove("InputSize");
+	ChatRoomRefreshFontSize();
 	ChatRoomCreateElement();
 	ChatRoomCharacterUpdate(Player);
 	ActivityChatRoomArousalSync(Player);
@@ -578,7 +586,8 @@ function ChatRoomOwnerInside() {
 
 
 /**
- * Updates the temporary drawing arrays for characters, to handle things that are dependent on the drawn chat room characters rather than the ones actually present
+ * Updates the temporary drawing arrays for characters, to handle things that are dependent on the drawn chat room
+ * characters rather than the ones actually present
  * @returns {void} - Nothing
  */
  
@@ -1107,7 +1116,7 @@ function ChatRoomRun() {
 	ChatRoomBackground = "";
 	DrawRect(0, 0, 2000, 1000, "Black");
 	ChatRoomDrawCharacter(false);
-	ElementPositionFix("TextAreaChatLog", 36, 1005, 66, 988, 835);
+	ElementPositionFix("TextAreaChatLog", ChatRoomFontSize, 1005, 66, 988, 835);
 	ElementPosition("InputChat", 1456, 950, 900, 82);
 	DrawButton(1905, 908, 90, 90, "", "White", "Icons/Chat.png");
 	if (!ChatRoomCanLeave() && ChatRoomSlowtimer != 0){//Player got interrupted while trying to leave. (Via a bind)
@@ -1633,10 +1642,12 @@ function ChatRoomPublishAction(C, StruggleProgressPrevItem, StruggleProgressNext
 function ChatRoomCharacterItemUpdate(C, Group) {
 	if ((Group == null) && (C.FocusGroup != null)) Group = C.FocusGroup.Name;
 	if ((CurrentScreen == "ChatRoom") && (Group != null)) {
-		// Single item updates aren't sent back to the source member, so update the ChatRoomData accordingly
-		const characterIndex = ChatRoomData.Character.findIndex((char) => char.MemberNumber === C.MemberNumber);
-		if (characterIndex !== -1) {
-			ChatRoomData.Character[characterIndex] = C;
+		if (ChatRoomData && ChatRoomData.Character) {
+			// Single item updates aren't sent back to the source member, so update the ChatRoomData accordingly
+			const characterIndex = ChatRoomData.Character.findIndex((char) => char.MemberNumber === C.MemberNumber);
+			if (characterIndex !== -1) {
+				ChatRoomData.Character[characterIndex] = C;
+			}
 		}
 
 		const Item = InventoryGet(C, Group);
@@ -3345,4 +3356,8 @@ function ChatRoomDataChanged() {
 		ChatRoomLastPrivate != ChatRoomData.Private ||
 		ChatRoomLastDesc != ChatRoomData.Description ||
 		!CommonArraysEqual(ChatRoomLastAdmin, ChatRoomData.Admin);
+}
+
+function ChatRoomRefreshFontSize() {
+	ChatRoomFontSize = ChatRoomFontSizes[Player.ChatSettings.FontSize || "Medium"];
 }

--- a/BondageClub/Scripts/Typedef.d.ts
+++ b/BondageClub/Scripts/Typedef.d.ts
@@ -392,6 +392,7 @@ interface Character {
 		OrgasmTimer?: number;
 		OrgasmStage?: number;
 		OrgasmCount?: number;
+        DisableAdvancedVibes: boolean;
 	};
 	AppearanceFull?: Item[];
 	Trait?: any[];
@@ -418,6 +419,7 @@ interface Character {
 	Love?: number;
 	Difficulty?: {
 		Level: number;
+		LastChange?: number;
 	};
 	ArousalZoom?: boolean;
 	FixedImage?: string;
@@ -512,6 +514,7 @@ interface PlayerCharacter extends Character {
 		StimulationFlashes: boolean;
 		DoBlindFlash: boolean;
 		AnimationQuality: number;
+		StimulationFlash: boolean;
 	}
 	NotificationSettings?: {
 		/** @deprecated */

--- a/BondageClub/Scripts/Typedef.d.ts
+++ b/BondageClub/Scripts/Typedef.d.ts
@@ -425,6 +425,10 @@ interface Character {
 
 interface PlayerCharacter extends Character {
 	ChatSettings?: {
+	    ColorTheme: string;
+	    EnterLeave: string;
+	    MemberNumbers: string;
+	    FontSize: string;
 		DisplayTimestamps: boolean;
 		ColorNames: boolean;
 		ColorActions: boolean;


### PR DESCRIPTION
## Summary

Adds a new chat preference for the font size of the chat log. Players can pick between "Small", "Medium" and "Large", with "Large" being the current chat font size. I also included a few small refactors to some of the chat preference subscreen, to hopefully improve the readability somewhat, along with some clean up of a couple of unused variables and missing type definitions for a few preferences.