### PR TITLE
Improvement: Force reset the canvas after a context loss if it is not restored after 10 seconds

### DIFF
--- a/BondageClub/Scripts/Drawing.js
+++ b/BondageClub/Scripts/Drawing.js
@@ -28,6 +28,12 @@ let DrawCacheTotalImages = 0;
 var DrawLastDarkFactor = 0;
 
 /**
+ * A list of the characters that are drawn every frame
+ * @type {Character[]}
+ */
+var DrawLastCharacters = [];
+
+/**
  * Converts a hex color string to a RGB color
  * @param {string} color - Hex color to conver
  * @returns {{ r: number, g: number, b: number }} - RGB color
@@ -244,6 +250,9 @@ function DrawArousalMeter(C, X, Y, Zoom) {
  * @returns {void} - Nothing
  */
 function DrawCharacter(C, X, Y, Zoom, IsHeightResizeAllowed, DrawCanvas) {
+	// Record that the character was drawn this frame
+	DrawLastCharacters.push(C);
+
 	if (!DrawCanvas) DrawCanvas = MainCanvas;
 
 	var OverrideDark = CurrentModule == "MiniGame" || ((Player.Effect.includes("VRAvatars") && C.Effect.includes("VRAvatars"))) || CurrentScreen == "InformationSheet";
@@ -1216,6 +1225,9 @@ function DrawBlindFlash(intensity) {
  * @returns {void} - Nothing
  */
 function DrawProcess() {
+	// Clear the list of characters that were drawn last frame
+	DrawLastCharacters = [];
+
 	let RefreshDrawFunction = false;
 	if (DrawScreen != CurrentScreen) {
 		DrawScreen = CurrentScreen;

--- a/BondageClub/Scripts/GLDraw.js
+++ b/BondageClub/Scripts/GLDraw.js
@@ -41,6 +41,11 @@ function GLDrawLoad() {
 	GLDrawCanvas.addEventListener("webglcontextrestored", GLDrawOnContextRestored, false);
 }
 
+/**
+ * Handler for WebGL context lost events
+ * @param {WebGLContextEvent} event
+ * @returns {void} - Nothing
+ */
 function GLDrawOnContextLost(event) {
 	event.preventDefault();
 	console.log("WebGL Drawing disabled: Context Lost. If the context does not restore itself, refresh your page.");
@@ -51,6 +56,10 @@ function GLDrawOnContextLost(event) {
 	}, 10000);
 }
 
+/**
+ * Handler for WebGL context restored events
+ * @returns {void} - Nothing
+ */
 function GLDrawOnContextRestored() {
 	console.log("WebGL: Context restored.");
 	clearTimeout(GLDrawContextLostTimeout);

--- a/BondageClub/Scripts/GLDraw.js
+++ b/BondageClub/Scripts/GLDraw.js
@@ -11,7 +11,22 @@ var GLVersion;
 
 var GLDrawCanvas;
 
+/**
+ * How many seconds to wait before forcefully resetting the canvas after a
+ * context loss
+ */
+const GLDrawContextResetSeconds = 10;
+/**
+ * The cooldown in seconds after resetting the canvas. If another context loss
+ * happens in this cooldown, we'll revert to canvas2d rendering
+ */
+const GLDrawRevertToDraw2DSeconds = 50;
+
 let GLDrawContextLostTimeout;
+let GLDrawRecoveryMode = false;
+let GLDrawCrashTimeout;
+
+let GLDrawBuildCanvasBackup;
 
 var GLDrawAlphaThreshold = 0.01;
 var GLDrawHalfAlphaLow = 0.8 / 256.0;
@@ -34,6 +49,10 @@ function GLDrawLoad() {
 
 	GLDrawCanvas = GLDrawInitCharacterCanvas(GLDrawCanvas);
 
+	if (!GLDrawBuildCanvasBackup) {
+		// Keep a backup of the original CharacterAppearanceBuildCanvas function in case we need to revert
+		GLDrawBuildCanvasBackup = CharacterAppearanceBuildCanvas;
+	}
 	CharacterAppearanceBuildCanvas = GLDrawAppearanceBuild;
 
 	// Attach context listeners
@@ -49,11 +68,35 @@ function GLDrawLoad() {
 function GLDrawOnContextLost(event) {
 	event.preventDefault();
 	console.log("WebGL Drawing disabled: Context Lost. If the context does not restore itself, refresh your page.");
+
+	if (GLDrawRecoveryMode) {
+		// If the context has been lost again whilst in crash cooldown, revert to canvas2d drawing
+		return GLDrawRevertToCanvas2D();
+	}
+
 	GLDrawContextLostTimeout = setTimeout(() => {
 		// If the context has not been automatically restored after
-		console.log("Context not restored after 10 seconds... resetting canvas.");
+		console.log(`Context not restored after ${GLDrawContextResetSeconds} seconds... resetting canvas.`);
 		GLDrawResetCanvas();
-	}, 10000);
+
+		// After forcefully resetting the canvas, we're in crash cooldown mode
+		GLDrawRecoveryMode = true;
+		GLDrawCrashTimeout = setTimeout(() => GLDrawRecoveryMode = false, GLDrawRevertToDraw2DSeconds * 1000);
+	}, GLDrawContextResetSeconds * 1000);
+}
+
+/**
+ * Restores the original CharacterAppearanceBuildCanvas function, and cleans up any GLDraw resources.
+ * @returns {void} - Nothing
+ */
+function GLDrawRevertToCanvas2D() {
+	const seconds = GLDrawContextResetSeconds + GLDrawRevertToDraw2DSeconds;
+	console.log(`WebGL context lost twice within ${seconds} seconds - reverting to canvas2D rendering`);
+	clearTimeout(GLDrawCrashTimeout);
+	GLDrawCanvas.remove();
+	GLDrawImageCache.clear();
+	CharacterAppearanceBuildCanvas = GLDrawBuildCanvasBackup;
+	GLDrawRebuildCharacters();
 }
 
 /**
@@ -64,10 +107,7 @@ function GLDrawOnContextRestored() {
 	console.log("WebGL: Context restored.");
 	clearTimeout(GLDrawContextLostTimeout);
 	GLDrawLoad();
-	// Ensure all the characters currently on screen are refreshed
-	for (const C of DrawLastCharacters) {
-		CharacterAppearanceBuildCanvas(C);
-	}
+	GLDrawRebuildCharacters();
 }
 
 /**
@@ -78,6 +118,14 @@ function GLDrawResetCanvas() {
 	GLDrawCanvas.remove();
 	GLDrawImageCache.clear();
 	GLDrawLoad();
+	GLDrawRebuildCharacters();
+}
+
+/**
+ * Rebuilds the canvas for any characters that are currently on screen.
+ * @returns {void} - Nothing
+ */
+function GLDrawRebuildCharacters() {
 	for (const C of DrawLastCharacters) {
 		CharacterAppearanceBuildCanvas(C);
 	}


### PR DESCRIPTION
## Summary

In #1026, handling was added for when the WebGL context is lost and restored. Usually this is due to a lack of resources on the player's machine, but more often than not, it never seems to get restored when the issue occurs in real situations. This adds a timeout to the context lost listener so that if the context isn't successfully restored after 10 seconds, the game will forcefully remove the GLDraw canvas and recreate it, and rebuild the canvas of all characters currently on the screen, forcing them to be re-rendered.

If _another_ context loss then happens within a further 50 seconds (i.e. two context losses within a minute), the game will revert character rendering back to the original `CharacterAppearanceBuildCanvas` function, and no longer use `GLDraw` (thanks to @ace-1331 for that suggestion).

This shouldn't happen during normal gameplay, but will hopefully alleviate the "WebGL context lost" issue for players for whom it never automatically restores. This change was prompted by the latest WebGL context lost issue that was posted on the game's Discord (see image below). I've tested this with the `WEBGL_lose_context` plugin, and it seems to work well.

![image](https://user-images.githubusercontent.com/62729616/123877017-586d0a80-d934-11eb-9b0b-9a457ef0ef2b.png)
