### PR TITLE
validation lock check

### DIFF
--- a/BondageClub/Scripts/Validation.js
+++ b/BondageClub/Scripts/Validation.js
@@ -220,13 +220,14 @@ function ValidationResolveLockModification(previousItem, newItem, params, itemBl
 
 	const previousProperty = previousItem.Property || {};
 	const newProperty = newItem.Property = newItem.Property || {};
-
-	if (!ValidationLockWasModified(previousProperty, newProperty)) {
-		return true;
-	}
-
+	
 	const previousLock = InventoryGetLock(previousItem);
 	const newLock = InventoryGetLock(newItem);
+	const notLocked = !previousLock && !newLock;
+	
+	if (notLocked || !ValidationLockWasModified(previousProperty, newProperty)) {
+		return true;
+	}
 
 	const lockSwapped = !!newLock && !!previousLock && newLock.Asset.Name !== previousLock.Asset.Name;
 	const lockModified = !!newLock && !!previousLock && !lockSwapped;


### PR DESCRIPTION
- fixed the validation code to understand cases where items were not locked

Expression triggers were causing false errors and refreshes because of the property RemoveTimer which is common on both locks and expressions.