### PR TITLE
Fix: Private ActivityTarget being replaced only once

### DIFF
--- a/BondageClub/Screens/Room/Private/Private.js
+++ b/BondageClub/Screens/Room/Private/Private.js
@@ -1001,7 +1001,7 @@ function PrivateStartActivity() {
 	PrivateActivityCount = 0;
 	CurrentCharacter.Stage = "Activity" + PrivateActivity;
 	CurrentCharacter.CurrentDialog = DialogFind(CurrentCharacter, "Activity" + PrivateActivity + "Intro");
-	if (PrivateActivityTarget != null) CurrentCharacter.CurrentDialog = CurrentCharacter.CurrentDialog.replace("ActivityTarget", PrivateActivityTarget.Name);
+	if (PrivateActivityTarget != null) CurrentCharacter.CurrentDialog = CurrentCharacter.CurrentDialog.replace(/ActivityTarget/g, PrivateActivityTarget.Name);
 
 }
 


### PR DESCRIPTION
Fixes problem with dialog reported on Discord:
![](https://media.discordapp.net/attachments/554378725916147722/867077288855076884/error.jpg?width=1203&height=654)