### PR TITLE
Unusable Favorites Fix

### DIFF
--- a/BondageClub/Screens/Character/Appearance/Appearance.js
+++ b/BondageClub/Screens/Character/Appearance/Appearance.js
@@ -733,7 +733,8 @@ function AppearanceGetPreviewImageColor(C, item, hover) {
 		else if (InventoryIsPermissionLimited(C, item.Asset.Name, item.Asset.Group.Name)) permission = "amber";
 		return item.Worn ? "gray" : AppearancePermissionColors[permission][hover ? 1 : 0];
 	} else {
-		const Unusable = item.SortOrder.startsWith(DialogSortOrder.Unusable.toString());
+		const Unusable = item.SortOrder.startsWith(DialogSortOrder.Unusable.toString())
+			|| item.SortOrder.startsWith(DialogSortOrder.FavoriteUnusable.toString());
 		const Blocked = item.SortOrder.startsWith(DialogSortOrder.Blocked.toString());
 		if (hover && !Blocked) return "cyan";
 		else if (item.Worn) return "pink";


### PR DESCRIPTION
When an item cannot be used due to failed prerequisites but is a favorite of the character, the box background was white when it should be grey. Now fixed.