### PR TITLE
Allows lovers and owners to trap players in private rooms

### DIFF
--- a/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
+++ b/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
@@ -3347,7 +3347,15 @@ function ChatRoomRecreate() {
 	if (Player.ImmersionSettings && Player.ImmersionSettings.ReturnToChatRoomAdmin &&
 		Player.ImmersionSettings.ReturnToChatRoom && Player.LastChatRoomAdmin && ChatRoomNewRoomToUpdate) {
 		// Add the player if they are not an admin
-		if (!Player.LastChatRoomAdmin.includes(Player.MemberNumber) && Player.LastChatRoomPrivate) {
+		let isTrapped = false;
+		let C = Player;
+		for (let A = 0; A < C.Appearance.length; A++)
+			if ((C.Appearance[A].Asset != null) && (C.Appearance[A].Asset.Group.Family == C.AssetFamily) && C.Appearance[A].Asset.IsRestraint && (InventoryOwnerOnlyItem(C.Appearance[A]) || InventoryLoverOnlyItem(C.Appearance[A])) && 
+				(InventoryItemHasEffect(C.Appearance[A], "Tethered", true) || InventoryItemHasEffect(C.Appearance[A], "Mounted", true) || InventoryItemHasEffect(C.Appearance[A], "Enclose", true) || InventoryItemHasEffect(C.Appearance[A], "OneWayEnclose", true))) {
+				isTrapped = true;
+			}
+		
+		if (!isTrapped && !Player.LastChatRoomAdmin.includes(Player.MemberNumber) && Player.LastChatRoomPrivate) {
 			Player.LastChatRoomAdmin.push(Player.MemberNumber);
 		}
 		var UpdatedRoom = {


### PR DESCRIPTION
The Auto-remake feature for chat rooms now looks at the player's items and determines if there are any owner-locked or lover-locked items that tether, enclose, or mount the player. Since these locks cannot be applied by non-owners or non-lovers, a troll cannot apply them to keep a player trapped. Also, since these items make it impossible to leash a player, a troll cannot leash a player who has these conditions into a private room.

This allows for owners to lock their subs in a private room as part of roleplay without the player being able to change the room properties (e.g. to make it public and plead for help)