### PR TITLE
fix random typed items

### DIFF
--- a/BondageClub/Assets/Female3DCG/Female3DCGExtended.js
+++ b/BondageClub/Assets/Female3DCG/Female3DCGExtended.js
@@ -658,7 +658,8 @@ var AssetFemale3DCGExtended = {
 							AllowActivityOn: ["ItemHands", "ItemLegs", "ItemFeet", "ItemBoots"],
 							SetPose: ["Kneel", "BackElbowTouch"], Difficulty: 3
 						},
-						Expression: [{ Group: "Blush", Name: "Medium", Timer: 10 }]
+						Expression: [{ Group: "Blush", Name: "Medium", Timer: 10 }],
+						Random: false,
 					}, {
 						Name: "ZipHogtie",
 						Prerequisite: ["NotMounted", "NotSuspended", "CannotBeHogtiedWithAlphaHood"],
@@ -669,7 +670,8 @@ var AssetFemale3DCGExtended = {
 							AllowActivityOn: ["ItemHands", "ItemLegs", "ItemFeet", "ItemBoots"],
 							SetPose: ["Hogtied"], Difficulty: 3
 						},
-						Expression: [{ Group: "Blush", Name: "Medium", Timer: 10 }]
+						Expression: [{ Group: "Blush", Name: "Medium", Timer: 10 }],
+						Random: false,
 					}, {
 						Name: "ZipAllFours",
 						Prerequisite: ["NotMounted", "NotSuspended", "CannotBeHogtiedWithAlphaHood"],
@@ -679,7 +681,8 @@ var AssetFemale3DCGExtended = {
 							AllowActivityOn: ["ItemLegs", "ItemFeet", "ItemBoots"],
 							SetPose: ["AllFours"], Difficulty: 3
 						},
-						Expression: [{ Group: "Blush", Name: "Medium", Timer: 10 }]
+						Expression: [{ Group: "Blush", Name: "Medium", Timer: 10 }],
+						Random: false,
 					},
 				],
 				ChatTags: [CommonChatTags.SOURCE_CHAR, CommonChatTags.TARGET_CHAR],
@@ -696,7 +699,13 @@ var AssetFemale3DCGExtended = {
 					{ Name: "Boxtie", Property: { Type: null, SetPose: ["BackBoxTie"] } },
 					{ Name: "WristElbow", Property: { Type: "WristElbow", SetPose: ["BackElbowTouch"] } },
 					{ Name: "WristElbowHarness", Property: { Type: "WristElbowHarness", SetPose: ["BackElbowTouch"] } },
-					{ Name: "Hogtie", Property: { Type: "Hogtie", SetPose: ["Hogtied"], Effect: ["Block", "Freeze", "Prone"] } }
+					{
+						Name: "Hogtie",
+						Property: {
+							Type: "Hogtie", SetPose: ["Hogtied"], Effect: ["Block", "Freeze", "Prone"]
+						},
+						Random: false,
+					}
 				]
 			}
 		}, //ThinLeatherStraps
@@ -1081,6 +1090,7 @@ var AssetFemale3DCGExtended = {
 								"ItemPelvis", "ItemTorso", "ItemVulva", "ItemVulvaPiercings"
 							]
 						},
+						Random: false,
 					},
 				],
 			},
@@ -1974,7 +1984,8 @@ var AssetFemale3DCGExtended = {
 					}, {
 						Name: "ZipFrogtie",
 						Property: { Type: "ZipFrogtie", SetPose: ["Kneel"], Block: ["ItemFeet"], Effect: ["ForceKneel"], Difficulty: 3 },
-						Prerequisite: ["NotSuspended", "CanKneel"]
+						Prerequisite: ["NotSuspended", "CanKneel"],
+						Random: false,
 					}
 				],
 				Dialog: {

--- a/BondageClub/Tools/Node/AssetCheck_Types.js
+++ b/BondageClub/Tools/Node/AssetCheck_Types.js
@@ -216,6 +216,7 @@ const ExtendedItemOption = {
 	Property: "Maybe Object",
 	Expression: "Maybe [{ Name: String, Group: String, Timer: Number }]",
 	HasSubscreen: "Maybe Boolean",
+	Random: "Maybe Boolean",
 }
 
 module.exports = {


### PR DESCRIPTION
- fixed some typed item not having Random: false which caused problems in areas where npcs would apply a random type that blocks the player within the room (such as serving drinks in online rooms)
- fixed the asset check to include proper verification for the new Random property on typed items

This covers all hogtie + allfours + frogtie types currently available in the typed items which is in line with how normal items are blocked from being randomly applied.