### PR TITLE
Modular Item Validation Fix

### DIFF
--- a/BondageClub/Scripts/TypedItem.js
+++ b/BondageClub/Scripts/TypedItem.js
@@ -305,7 +305,7 @@ function TypedItemGetOption(groupName, assetName, optionName) {
  * message informing the player of the requirements that are not met.
  */
 function TypedItemValidateOption(C, item, option, previousOption) {
-	if (InventoryBlockedOrLimited(C, item, option.Property.Type)) {
+	if (option.Property && option.Property.Type && InventoryBlockedOrLimited(C, item, option.Property.Type)) {
 		return DialogFindPlayer("ExtendedItemNoItemPermission");
 	}
 	const validationFunctionName = `Inventory${item.Asset.Group.Name}${item.Asset.Name}Validate`;


### PR DESCRIPTION
A fix to prevent crashing for extended items with no Type in their config, such as the Kigurumi Mask.