### PR TITLE
Gag Removal Fix

### DIFF
--- a/BondageClub/Scripts/Inventory.js
+++ b/BondageClub/Scripts/Inventory.js
@@ -314,7 +314,7 @@ function InventoryPrerequisiteConflictingGags(C, BlockingPrereqs) {
 	let GagIndex = 4; // By default, assume no gag slots are allowed to conflict
 	if (C.FocusGroup && C.FocusGroup.Name.startsWith("ItemMouth")) {
 		// If there's a focus group, calculate the gag index
-		GagIndex = Number(C.FocusGroup.Name.replace("ItemMouth", "") || 4);
+		GagIndex = Number(C.FocusGroup.Name.replace("ItemMouth", "") || 1);
 	}
 	const MouthItems = [InventoryGet(C, "ItemMouth"), InventoryGet(C, "ItemMouth2"), InventoryGet(C, "ItemMouth3")];
 	let MinBlockingIndex = 0;


### PR DESCRIPTION
Examining a gag in the first/leftmost gag slot was not showing the Remove button, since it thought the player was looking at a "4th" mouth slot rather than the 1st.