### PR TITLE
Bugfix: Ensures characters refresh properly after calling `InventoryWearRandom`

### DIFF
--- a/BondageClub/Scripts/Inventory.js
+++ b/BondageClub/Scripts/Inventory.js
@@ -417,14 +417,14 @@ function InventoryLocked(C, AssetGroup, CheckProperties) {
  * @param {Character} C - The character that must wear the item
  * @param {string} GroupName - The name of the asset group (body area)
  * @param {number} [Difficulty] - The difficulty, on top of the base asset difficulty, to assign to the item
- * @param {boolean} [Refresh] - Do not call CharacterRefresh if false
+ * @param {boolean} [Refresh=true] - Do not call CharacterRefresh if false
  * @param {boolean} [MustOwn=false] - If TRUE, only assets that the character owns can be worn. Otherwise any asset can
  * be used
  * @param {boolean} [Extend=true] - Whether or not to randomly extend the item (i.e. set the item type), provided it has
  * an archetype that supports random extension
  * @returns {void} - Nothing
  */
-function InventoryWearRandom(C, GroupName, Difficulty, Refresh, MustOwn = false, Extend = true) {
+function InventoryWearRandom(C, GroupName, Difficulty, Refresh = true, MustOwn = false, Extend = true) {
 	if (InventoryLocked(C, GroupName, true)) {
 		return;
 	}


### PR DESCRIPTION
## Summary

As part of #2649, the `InventoryWearRandom` function was changed such that calling it without a `Refresh` argument would result in the character not refreshing. This meant that a subset of `InventoryWearRandom` calls in the game would not refresh the character after an item had been applied when they should have, causing the added items not to render.