### PR TITLE
Updates and fixes to the FuturisticVibrator (and minor change to FuturisticTrainingBelt)

### DIFF
--- a/BondageClub/Screens/Inventory/ItemPelvis/FuturisticTrainingBelt/FuturisticTrainingBelt.js
+++ b/BondageClub/Screens/Inventory/ItemPelvis/FuturisticTrainingBelt/FuturisticTrainingBelt.js
@@ -395,6 +395,9 @@ function InventoryFuturisticTrainingBeltCheckPunishSpeech(Item, LastTime) {
 		// Messages are in order, no need to keep looping
 		if (ChatRoomChatLog[CH].Time <= LastTime) break
 
+		// If the message is OOC, just return immediately
+		if (ChatRoomChatLog[CH].Chat.indexOf('(') == 0) return "";
+
 		if (ChatRoomChatLog[CH].SenderMemberNumber == Player.MemberNumber) {
 			let msg = ChatRoomChatLog[CH].Chat.toUpperCase().replace(/[^a-z0-9]/gmi, " ").replace(/\s+/g, " ");
 			let msgTruncated = ChatRoomChatLog[CH].Chat.toUpperCase().replace(/[^a-z0-9]/gmi, "").replace(/\s+/g, "");

--- a/BondageClub/Screens/Inventory/ItemPelvis/FuturisticTrainingBelt/FuturisticTrainingBelt.js
+++ b/BondageClub/Screens/Inventory/ItemPelvis/FuturisticTrainingBelt/FuturisticTrainingBelt.js
@@ -389,8 +389,13 @@ function InventoryItemPelvisFuturisticTrainingBeltUpdateVibeMode(C, Item, Force)
 function InventoryFuturisticTrainingBeltCheckPunishSpeech(Item, LastTime) {
 	if (!Item) return "";
 	if (!Item.Property) return "";
-	for (let CH = 0; CH < ChatRoomChatLog.length; CH++) {
-		if (ChatRoomChatLog[CH].Time > LastTime && ChatRoomChatLog[CH].SenderMemberNumber == Player.MemberNumber) {
+	// Search from latest message backwards, allowing early exit
+	for (let CH = ChatRoomChatLog.length - 1; CH >= 0; CH--) {
+
+		// Messages are in order, no need to keep looping
+		if (ChatRoomChatLog[CH].Time <= LastTime) break
+
+		if (ChatRoomChatLog[CH].SenderMemberNumber == Player.MemberNumber) {
 			let msg = ChatRoomChatLog[CH].Chat.toUpperCase().replace(/[^a-z0-9]/gmi, " ").replace(/\s+/g, " ");
 			let msgTruncated = ChatRoomChatLog[CH].Chat.toUpperCase().replace(/[^a-z0-9]/gmi, "").replace(/\s+/g, "");
 
@@ -641,12 +646,12 @@ function AssetsItemPelvisFuturisticTrainingBeltScriptDraw(data) {
 	var property = (data.Item.Property = data.Item.Property || {});
 	if (typeof persistentData.UpdateTime !== "number") persistentData.UpdateTime = CommonTime() + 4000;
 	if (typeof persistentData.LastMessageLen !== "number") persistentData.LastMessageLen = (ChatRoomLastMessage) ? ChatRoomLastMessage.length : 0;
-	if (typeof persistentData.CheckTime !== "number") persistentData.CheckTime = CommonTime() + FuturisticVibratorCheckChatTime;
+	if (typeof persistentData.CheckTime !== "number") persistentData.CheckTime = 0;
 
 	if (persistentData.UpdateTime < CommonTime() && data.C == Player) {
 
 		if (CommonTime() > property.NextShockTime) {
-			AssetsItemPelvisFuturisticTrainingBeltScriptUpdatePlayer(data, persistentData.CheckTime - FuturisticVibratorCheckChatTime);
+			AssetsItemPelvisFuturisticTrainingBeltScriptUpdatePlayer(data, persistentData.CheckTime);
 			AssetsItemPelvisFuturisticTrainingBeltScriptStateMachine(data);
 			persistentData.LastMessageLen = (ChatRoomLastMessage) ? ChatRoomLastMessage.length : 0;
 		}
@@ -656,7 +661,8 @@ function AssetsItemPelvisFuturisticTrainingBeltScriptDraw(data) {
 		AnimationRequestRefreshRate(data.C, 5000 - timeToNextRefresh);
 		AnimationRequestDraw(data.C);
 		
-		
-		persistentData.CheckTime = CommonTime() + FuturisticVibratorCheckChatTime;
+		// Set CheckTime to last processed chat message time
+		var lastMsgIndex = ChatRoomChatLog.length - 1;
+		persistentData.CheckTime = (lastMsgIndex >= 0 ? ChatRoomChatLog[lastMsgIndex].Time : 0);
 	}
 }

--- a/BondageClub/Screens/Inventory/ItemVulva/FuturisticVibrator/FuturisticVibrator.js
+++ b/BondageClub/Screens/Inventory/ItemVulva/FuturisticVibrator/FuturisticVibrator.js
@@ -173,27 +173,29 @@ function InventoryItemVulvaFuturisticVibratorHandleChat(C, Item, LastTime) {
 	if (!Item.Property) VibratorModeSetProperty(Item, VibratorModeOptions[VibratorModeSet.STANDARD][0].Property);
 	var TriggerValues = Item.Property.TriggerValues && Item.Property.TriggerValues.split(',');
 	if (!TriggerValues) TriggerValues = ItemVulvaFuturisticVibratorTriggers;
-	for (let CH = 0; CH < ChatRoomChatLog.length; CH++) {
-		if (ChatRoomChatLog[CH].Time > LastTime) {
-			var msg = InventoryItemVulvaFuturisticVibratorDetectMsg(ChatRoomChatLog[CH].Chat.toUpperCase(), TriggerValues);
 
-			if (msg.length > 0) {
-				//vibrator modes, can only pick one
-				if (msg.includes("Edge")) InventoryItemVulvaFuturisticVibratorSetMode(C, Item, VibratorModeGetOption(VibratorMode.EDGE));
-				else if (msg.includes("Deny")) InventoryItemVulvaFuturisticVibratorSetMode(C, Item, VibratorModeGetOption(VibratorMode.DENY));
-				else if (msg.includes("Tease")) InventoryItemVulvaFuturisticVibratorSetMode(C, Item, VibratorModeGetOption(VibratorMode.TEASE));
-				else if (msg.includes("Random")) InventoryItemVulvaFuturisticVibratorSetMode(C, Item, VibratorModeGetOption(VibratorMode.RANDOM));
-				else if (msg.includes("Disable")) InventoryItemVulvaFuturisticVibratorSetMode(C, Item, VibratorModeGetOption(VibratorMode.OFF));
-				else if (msg.includes("Increase")) InventoryItemVulvaFuturisticVibratorSetMode(C, Item, VibratorModeGetOption(InventoryItemVulvaFuturisticVibratorGetMode(Item, true)), true);
-				else if (msg.includes("Decrease")) InventoryItemVulvaFuturisticVibratorSetMode(C, Item, VibratorModeGetOption(InventoryItemVulvaFuturisticVibratorGetMode(Item, false)), true);
-				
-				//triggered actions
-				if (msg.includes("Shock")) InventoryItemVulvaFuturisticVibratorTriggerShock(C, Item);
-			}
+	// Search from latest message backwards, allowing early exit
+	for (let CH = ChatRoomChatLog.length - 1; CH >= 0; CH--) {
 
+		// Messages are in order, no need to keep looping
+		if (ChatRoomChatLog[CH].Time <= LastTime) break
+
+		var msg = InventoryItemVulvaFuturisticVibratorDetectMsg(ChatRoomChatLog[CH].Chat.toUpperCase(), TriggerValues);
+
+		if (msg.length > 0) {
+			//vibrator modes, can only pick one
+			if (msg.includes("Edge")) InventoryItemVulvaFuturisticVibratorSetMode(C, Item, VibratorModeGetOption(VibratorMode.EDGE));
+			else if (msg.includes("Deny")) InventoryItemVulvaFuturisticVibratorSetMode(C, Item, VibratorModeGetOption(VibratorMode.DENY));
+			else if (msg.includes("Tease")) InventoryItemVulvaFuturisticVibratorSetMode(C, Item, VibratorModeGetOption(VibratorMode.TEASE));
+			else if (msg.includes("Random")) InventoryItemVulvaFuturisticVibratorSetMode(C, Item, VibratorModeGetOption(VibratorMode.RANDOM));
+			else if (msg.includes("Disable")) InventoryItemVulvaFuturisticVibratorSetMode(C, Item, VibratorModeGetOption(VibratorMode.OFF));
+			else if (msg.includes("Increase")) InventoryItemVulvaFuturisticVibratorSetMode(C, Item, VibratorModeGetOption(InventoryItemVulvaFuturisticVibratorGetMode(Item, true)), true);
+			else if (msg.includes("Decrease")) InventoryItemVulvaFuturisticVibratorSetMode(C, Item, VibratorModeGetOption(InventoryItemVulvaFuturisticVibratorGetMode(Item, false)), true);
+			
+			//triggered actions
+			if (msg.includes("Shock")) InventoryItemVulvaFuturisticVibratorTriggerShock(C, Item);
 		}
 	}
-
 }
 
 function AssetsItemVulvaFuturisticVibratorScriptDraw(data) {
@@ -203,12 +205,15 @@ function AssetsItemVulvaFuturisticVibratorScriptDraw(data) {
 	// Only run updates on the player and NPCs
 	if (C.ID !== 0 && C.MemberNumber !== null) return;
 
-	if (typeof PersistentData.CheckTime !== "number") PersistentData.CheckTime = CommonTime() + FuturisticVibratorCheckChatTime;
+	// Default to some number that just means all messages are viable
+	if (typeof PersistentData.CheckTime !== "number") PersistentData.CheckTime = 0;
 
-	if (CommonTime() > PersistentData.CheckTime) {
-		InventoryItemVulvaFuturisticVibratorHandleChat(C, Item, PersistentData.CheckTime - FuturisticVibratorCheckChatTime);
+	// Trigger a check if a new message is detected
+	var lastMsgIndex = ChatRoomChatLog.length - 1
+	if (lastMsgIndex >= 0 && ChatRoomChatLog[lastMsgIndex].Time > PersistentData.CheckTime) {
+		InventoryItemVulvaFuturisticVibratorHandleChat(C, Item, PersistentData.CheckTime);
 
-		PersistentData.CheckTime = CommonTime() + FuturisticVibratorCheckChatTime;
+		PersistentData.CheckTime = ChatRoomChatLog[lastMsgIndex].Time;
 	}
 
 	VibratorModeScriptDraw(data);

--- a/BondageClub/Screens/Inventory/ItemVulva/FuturisticVibrator/FuturisticVibrator.js
+++ b/BondageClub/Screens/Inventory/ItemVulva/FuturisticVibrator/FuturisticVibrator.js
@@ -89,11 +89,22 @@ function InventoryItemVulvaFuturisticVibratorExit() {
 
 function InventoryItemVulvaFuturisticVibratorDetectMsg(msg, TriggerValues) {
 	var commandsReceived = [];
+
+	// If the message is OOC, just return immediately
+	if (msg.indexOf('(') == 0) return commandsReceived;
+
 	for (let I = 0; I < TriggerValues.length; I++) {
-		const triggerRegex = new RegExp(`\\b${TriggerValues[I].toUpperCase()}\\b`);
-		const success = triggerRegex.test(msg.replace(/[^a-z0-9]/gmi, " ").replace(/\s+/g, " "));
+		// Don't execute arbitrary regex
+		let regexString = TriggerValues[I].replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+		// Allow `*` wildcard, and normalize case
+		regexString = regexString.replaceAll("\\*", ".*")
+		regexString = regexString.toUpperCase()
+
+		const triggerRegex = new RegExp(`\\b${regexString}\\b`);
+		const success = triggerRegex.test(msg);
 		
-		if (success && msg.indexOf('(') != 0) commandsReceived.push(ItemVulvaFuturisticVibratorTriggers[I]);
+		if (success) commandsReceived.push(ItemVulvaFuturisticVibratorTriggers[I]);
 	}
 	return commandsReceived;
 }

--- a/BondageClub/Screens/Inventory/ItemVulva/FuturisticVibrator/FuturisticVibrator.js
+++ b/BondageClub/Screens/Inventory/ItemVulva/FuturisticVibrator/FuturisticVibrator.js
@@ -2,7 +2,6 @@
 
 var ItemVulvaFuturisticVibratorTriggers = ["Increase", "Decrease", "Disable", "Edge", "Random", "Deny", "Tease", "Shock"];
 var ItemVulvaFuturisticVibratorTriggerValues = [];
-var FuturisticVibratorCheckChatTime = 1000; // Checks chat every 1 sec
 
 function InventoryItemVulvaFuturisticVibratorLoad() {
 	var C = (Player.FocusGroup != null) ? Player : CurrentCharacter;


### PR DESCRIPTION
This pull requests does the following things:

**Update the FuturisticVibrator to escape user inputs rather than accepting raw regex**

This would confuse users, where characters like `.` would cause unintended side effects.
It is also a vector for attack, as it is possible to craft "evil regex" that would crash browsers.
Escaping avoids this issue.

**Update the FuturisticVibrator to accept \* wildcards**

As a result of the new changes (prior to this pull request), the belt now only triggers on full words.
This new change handles this by converting any `*` character into a wildcard that will match anything.

**Update the FuturisticVibrator to instantly respond to messages**

Previously, the vibrator would check the chat chat log for messages once every second.
This change has the script monitor the time of the last message,
and triggers the keyword searches the moment a newer message is seen.
This results in triggers occurring in the very next frame,
and a much snappier experience.

**Update the FuturisticTrainingBelt to not use FuturisticVibratorCheckChatTime**

As `FuturisticVibratorCheckChatTime` was no longer being used in the main vibrator,
it made sense to no longer use it in the training belt, and instead clear up the variable.
At the end of the day, the `FuturisticTrainingBelt` is still limited by its `UpdateTime`,
so this change has no practical effect on this item.

**Update FuturisticTrainingBelt to not trigger on OOC chat**

Add check for starting `(` in messages, and skip over messages that do this.
This is already included in the `FuturisticVibrator`, but missed in the `FuturisticTrainingBelt`.

**Minor extra clean-up**

Over the code there is some minor cleanup, such as improving loop ordering,
or taking checks outside loops. They should be obvious looking at the code changes.