### PR TITLE
Beta-fix: Convert ItemTorso:NylonRopeHarness to typed item

### DIFF
--- a/BondageClub/Assets/Female3DCG/Female3DCG.js
+++ b/BondageClub/Assets/Female3DCG/Female3DCG.js
@@ -2036,7 +2036,7 @@ var AssetFemale3DCG = [
 			{ Group: "ItemAddon", Name: "CeilingChain" },
 		],
 		Asset: [
-			{ Name: "NylonRopeHarness", Fetish: ["Rope", "Nylon"], Value: 30, Time: 20, DefaultColor: "#909090", BuyGroup: "NylonRope", Audio: "RopeShort", Prerequisite: "AccessTorso", AllowType: ["Harness", "Diamond", "Star", "Waist"], Extended: true, AllowEffect: ["CrotchRope"] },
+			{ Name: "NylonRopeHarness", Fetish: ["Rope", "Nylon"], Value: 30, Time: 20, DefaultColor: "#909090", BuyGroup: "NylonRope", Audio: "RopeShort", Prerequisite: "AccessTorso", Extended: true },
 			{ Name: "HempRopeHarness", Fetish: ["Rope"], Value: 60, Difficulty: 3, Time: 20, RemoveTime: 25, DefaultColor: "#956B1C", BuyGroup: "HempRope", Audio: "RopeShort", Prerequisite: "AccessTorso", Extended: true },
 			{ Name: "LeatherHarness", Fetish: ["Leather"], Value: 60, Difficulty: 50, Time: 15, RemoveTime: 10, AllowLock: true, Prerequisite: "AccessTorso" },
 			{ Name: "LeatherStrapHarness", Fetish: ["Leather"], Value: 50, Difficulty: 50, Time: 15, RemoveTime: 10, DefaultColor: "#101010", AllowLock: true, Prerequisite: "AccessTorso" },

--- a/BondageClub/Assets/Female3DCG/Female3DCGExtended.js
+++ b/BondageClub/Assets/Female3DCG/Female3DCGExtended.js
@@ -1314,6 +1314,10 @@ var AssetFemale3DCGExtended = {
 				]
 			},
 		}, // ThinLeatherStraps
+		NylonRopeHarness: {
+			Archetype: ExtendedArchetype.TYPED,
+			CopyConfig: { AssetName: "HempRopeHarness" }
+		}, // NylonRopeHarness
 		HempRopeHarness: {
 			Archetype: ExtendedArchetype.TYPED,
 			Config: {

--- a/BondageClub/Screens/Inventory/ItemTorso/NylonRopeHarness/NylonRopeHarness.js
+++ b/BondageClub/Screens/Inventory/ItemTorso/NylonRopeHarness/NylonRopeHarness.js
@@ -1,8 +1,0 @@
-"use strict";
-
-// The nylon rope harness uses the scripts from the hemp rope, they are copied items
-function InventoryItemTorsoNylonRopeHarnessLoad() { InventoryItemTorsoHempRopeHarnessLoad(); }
-function InventoryItemTorsoNylonRopeHarnessDraw() { InventoryItemTorsoHempRopeHarnessDraw(); }
-function InventoryItemTorsoNylonRopeHarnessClick() { InventoryItemTorsoHempRopeHarnessClick(); }
-function InventoryItemTorsoNylonRopeHarnessPublishAction(C, Option) { InventoryItemTorsoHempRopeHarnessPublishAction(C, Option); }
-function InventoryItemTorsoNylonRopeHarnessNpcDialog(C, Option) {  InventoryItemTorsoHempRopeHarnessNpcDialog(C, Option); }

--- a/BondageClub/index.html
+++ b/BondageClub/index.html
@@ -191,7 +191,6 @@
 <script src="Screens/Inventory/ItemNeck/FuturisticCollar/FuturisticCollar.js"></script>
 <script src="Screens/Inventory/ItemTorso/FuturisticHarness/FuturisticHarness.js"></script>
 <script src="Screens/Inventory/ItemHands/SpankingToys/SpankingToy.js"></script>
-<script src="Screens/Inventory/ItemTorso/NylonRopeHarness/NylonRopeHarness.js"></script>
 <script src="Screens/Inventory/ItemFeet/HempRope/HempRope.js"></script>
 <script src="Screens/Inventory/ItemFeet/Chains/Chains.js"></script>
 <script src="Screens/Inventory/ItemLegs/HempRope/HempRope.js"></script>


### PR DESCRIPTION
`NylonRopeHarness` used `HempRopeHarness` functions, however `HempRopeHarness` was converted while `NylonRopeHarness` wasn't, this PR fixes that.