### PR TITLE
Shop Sell Group Fix

### DIFF
--- a/BondageClub/Screens/Room/Shop/Dialog_NPC_Shop_Vendor.csv
+++ b/BondageClub/Screens/Room/Shop/Dialog_NPC_Shop_Vendor.csv
@@ -56,7 +56,7 @@ ItemPelvisLeatherCrop,,,(You lash the leather crop pretty hard on her butt.)  Da
 34,31,Can I try again?,Alright.  Let me find an item to promote.  (She checks on the shelves for an item to use on you.),,JobCanGoAgain()
 34,,Can you help me out?,"I don't have time, there's too many customers.  Go find a maid if you can't struggle out.",DialogRemove(),!Player.CanInteract()
 90,100,Clothes and accessories.,"What kind of clothes?",,CanShow(Cloth|ClothAccessory|Suit|ClothLower|Hat|Glasses|Mask|Necklace|Gloves|Shoes|Corset)
-90,110,Underwear.,"What kind of underwear?",,CanShow(Bra|Panties|Socks)
+90,110,Underwear.,"What kind of underwear?",,CanShow(Bra|Panties|Socks|Garters)
 90,120,Exotic accessories.,"What kind of accessories?",,CanShow(Wings|TailStraps|HairAccessory1|ItemDevices|ItemAddon)
 90,200,Something for the head.,For which body part exactly?,,CanShow(ItemHead|ItemEars|ItemMouth|ItemNeck|ItemNeckAccessories|ItemNeckRestraints|ItemHood|ItemNose|ItemMisc)
 90,210,Something for the body or arms.,For which body part exactly?,,CanShow(ItemArms|ItemHands|ItemBreast|ItemNipples|ItemNipplesPiercings|ItemTorso|ItemPelvis)
@@ -68,7 +68,7 @@ ItemPelvisLeatherCrop,,,(You lash the leather crop pretty hard on her butt.)  Da
 100,,Pants or skirts.,,Start(ClothLower),CanShow(ClothLower)
 100,,Hats or head accessories.,,Start(Hat),CanShow(Hat)
 100,,Glasses.,,Start(Glasses),CanShow(Glasses)
-100,101,It's another type of clothes.,What kind is it?,,CanShow(Mask|Necklace|Gloves|Shoes|Corset)
+100,101,It's another type of clothes.,What kind is it?,,CanShow(Mask|Necklace|Gloves|Shoes|Corset|Bracelet)
 100,90,What else do you have?,We have many items available.,,BuyMode
 100,90,Actually it's something else.,What kind of item is it?,,!BuyMode
 101,,Masks.,,Start(Mask),CanShow(Mask)


### PR DESCRIPTION
A small fix to ensure the two new groups appear in the shop's sell options in the rare case they're the only owned items on that page.