### PR TITLE
Feature: Adds extended item support to `InventoryWearRandom` (and NPCs!)

### DIFF
--- a/BondageClub/Screens/Character/Player/Dialog_Player.csv
+++ b/BondageClub/Screens/Character/Player/Dialog_Player.csv
@@ -391,6 +391,7 @@ Yacht1,,,Yacht Chill Room
 Yacht2,,,Yacht Main Hall
 Yacht3,,,Yacht Deck
 ExtendedItemUnlockBeforeChange,,,Remove locks before changing,,
+ExtendedItemNoItemPermission,,,Blocked due to item permissions,,
 IntroductionMaidGreetings,,,"(As you enter the luxurious hallway, a maid comes to greet you.)  Welcome to the Bondage Club, is this your first visit?",,
 ServerMessageOfferStartTrial,,,"SourceCharacter is offering you to start a trial period as her submissive.  Click on her and manage your relationship to accept, don't do anything to refuse.",,
 ServerMessageStartTrial,,,The Bondage Club is pleased to announce that SourceCharacter is starting a 7 days minimum trial period as a submissive.,,

--- a/BondageClub/Scripts/ExtendedItem.js
+++ b/BondageClub/Scripts/ExtendedItem.js
@@ -347,9 +347,6 @@ function ExtendedItemHandleOptionClick(C, Options, Option, IsSelfBondage) {
 		if (Option.Property.Type == null || (C.ID == 0 && DialogFocusItem.Property.Type == Option.Property.Type)) return;
 		InventoryTogglePermission(DialogFocusItem, Option.Property.Type);
 	} else {
-		if (InventoryBlockedOrLimited(C, DialogFocusItem, Option.Property.Type)) {
-			return;
-		}
 		if (DialogFocusItem.Property.Type === Option.Property.Type && !Option.HasSubscreen) {
 			return;
 		}
@@ -381,9 +378,9 @@ function ExtendedItemHandleOptionClick(C, Options, Option, IsSelfBondage) {
  */
 function ExtendedItemRequirementCheckMessage(Option, CurrentOption, IsSelfBondage) {
 	const C = CharacterGetCurrent() || CharacterAppearanceSelection;
-	let ValidationMessage = ExtendedItemCheckSkillRequirements(C, DialogFocusItem, Option);
+	let ValidationMessage = TypedItemValidateOption(C, DialogFocusItem, Option, CurrentOption);
 	if (!ValidationMessage) {
-		ValidationMessage = TypedItemValidateOption(C, DialogFocusItem, Option, CurrentOption);
+		ExtendedItemCheckSkillRequirements(C, DialogFocusItem, Option);
 	}
 	return ValidationMessage;
 }

--- a/BondageClub/Scripts/Inventory.js
+++ b/BondageClub/Scripts/Inventory.js
@@ -408,41 +408,73 @@ function InventoryLocked(C, AssetGroup, CheckProperties) {
 }
 
 /**
-* Makes the character wear a random item from a body area
-* @param {Character} C - The character that must wear the item
-* @param {string} GroupName - The name of the asset group (body area)
-* @param {number} [Difficulty] - The difficulty, on top of the base asset difficulty, to assign to the item
-* @param {boolean} [Refresh] - Do not call CharacterRefresh if false
-* @param {boolean} [MustOwn=false] - If TRUE, only assets that the character owns can be worn. Otherwise any asset can be used
-* @returns {void} - Nothing
-*/
-function InventoryWearRandom(C, GroupName, Difficulty, Refresh, MustOwn=false) {
-	if (!InventoryLocked(C, GroupName, true)) {
-		var IsClothes = false;
+ * Makes the character wear a random item from a body area
+ * @param {Character} C - The character that must wear the item
+ * @param {string} GroupName - The name of the asset group (body area)
+ * @param {number} [Difficulty] - The difficulty, on top of the base asset difficulty, to assign to the item
+ * @param {boolean} [Refresh] - Do not call CharacterRefresh if false
+ * @param {boolean} [MustOwn=false] - If TRUE, only assets that the character owns can be worn. Otherwise any asset can
+ * be used
+ * @param {boolean} [Extend=true] - Whether or not to randomly extend the item (i.e. set the item type), provided it has
+ * an archetype that supports random extension
+ * @returns {void} - Nothing
+ */
+function InventoryWearRandom(C, GroupName, Difficulty, Refresh, MustOwn = false, Extend = true) {
+	if (InventoryLocked(C, GroupName, true)) {
+		return;
+	}
 
-		// Finds the asset group and make sure it's not blocked
-		for (let A = 0; A < AssetGroup.length; A++)
-			if (AssetGroup[A].Name == GroupName) {
-				IsClothes = AssetGroup[A].Clothing;
-				var IsBlocked = InventoryGroupIsBlocked(C, GroupName);
-				if (IsBlocked) return;
-				break;
-			}
+	// Finds the asset group and make sure it's not blocked
+	const Group = AssetGroupGet(C.AssetFamily, GroupName);
+	if (!Group || InventoryGroupIsBlocked(C, GroupName)) {
+		return;
+	}
+	const IsClothes = Group.Clothing;
 
-		// Restrict the options to assets owned by the character if required
-		var AssetList = null;
-		if (MustOwn) {
-			CharacterAppearanceBuildAssets(C);
-			AssetList = CharacterAppearanceAssets;
-		}
+	// Restrict the options to assets owned by the character if required
+	let AssetList = null;
+	if (MustOwn) {
+		CharacterAppearanceBuildAssets(C);
+		AssetList = CharacterAppearanceAssets;
+	}
 
-		// Get and apply a random asset
-		var SelectedAsset = InventoryGetRandom(C, GroupName, AssetList);
+	// Get and apply a random asset
+	const SelectedAsset = InventoryGetRandom(C, GroupName, AssetList);
 
-		// Pick a random color for clothes from their schema
-		var SelectedColor = IsClothes ? SelectedAsset.Group.ColorSchema[Math.floor(Math.random() * SelectedAsset.Group.ColorSchema.length)] : null;
+	// Pick a random color for clothes from their schema
+	const SelectedColor = IsClothes ? SelectedAsset.Group.ColorSchema[Math.floor(Math.random() * SelectedAsset.Group.ColorSchema.length)] : null;
 
-		CharacterAppearanceSetItem(C, GroupName, SelectedAsset, SelectedColor, Difficulty, null, Refresh);
+	CharacterAppearanceSetItem(C, GroupName, SelectedAsset, SelectedColor, Difficulty, null, false);
+
+	if (Extend) {
+		InventoryRandomExtend(C, GroupName);
+	}
+
+	if (Refresh) {
+		CharacterRefresh(C);
+	}
+}
+
+/**
+ * Randomly extends an item (sets an item type, etc.) on a character
+ * @param {Character} C - The character wearing the item
+ * @param {string} GroupName - The name of the item's group
+ * @returns {void} - Nothing
+ */
+function InventoryRandomExtend(C, GroupName) {
+	const Item = InventoryGet(C, GroupName);
+
+	if (!Item || !Item.Asset.Archetype) {
+		return;
+	}
+
+	switch (Item.Asset.Archetype) {
+		case ExtendedArchetype.TYPED:
+			TypedItemSetRandomOption(C, Item);
+			break;
+		default:
+			// Archetype does not yet support random extension
+			break;
 	}
 }
 

--- a/BondageClub/Scripts/Typedef.d.ts
+++ b/BondageClub/Scripts/Typedef.d.ts
@@ -698,11 +698,13 @@ interface ExtendedItemOption {
 	/**
 	 * Trigger this expression when changing to this option
 	 *
-	 * **Curretnly broken!**
+	 * FIXME: **Currently broken!**
 	 */
 	Expression?: ExpressionTrigger[];
 	/** Whether or not the option should open a subscreen in the extended item menu */
 	HasSubscreen?: boolean;
+	/** Whether or not this option can be selected randomly */
+	Random?: boolean;
 }
 
 //#endregion


### PR DESCRIPTION
## Summary

This is a follow-up to #2637, and adds support for random item extension to the `InventoryWearRandom` function. If the item has the correct archetype (only typed items are supported for now), and the `Extend` parameter is passed to the function, `InventoryWearRandom` will now randomly select an item type and apply it. This means that anywhere which was previously using `InventoryWearRandom` to bind the player will now also be able to randomly select item types, as applicable. As we move more items over to the archetypes system, this feature should automatically support those items. Typed item options also now support a `Random` flag just like assets to indicate whether or not they can be randomly selected.

The PR also modifies some of the functions added by #2637 so that they now respect the player's blocked/limited types, and adds a dialogue message to the extended item screen for typed items and items using the extended item script, indicating that a given type is blocked/limited by player permissions.