### PR TITLE
Bugfix: Font size setting adjustments

### DIFF
--- a/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
+++ b/BondageClub/Screens/Online/ChatRoom/ChatRoom.js
@@ -80,9 +80,9 @@ var ChatRoomHideIconState = 0;
 var ChatRoomMenuButtons = [];
 let ChatRoomFontSize = 30;
 const ChatRoomFontSizes = {
-	Small: 24,
-	Medium: 30,
-	Large: 36,
+	Small: 28,
+	Medium: 36,
+	Large: 44,
 };
 
 /**


### PR DESCRIPTION
Not really a fix so much as an adjustment based on feedback in the beta errors channel. This adjusts the font size settings so that:
* Medium is now the same size as the old default font size (for the dark 1/light 1 themes)
* Large should now allow for a larger size on mobile devices and smaller screens as it did before in the light 2/dark 2 themes (although not to quite the same extreme on mobiles)