### PR TITLE
Bugfix/Improvement: `GagUnique` prerequisite improvements

### DIFF
--- a/BondageClub/Scripts/Inventory.js
+++ b/BondageClub/Scripts/Inventory.js
@@ -228,8 +228,8 @@ function InventoryPrerequisiteMessage(C, Prerequisite) {
 		case "RemotesAllowed": return LogQuery("BlockRemoteSelf", "OwnerRule") && C.ID === 0 ? "OwnerBlockedRemotes" : "";
 
 		// Layered Gags, prevent gags from being equipped over other gags they are incompatible with
-		case "GagUnique": return C.FocusGroup && InventoryPrerequisiteConflictingGags(C, ["GagFlat", "GagCorset", "GagUnique"]);
-		case "GagCorset": return C.FocusGroup && InventoryPrerequisiteConflictingGags(C, ["GagCorset"]);
+		case "GagUnique": return InventoryPrerequisiteConflictingGags(C, ["GagFlat", "GagCorset", "GagUnique"]);
+		case "GagCorset": return InventoryPrerequisiteConflictingGags(C, ["GagCorset"]);
 
 		// Returns no message, indicating that all prerequisites are fine
 		default: return "";
@@ -311,12 +311,16 @@ function InventoryHasItemInAnyGroup(C, GroupList) {
  */
 function InventoryPrerequisiteConflictingGags(C, BlockingPrereqs) {
 	// Index of the gag we're trying to add (1-indexed)
-	var GagIndex = Number(C.FocusGroup.Name.replace("ItemMouth", "") || 1);
-	var MouthItems = [InventoryGet(C, "ItemMouth"), InventoryGet(C, "ItemMouth2"), InventoryGet(C, "ItemMouth3")];
-	var MinBlockingIndex = 0;
+	let GagIndex = 4; // By default, assume no gag slots are allowed to conflict
+	if (C.FocusGroup && C.FocusGroup.Name.startsWith("ItemMouth")) {
+		// If there's a focus group, calculate the gag index
+		GagIndex = Number(C.FocusGroup.Name.replace("ItemMouth", "") || 4);
+	}
+	const MouthItems = [InventoryGet(C, "ItemMouth"), InventoryGet(C, "ItemMouth2"), InventoryGet(C, "ItemMouth3")];
+	let MinBlockingIndex = 0;
 	for (let i = 0; i < MouthItems.length && !MinBlockingIndex; i++) {
 		// Find the lowest indexed slot in which there is a gag with a prerequisite that blocks the new gag
-		var AssetPrerequisite = MouthItems[i] && MouthItems[i].Asset.Prerequisite;
+		const AssetPrerequisite = MouthItems[i] && MouthItems[i].Asset.Prerequisite;
 		if (BlockingPrereqs.indexOf(AssetPrerequisite) >= 0) MinBlockingIndex = i + 1;
 	}
 	// Not allowed to add the new gag if there is a blocking gag anywhere below it


### PR DESCRIPTION
## Summary

It came to my attention recently that ball gags (or, as it turns out any gags with the `GagUnique` prerequisite) were never being selected in the random item pool. The reason for this is that the `InventoryPrerequisiteMessage` function returns `null` rather than an empty string if `C.FocusGroup` isn't set, which meant it would fail this check in `InventoryAllow`:
```js
return (Msg == "");
```

This PR updates `InventoryPrerequisiteMessage` and `InventoryPrerequisiteConflictingGags` so that `C.FocusGroup` being set is no longer a hard requirement. However, the `GagUnique` prerequisite is slightly different from others in that it pulls some contextual information from the current focus group. Therefore, if no focus group is set, the prerequisite returns an error if _any_ of the mouth groups contains a conflicting gag. If a focus group is set, the prerequisite behaves as it did before. This should bring a lot more gag variety (back?) into the random item pool.