### PR TITLE
Up button improvements

### DIFF
--- a/BondageClub/Screens/Character/Appearance/Appearance.js
+++ b/BondageClub/Screens/Character/Appearance/Appearance.js
@@ -428,11 +428,7 @@ function CharacterAppearanceItemIsHidden(AssetName, GroupName) {
  * @returns {void} - Nothing
  */
 function CharacterAppearanceSetHeightModifiers(C) {
-	if (CharacterAppearanceForceUpCharacter == C.MemberNumber) {
-		// If the "Up" button was clicked, move the character to the top
-		C.HeightModifier = 0;
-		C.HeightRatioProportion = 1;
-	} else {
+	if (CharacterAppearanceForceUpCharacter != C.MemberNumber) {
 		let Height = 0;
 		let HeightRatioProportion = 1;
 
@@ -533,11 +529,12 @@ function CharacterAppearanceXOffset(C, HeightRatio) {
  * up at the 'ceiling'
  * @param {Character} C - The character to reposition
  * @param {number} HeightRatio - The character's height ratio
+ * @param {boolean} [IgnoreUpButton=false] - Whether or not to ignore the up button status
  * @returns {number} - The amounnt to move the character along the Y co-ordinate
  */
-function CharacterAppearanceYOffset(C, HeightRatio) {
+function CharacterAppearanceYOffset(C, HeightRatio, IgnoreUpButton) {
 	let HeightModifier = C.HeightModifier;
-	if (CharacterAppearanceForceUpCharacter == C.MemberNumber) {
+	if (!IgnoreUpButton && CharacterAppearanceForceUpCharacter == C.MemberNumber) {
 		HeightModifier = 0;
 	}
 	return 1000 * (1 - HeightRatio) * C.HeightRatioProportion - HeightModifier * HeightRatio;

--- a/BondageClub/Screens/Character/Appearance/Appearance.js
+++ b/BondageClub/Screens/Character/Appearance/Appearance.js
@@ -536,7 +536,11 @@ function CharacterAppearanceXOffset(C, HeightRatio) {
  * @returns {number} - The amounnt to move the character along the Y co-ordinate
  */
 function CharacterAppearanceYOffset(C, HeightRatio) {
-	return 1000 * (1 - HeightRatio) * C.HeightRatioProportion - C.HeightModifier * HeightRatio;
+	let HeightModifier = C.HeightModifier;
+	if (CharacterAppearanceForceUpCharacter == C.MemberNumber) {
+		HeightModifier = 0;
+	}
+	return 1000 * (1 - HeightRatio) * C.HeightRatioProportion - HeightModifier * HeightRatio;
 }
 
 /**

--- a/BondageClub/Scripts/CommonDraw.js
+++ b/BondageClub/Scripts/CommonDraw.js
@@ -146,7 +146,7 @@ function CommonDrawAppearanceBuild(C, {
 		let YFixedOffset = 0;
 		if (A.FixedPosition) {
 			if (C.IsInverted()) {
-				YFixedOffset = -Y + 1000 - (Y + CharacterAppearanceYOffset(C, C.HeightRatio) / C.HeightRatio);
+				YFixedOffset = -Y + 1000 - (Y + CharacterAppearanceYOffset(C, C.HeightRatio, true) / C.HeightRatio);
 			} else {
 				YFixedOffset = C.HeightModifier + 1000 * (1 - C.HeightRatio) * (1 - C.HeightRatioProportion) / C.HeightRatio;
 			}

--- a/BondageClub/Scripts/Dialog.js
+++ b/BondageClub/Scripts/Dialog.js
@@ -1282,8 +1282,7 @@ function DialogClick() {
 
 	// If the user clicked the Up button, move the character up to the top of the screen
 	if ((CurrentCharacter.HeightModifier < -90 || CurrentCharacter.HeightModifier > 30) && (CurrentCharacter.FocusGroup != null) && MouseIn (510,50,90,90)) {
-		CharacterAppearanceForceUpCharacter = CurrentCharacter.MemberNumber;
-		CurrentCharacter.HeightModifier = 0;
+		CharacterAppearanceForceUpCharacter = CharacterAppearanceForceUpCharacter == CurrentCharacter.MemberNumber ? -1 : CurrentCharacter.MemberNumber;
 		return;
 	}
 
@@ -1820,7 +1819,9 @@ function DialogDraw() {
 		// Draw a repositioning button if some zones are offscreen
 		if (CurrentCharacter != null && CurrentCharacter.HeightModifier != null && CurrentCharacter.FocusGroup != null) {
 			let drawButton = "";
-			if (CurrentCharacter.HeightModifier < -90) {
+			if (CharacterAppearanceForceUpCharacter == CurrentCharacter.MemberNumber) {
+				drawButton = "Icons/Remove.png";
+			} else if (CurrentCharacter.HeightModifier < -90) {
 				drawButton = "Icons/Up.png";
 			} else if (CurrentCharacter.HeightModifier > 30) {
 				drawButton = "Icons/Down.png";

--- a/BondageClub/Scripts/Dialog.js
+++ b/BondageClub/Scripts/Dialog.js
@@ -1822,9 +1822,9 @@ function DialogDraw() {
 			if (CharacterAppearanceForceUpCharacter == CurrentCharacter.MemberNumber) {
 				drawButton = "Icons/Remove.png";
 			} else if (CurrentCharacter.HeightModifier < -90) {
-				drawButton = "Icons/Up.png";
+				drawButton = C.IsInverted() ? "Icons/Down.png" : "Icons/Up.png";
 			} else if (CurrentCharacter.HeightModifier > 30) {
-				drawButton = "Icons/Down.png";
+				drawButton = C.IsInverted() ? "Icons/Up.png" : "Icons/Down.png";
 			}
 			if (drawButton) DrawButton(510, 50, 90, 90, "", "White", drawButton, DialogFindPlayer("ShowAllZones"));
 		}

--- a/BondageClub/Scripts/Dialog.js
+++ b/BondageClub/Scripts/Dialog.js
@@ -1822,9 +1822,9 @@ function DialogDraw() {
 			if (CharacterAppearanceForceUpCharacter == CurrentCharacter.MemberNumber) {
 				drawButton = "Icons/Remove.png";
 			} else if (CurrentCharacter.HeightModifier < -90) {
-				drawButton = C.IsInverted() ? "Icons/Down.png" : "Icons/Up.png";
+				drawButton = CurrentCharacter.IsInverted() ? "Icons/Down.png" : "Icons/Up.png";
 			} else if (CurrentCharacter.HeightModifier > 30) {
-				drawButton = C.IsInverted() ? "Icons/Up.png" : "Icons/Down.png";
+				drawButton = CurrentCharacter.IsInverted() ? "Icons/Up.png" : "Icons/Down.png";
 			}
 			if (drawButton) DrawButton(510, 50, 90, 90, "", "White", drawButton, DialogFindPlayer("ShowAllZones"));
 		}


### PR DESCRIPTION
The up button could have strange behaviors in certain cases, some were accentuated by certain types of items, this aims to make it a bit more user friendly

- turned the up button into a toggle so it is possible to revert to normal height without losing focus on the character
- fixed the arrows being inverted while suspended
- fixed the character going back down on refreshes
- fixed the items with `FixedPosition: true` being rendered in a different position compared to the character, which can break most items that aren't just "decor"/ need to maintain consistency in height (like boxes, the kennel, etc.)