### PR TITLE
Beta-fix: AssetCheck: respect CopyConfig

### DIFF
--- a/BondageClub/Tools/Node/AssetCheck.js
+++ b/BondageClub/Tools/Node/AssetCheck.js
@@ -213,9 +213,22 @@ function validateArray(definition, obj, description, allowMissing=false) {
 				// Check any extended item config
 				if (Asset.Extended) {
 					const groupConfig = AssetFemale3DCGExtended[Group.Group] || {};
-					const assetConfig = groupConfig[Asset.Name];
+					let assetConfig = groupConfig[Asset.Name];
 					if (assetConfig) {
 						validateObject(types.ExtendedItemAssetConfig, assetConfig, `Extended asset archetype for ${Group.Group}:${Asset.Name}`);
+						const Config = assetConfig.Config;
+						if (assetConfig && assetConfig.CopyConfig) {
+							const Overrides = assetConfig.Config;
+							const { GroupName, AssetName } = assetConfig.CopyConfig;
+							assetConfig = AssetFemale3DCGExtended[GroupName || Group.Group]?.[AssetName];
+							if (!assetConfig) {
+								error(`Asset ${Group.Group}:${Asset.Name}: CopyConfig target not found!`);
+								assetConfig = groupConfig[Asset.Name];
+							} else if (Overrides) {
+								const MergedConfig = Object.assign({}, assetConfig.Config, Overrides);
+								assetConfig = Object.assign({}, assetConfig, {Config: MergedConfig});
+							}
+						}
 						if (assetConfig.Config) {
 							if (assetConfig.Archetype === "modular") {
 								validateObject(types.ModularItemConfig, assetConfig.Config, `Extended asset config for ${Group.Group}:${Asset.Name}`);

--- a/BondageClub/Tools/Node/AssetCheck.js
+++ b/BondageClub/Tools/Node/AssetCheck.js
@@ -220,7 +220,7 @@ function validateArray(definition, obj, description, allowMissing=false) {
 						if (assetConfig && assetConfig.CopyConfig) {
 							const Overrides = assetConfig.Config;
 							const { GroupName, AssetName } = assetConfig.CopyConfig;
-							assetConfig = AssetFemale3DCGExtended[GroupName || Group.Group]?.[AssetName];
+							assetConfig = (AssetFemale3DCGExtended[GroupName || Group.Group] || {} )[AssetName];
 							if (!assetConfig) {
 								error(`Asset ${Group.Group}:${Asset.Name}: CopyConfig target not found!`);
 								assetConfig = groupConfig[Asset.Name];


### PR DESCRIPTION
Makes AssetCheck follow extended item's `CopyConfig`, so it can catch more errors