### PR TITLE
fix incorrect room blocks persistance

### DIFF
--- a/BondageClub/Screens/Online/ChatAdmin/ChatAdmin.js
+++ b/BondageClub/Screens/Online/ChatAdmin/ChatAdmin.js
@@ -10,6 +10,7 @@ var ChatAdminGameList = ["", "LARP"];
 var ChatAdminBackgroundSelected = null;
 var ChatAdminTemporaryData = null;
 var ChatAdminBlockCategory = [];
+var ChatAdminInitialLoad = false;
 
 /**
  * Loads the chat Admin screen properties and creates the inputs
@@ -22,7 +23,7 @@ function ChatAdminLoad() {
 	ChatAdminBackgroundIndex = ChatCreateBackgroundList.indexOf(ChatAdminBackgroundSelect);
 	if (ChatAdminBackgroundIndex < 0) ChatAdminBackgroundIndex = 0;
 	ChatAdminBackgroundSelect = ChatCreateBackgroundList[ChatAdminBackgroundIndex];
-	ChatAdminBlockCategory = ChatRoomData.BlockCategory;
+	if (!ChatAdminInitialLoad) ChatAdminBlockCategory = ChatRoomData.BlockCategory.slice();
 	ChatAdminGame = ChatRoomGame;
 
 	// Prepares the controls to edit a room
@@ -60,7 +61,7 @@ function ChatAdminLoad() {
 		document.getElementById("InputSize").setAttribute("disabled", "disabled");
 		ChatAdminMessage = "AdminOnly";
 	} else ChatAdminMessage = "UseMemberNumbers";
-
+	ChatAdminInitialLoad = true;
 }
 
 /**
@@ -183,6 +184,7 @@ function ChatAdminExit() {
 	ElementRemove("InputAdminList");
 	ElementRemove("InputBanList");
 	CommonSetScreen("Online", "ChatRoom");
+	ChatAdminInitialLoad = false;
 }
 
 /**

--- a/BondageClub/Screens/Online/ChatBlockItem/ChatBlockItem.js
+++ b/BondageClub/Screens/Online/ChatBlockItem/ChatBlockItem.js
@@ -49,6 +49,4 @@ function ChatBlockItemExit() {
 		ElementValue("InputDescription", ChatBlockItemReturnData.Description);
 		ElementValue("InputSize", ChatBlockItemReturnData.Limit);
 	}
-	if (ChatBlockItemReturnData.Screen == "ChatAdmin")
-		ChatBlockItemCategory = ChatAdminBlockCategory;
 }


### PR DESCRIPTION
- fixed the block category UI menu toggle not being properly canceled

Currently, going in chatadmin to update room blocks will keep them the way you left them even if you cancel out, which can cause desyncs (for example, you have or dont have a room block others have). This was in part due to the fact that ChatRoomData.BlockCategory, ChatAdminBlockCategory and ChatBlockItemCategory were all referencing the same array so the "reset" logic wasnt working as intended (and was logically incorrect).

This fix properly instates the expected (and intended) behavior where the menu will always reflect the current state of the room when you first open the chatadmin screen, then will keep the last edits until you quit by saving or cancelling