### PR TITLE
Colour Entry Fix

### DIFF
--- a/BondageClub/Scripts/ColorPicker.js
+++ b/BondageClub/Scripts/ColorPicker.js
@@ -232,17 +232,17 @@ function ColorPickerSelectButton(Event) {
 
 /**
  * Alters the color picker display based on the selected value
- * @param {boolean} [updateSourceElement] - False if the change came from a typed hex value
+ * @param {boolean} [sourceElementChanged=false] - True if the color was updated by the text input element
  * @returns {void} - Nothing
  */
-function ColorPickerNotify(updateSourceElement=true) {
+function ColorPickerNotify(sourceElementChanged = false) {
 	ColorPickerLastHSV = Object.assign({}, ColorPickerHSV);
-	ColorPickerCSS = ColorPickerHSVToCSS(ColorPickerHSV);
+	if (!sourceElementChanged) ColorPickerCSS = ColorPickerHSVToCSS(ColorPickerHSV);
 	if (ColorPickerCallback) {
 		ColorPickerCallback(ColorPickerCSS);
 	}
 
-	if (updateSourceElement && ColorPickerSourceElement) {
+	if (!sourceElementChanged && ColorPickerSourceElement) {
 		ColorPickerSourceElement.value = ColorPickerCSS;
 	}
 }
@@ -342,7 +342,7 @@ function ColorPickerDraw(X, Y, Width, Height, Src, Callback) {
 				if (!ColorPickerCSSColorEquals(UserInputColor, ColorPickerCSS)) {
 					ColorPickerCSS = UserInputColor;
 					ColorPickerHSV = ColorPickerCSSToHSV(UserInputColor, ColorPickerHSV);
-					ColorPickerNotify(false);
+					ColorPickerNotify(true);
 				}
 			} else if (UserInputColor === "DEFAULT" && !ColorPickerIsDefault) {
 				ColorPickerIsDefault = true;

--- a/BondageClub/Scripts/ColorPicker.js
+++ b/BondageClub/Scripts/ColorPicker.js
@@ -232,16 +232,17 @@ function ColorPickerSelectButton(Event) {
 
 /**
  * Alters the color picker display based on the selected value
+ * @param {boolean} [updateSourceElement] - False if the change came from a typed hex value
  * @returns {void} - Nothing
  */
-function ColorPickerNotify() {
+function ColorPickerNotify(updateSourceElement=true) {
 	ColorPickerLastHSV = Object.assign({}, ColorPickerHSV);
 	ColorPickerCSS = ColorPickerHSVToCSS(ColorPickerHSV);
 	if (ColorPickerCallback) {
 		ColorPickerCallback(ColorPickerCSS);
 	}
 
-	if (ColorPickerSourceElement) {
+	if (updateSourceElement && ColorPickerSourceElement) {
 		ColorPickerSourceElement.value = ColorPickerCSS;
 	}
 }
@@ -341,7 +342,7 @@ function ColorPickerDraw(X, Y, Width, Height, Src, Callback) {
 				if (!ColorPickerCSSColorEquals(UserInputColor, ColorPickerCSS)) {
 					ColorPickerCSS = UserInputColor;
 					ColorPickerHSV = ColorPickerCSSToHSV(UserInputColor, ColorPickerHSV);
-					ColorPickerNotify();
+					ColorPickerNotify(false);
 				}
 			} else if (UserInputColor === "DEFAULT" && !ColorPickerIsDefault) {
 				ColorPickerIsDefault = true;


### PR DESCRIPTION
When typing in a hex code for a colour, the step to refresh everything with the selected colour always included the input box as well, which resulted in the player being interrupted halfway through with a "completed" value. Now when the change comes from the input box, the box's value will not be changed.
There was also an issue where the colour was converted from hex to HSV then back to hex which could change the value.