### PR TITLE
Fix kinky dungeon restarting game

### DIFF
--- a/BondageClub/Screens/Room/Arcade/Arcade.js
+++ b/BondageClub/Screens/Room/Arcade/Arcade.js
@@ -167,7 +167,7 @@ function ArcadeClick() {
  * @returns {void} - Nothing
  */
 function ArcadeKinkyDungeonStart(PlayerLevel) {
-	if (KinkyDungeonPlayerCharacter != Player) {
+	if (KinkyDungeonPlayerCharacter != null) {
 		KinkyDungeonGameRunning = false; // Reset the game to prevent carrying over spectator data
 		KinkyDungeonPlayerCharacter = null;
 	}


### PR DESCRIPTION
You can resume the game in a chat room but not in the arcade. This fixes that.