### PR TITLE
resize crash fix

### DIFF
--- a/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
+++ b/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
@@ -22,6 +22,7 @@ var ChatRoomStruggleAssistBonus = 0;
 var ChatRoomStruggleAssistTimer = 0;
 var ChatRoomSlowtimer = 0;
 var ChatRoomSlowStop = false;
+var ChatRoomChatHidden = false;
 
 var ChatRoomCharacterCount = 0;
 var ChatRoomCharacterDrawlist = [];
@@ -879,6 +880,7 @@ function ChatRoomClickCharacter(C, CharX, CharY, Zoom, ClickX, ClickY, Pos) {
 	// Gives focus to the character
 	document.getElementById("InputChat").style.display = "none";
 	document.getElementById("TextAreaChatLog").style.display = "none";
+	ChatRoomChatHidden = true;
 	ChatRoomBackground = ChatRoomData.Background;
 	C.AllowItem = C.ID === 0 || ServerChatRoomGetAllowItem(Player, C);
 	ChatRoomOwnershipOption = "";
@@ -1152,6 +1154,10 @@ function ChatRoomRun() {
 	ChatRoomBackground = "";
 	DrawRect(0, 0, 2000, 1000, "Black");
 	ChatRoomDrawCharacter(false);
+	if (ChatRoomChatHidden) {
+		ChatRoomChatHidden = false;
+		ChatRoomResize(false);
+	}
 	DrawButton(1905, 908, 90, 90, "", "White", "Icons/Chat.png");
 	if (!ChatRoomCanLeave() && ChatRoomSlowtimer != 0){//Player got interrupted while trying to leave. (Via a bind)
 		ServerSend("ChatRoomChat", { Content: "SlowLeaveInterrupt", Type: "Action", Dictionary: [{Tag: "SourceCharacter", Text: Player.Name, MemberNumber: Player.MemberNumber}]});

--- a/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
+++ b/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
@@ -1128,8 +1128,10 @@ function ChatRoomStimulationMessage(Context) {
  * @param {boolean} load - If the reason for call was load (`true`) or window resize (`false`)
  */
 function ChatRoomResize(load) {
-	ElementPositionFix("TextAreaChatLog", ChatRoomFontSize, 1005, 66, 988, 835);
-	ElementPosition("InputChat", 1456, 950, 900, 82);
+	if (CharacterGetCurrent() == null) {
+		ElementPositionFix("TextAreaChatLog", ChatRoomFontSize, 1005, 66, 988, 835);
+		ElementPosition("InputChat", 1456, 950, 900, 82);
+	}
 }
 
 /**

--- a/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
+++ b/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
@@ -505,6 +505,9 @@ function ChatRoomLoad() {
  * Removes all elements that can be open in the chat room
 */
 function ChatRoomClearAllElements() {
+	// Dialog
+	DialogLeave();
+	
 	// Friendlist
 	ElementRemove("FriendList");
 	FriendListBeepMenuClose();
@@ -522,9 +525,6 @@ function ChatRoomClearAllElements() {
 	// Chatroom
 	ElementRemove("InputChat");
 	ElementRemove("TextAreaChatLog");
-
-	// Dialog
-	DialogLeave();
 
 	// Preferences
 	ElementRemove("InputEmailOld");

--- a/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
+++ b/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
@@ -1128,7 +1128,12 @@ function ChatRoomStimulationMessage(Context) {
  * @param {boolean} load - If the reason for call was load (`true`) or window resize (`false`)
  */
 function ChatRoomResize(load) {
-	if (CharacterGetCurrent() == null) {
+	if (
+		CharacterGetCurrent() == null
+		&& CurrentScreen == "ChatRoom"
+		&& document.getElementById("InputChat")
+		&& document.getElementById("TextAreaChatLog")
+	) {
 		ElementPositionFix("TextAreaChatLog", ChatRoomFontSize, 1005, 66, 988, 835);
 		ElementPosition("InputChat", 1456, 950, 900, 82);
 	}

--- a/BondageClub/Scripts/Dialog.js
+++ b/BondageClub/Scripts/Dialog.js
@@ -463,10 +463,6 @@ function DialogLeave() {
 	DialogSelfMenuSelected = null;
 	DialogFacialExpressionsSelected = -1;
 	ClearButtons();
-	// Required to restore chat visibility
-	if (CurrentScreen == "ChatRoom") {
-		ChatRoomResize(false);
-	}
 }
 
 /**

--- a/BondageClub/Scripts/Element.js
+++ b/BondageClub/Scripts/Element.js
@@ -293,6 +293,12 @@ function ElementPosition(ElementID, X, Y, W, H) {
  * @returns {void} - Nothing
  */
 function ElementPositionFix(ElementID, Font, X, Y, W, H) {
+	var E = document.getElementById(ElementID);
+	// Verify the element exists
+	if (!E) {
+		console.warn("A call to ElementPositionFix was made on non-existent element with ID '" + ElementID + "'");
+		return;
+	}
 
 	// Different positions based on the width/height ratio
 	const HRatio = MainCanvas.canvas.clientHeight / 1000;
@@ -304,7 +310,6 @@ function ElementPositionFix(ElementID, Font, X, Y, W, H) {
 	const Width = W * WRatio;
 
 	// Sets the element style
-	var E = document.getElementById(ElementID);
 	Object.assign(E.style, {
 		fontSize: Font + "px",
 		fontFamily: CommonGetFontName(),


### PR DESCRIPTION
- fixed a crash occurring when leaving rooms after the recent addition of the resize manager.
- fixed chat resizes being applied while resizing when in a dialog
- improved the resize and element functions to be more robust
-  jomshir reworked it so DialogLeave no longer calls the resize function (instead it is kept track of inside the chatroom logic)