### PR TITLE
Color Picker Fixes

### DIFF
--- a/BondageClub/Scripts/ColorPicker.js
+++ b/BondageClub/Scripts/ColorPicker.js
@@ -151,7 +151,6 @@ function ColorPickerGetCoordinates(Event) {
 function ColorPickerPickHue(Event) {
 	var C = ColorPickerGetCoordinates(Event);
 	ColorPickerHSV.H = Math.max(0, Math.min(1, (C.X - ColorPickerX) / ColorPickerWidth));
-	ColorPickerLastHSV = Object.assign({}, ColorPickerHSV);
 	ColorPickerNotify();
 }
 
@@ -169,7 +168,6 @@ function ColorPickerPickSV(Event) {
 	var V = 1 - (C.Y - SVPanelOffset) / SVPanelHeight;
 	ColorPickerHSV.S = Math.max(0, Math.min(1, S));
 	ColorPickerHSV.V = Math.max(0, Math.min(1, V));
-	ColorPickerLastHSV = Object.assign({}, ColorPickerHSV);
 	ColorPickerNotify();
 }
 
@@ -194,26 +192,7 @@ function ColorPickerSelectFromPalette(Event) {
 function ColorPickerSelectFromFavorites(Event) {
 	var C = ColorPickerGetCoordinates(Event);
 	var P = Math.max(0, Math.min(1, (C.X - ColorPickerX) / ColorPickerWidth));
-	var SelectedIndex;
-
-	if(P < (1/6)){
-		SelectedIndex = 0;
-	}
-	else if(P < (2/6)){
-		SelectedIndex = 1;
-	}
-	else if(P < (3/6)){
-		SelectedIndex = 2;
-	}
-	else if(P < (4/6)){
-		SelectedIndex = 3;
-	}
-	else if(P < (5/6)){
-		SelectedIndex = 4;
-	}
-	else{
-		SelectedIndex = 5;
-	}
+	var SelectedIndex = Math.min(Math.floor(P * 6), 5);
 
 	if (SelectedIndex == ColorPickerSelectedFavoriteIndex){
 		ColorPickerHSV = Object.assign({}, Player.SavedColors[ColorPickerSelectedFavoriteIndex + (ColorPickerFavoritesPage * 6)]);
@@ -256,6 +235,7 @@ function ColorPickerSelectButton(Event) {
  * @returns {void} - Nothing
  */
 function ColorPickerNotify() {
+	ColorPickerLastHSV = Object.assign({}, ColorPickerHSV);
 	ColorPickerCSS = ColorPickerHSVToCSS(ColorPickerHSV);
 	if (ColorPickerCallback) {
 		ColorPickerCallback(ColorPickerCSS);
@@ -359,12 +339,9 @@ function ColorPickerDraw(X, Y, Width, Height, Src, Callback) {
 			if (CommonIsColor(UserInputColor)) {
 				ColorPickerIsDefault = false;
 				if (!ColorPickerCSSColorEquals(UserInputColor, ColorPickerCSS)) {
-					if (ColorPickerCallback) {
-						// Fire callback due to source element changed by user interaction
-						ColorPickerCallback(UserInputColor);
-					}
 					ColorPickerCSS = UserInputColor;
 					ColorPickerHSV = ColorPickerCSSToHSV(UserInputColor, ColorPickerHSV);
+					ColorPickerNotify();
 				}
 			} else if (UserInputColor === "DEFAULT" && !ColorPickerIsDefault) {
 				ColorPickerIsDefault = true;

--- a/BondageClub/Scripts/Dialog.js
+++ b/BondageClub/Scripts/Dialog.js
@@ -1325,21 +1325,25 @@ function DialogInventoryTogglePermission(item) {
  */
 function DialogClick() {
 
+	// Gets the current character
+	let C = CharacterGetCurrent();
+
 	// If the user clicked the Up button, move the character up to the top of the screen
 	if ((CurrentCharacter.HeightModifier < -90 || CurrentCharacter.HeightModifier > 30) && (CurrentCharacter.FocusGroup != null) && MouseIn (510,50,90,90)) {
 		CharacterAppearanceForceUpCharacter = CharacterAppearanceForceUpCharacter == CurrentCharacter.MemberNumber ? -1 : CurrentCharacter.MemberNumber;
 		return;
 	}
 
-	if (DialogColor != null && CurrentCharacter.FocusGroup && InventoryGet(CurrentCharacter, CurrentCharacter.FocusGroup.Name) && MouseIn(1300, 25, 675, 950)) {
-		return ItemColorClick(CurrentCharacter, CurrentCharacter.FocusGroup.Name, 1200, 25, 775, 950, true);
+	// Pass the click to the color panel
+	if (DialogColor != null && C.FocusGroup && InventoryGet(C, C.FocusGroup.Name) && MouseIn(1300, 25, 675, 950)) {
+		return ItemColorClick(C, C.FocusGroup.Name, 1200, 25, 775, 950, true);
 	}
 
 	// If the user clicked on the interaction character or herself, we check to build the item menu
-	if ((CurrentCharacter.AllowItem || (MouseX < 500)) && MouseIn(0,0,1000,1000) && ((CurrentCharacter.ID != 0) || (MouseX > 500)) && (DialogIntro() != "") && DialogAllowItemScreenException()) {
+	if ((CurrentCharacter.AllowItem || (MouseX < 500)) && MouseIn(0, 0, 1000, 1000) && ((CurrentCharacter.ID != 0) || (MouseX > 500)) && (DialogIntro() != "") && DialogAllowItemScreenException()) {
 		DialogLeaveItemMenu();
 		DialogLeaveFocusItem();
-		var C = (MouseX < 500) ? Player : CurrentCharacter;
+		C = (MouseX < 500) ? Player : CurrentCharacter;
 		let X = MouseX < 500 ? 0 : 500;
 		for (let A = 0; A < AssetGroup.length; A++)
 			if ((AssetGroup[A].Category == "Item") && (AssetGroup[A].Zone != null))
@@ -1372,7 +1376,7 @@ function DialogClick() {
 				// If this specific activity is clicked, we run it
 				if ((MouseX >= X) && (MouseX < X + 225) && (MouseY >= Y) && (MouseY < Y + 275)) {
 					IntroductionJobProgress("SubActivity", DialogActivity[A].MaxProgress.toString(), true);
-					ActivityRun((Player.FocusGroup != null) ? Player : CurrentCharacter, DialogActivity[A]);
+					ActivityRun(C, DialogActivity[A]);
 					return;
 				}
 
@@ -1408,7 +1412,7 @@ function DialogClick() {
 			if ((MouseX >= 1000) && (MouseX < 2000) && (MouseY >= 15) && (MouseY <= 105)) DialogMenuButtonClick();
 
 			// If the user clicks on one of the items
-			if ((MouseX >= 1000) && (MouseX <= 1975) && (MouseY >= 125) && (MouseY <= 1000) && ((DialogItemPermissionMode && (Player.FocusGroup != null)) || (Player.CanInteract() && !InventoryGroupIsBlocked((Player.FocusGroup != null) ? Player : CurrentCharacter, null, true))) && (StruggleProgress < 0 && !StruggleLockPickOrder) && (DialogColor == null)) {
+			if ((MouseX >= 1000) && (MouseX <= 1975) && (MouseY >= 125) && (MouseY <= 1000) && ((DialogItemPermissionMode && (Player.FocusGroup != null)) || (Player.CanInteract() && !InventoryGroupIsBlocked(C, null, true))) && (StruggleProgress < 0 && !StruggleLockPickOrder) && (DialogColor == null)) {
 				// For each items in the player inventory
 				let X = 1000;
 				let Y = 125;


### PR DESCRIPTION
When the colour in the colour picker screen was changed using certain methods, such as typing in a hex code or loading a saved colour using the new feature, the 'current colour' box (near the bottom beside an 'initial colour' box) didn't change.

When viewing another character but changing the colour for an object on yourself, some buttons such as Exit and Default did nothing.