### PR TITLE
DrawTextFit Optimisation

### DIFF
--- a/BondageClub/Screens/Character/Preference/Preference.js
+++ b/BondageClub/Screens/Character/Preference/Preference.js
@@ -1328,6 +1328,7 @@ function PreferenceSubscreenGraphicsClick() {
 		Player.GraphicsSettings.Font = PreferenceGraphicsFontList[PreferenceGraphicsFontIndex];
 		CommonGetFont.clearCache();
 		CommonGetFontName.clearCache();
+		DrawingGetTextSize.clearCache();
 	}
 	if (MouseIn(500, 470, 64, 64)) Player.GraphicsSettings.InvertRoom = !Player.GraphicsSettings.InvertRoom;
 	if (MouseIn(500, 550, 64, 64)) Player.GraphicsSettings.StimulationFlash = !Player.GraphicsSettings.StimulationFlash;

--- a/BondageClub/Screens/Online/ChatSearch/ChatSearch.js
+++ b/BondageClub/Screens/Online/ChatSearch/ChatSearch.js
@@ -100,6 +100,7 @@ function ChatSearchExit() {
 	ChatSearchPreviousActivePose = Player.ActivePose;
 	ElementRemove("InputSearch");
 	CommonSetScreen("Room", ChatSearchLeaveRoom);
+	DrawingGetTextSize.clearCache();
 }
 
 /**


### PR DESCRIPTION
`MainCanvas.measureText(Text)` is resource heavy, and is called multiple times every frame whenever we call `DrawTextFit`, causing screens like `ChatSearch` to take a lot of unnecessary script time while idling or doing other things.

I extracted the logic that finds the size and text to render into its on memoized function so that it would only do the necessary calculations once. The difference here is astronomical (see pics below).

The decision to clear the memo cache when leaving chatsearch is to prevent the cache from growing too big if someone stays in the club for a long time. 

during ~26s of idling, before ~80% of script time was in `DrawTextFit` for a total of ~4.9s, after it was ~61% with ~0.9s which is ~80% less

Before:
![before](https://user-images.githubusercontent.com/59637973/123570705-caa7e880-d796-11eb-8db1-168c140ba093.PNG)

After:
![after](https://user-images.githubusercontent.com/59637973/123570719-d2678d00-d796-11eb-8ab7-de24a218c365.PNG)